### PR TITLE
add `expire`, use cache properly and auto-open url

### DIFF
--- a/cmd/expire.go
+++ b/cmd/expire.go
@@ -1,0 +1,58 @@
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import (
+	log "github.com/sirupsen/logrus"
+)
+
+type ExpireCmd struct {
+	All bool `kong:"optional,name='all',help='Expire ClientData and Token'"`
+}
+
+func (cc *ExpireCmd) Run(ctx *RunContext) error {
+	var secureStore SecureStorage
+	var err error
+
+	if ctx.Cli.Store == "json" {
+		secureStore, err = OpenJsonStore(GetPath(ctx.Cli.JsonStore))
+		if err != nil {
+			log.Panicf("Unable to open JSON Secure store: %s", err)
+		}
+	} else {
+		log.Panicf("SecureStorage '%s' is not yet supported", ctx.Cli.Store)
+	}
+
+	awssso := NewAWSSSO(ctx.Config.Region, ctx.Config.SSORegion, ctx.Config.StartUrl, &secureStore)
+
+	err = secureStore.DeleteCreateTokenResponse(awssso.StoreKey())
+	if err != nil {
+		log.WithError(err).Errorf("Unable to delete Token")
+	} else {
+		log.Infof("Deleted cached Token for %s", awssso.StoreKey())
+	}
+	if ctx.Cli.Expire.All {
+		err = secureStore.DeleteRegisterClientData(awssso.StoreKey())
+		if err != nil {
+			log.WithError(err).Errorf("Unable to delete ClientData")
+		} else {
+			log.Infof("Deleted cached ClientData for %s", awssso.StoreKey())
+		}
+	}
+	return nil
+}

--- a/cmd/json_store.go
+++ b/cmd/json_store.go
@@ -25,7 +25,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/davecgh/go-spew/spew"
+	// "github.com/davecgh/go-spew/spew"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -95,7 +95,6 @@ func (jc *JsonStore) saveCache() error {
 
 // RegisterClientData
 func (jc *JsonStore) SaveRegisterClientData(key string, client RegisterClientData) error {
-	log.Debugf("saving RegisterClient: %s", spew.Sdump(client))
 	jc.RegisterClient[key] = client
 	return jc.saveCache()
 }
@@ -116,7 +115,6 @@ func (jc *JsonStore) DeleteRegisterClientData(key string) error {
 
 // CreateTokenResponse
 func (jc *JsonStore) SaveCreateTokenResponse(key string, token CreateTokenResponse) error {
-	log.Debugf("saving CreateTokenResponse: %s", spew.Sdump(token))
 	jc.CreateTokenResponse[key] = token
 	return jc.saveCache()
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -59,10 +59,11 @@ func (cc *ListCmd) Run(ctx *RunContext) error {
 
 	roles := map[string][]RoleInfo{}
 	err = secureStore.GetRoles(&roles)
+
 	if err != nil || ctx.Cli.List.ForceUpdate {
 		roles = map[string][]RoleInfo{} // zero out roles if we are doing a --force-update
 		awssso := NewAWSSSO(ctx.Config.Region, ctx.Config.SSORegion, ctx.Config.StartUrl, &secureStore)
-		err = awssso.Authenticate()
+		err = awssso.Authenticate(ctx.Cli.PrintUrl, ctx.Cli.Browser)
 		if err != nil {
 			log.WithError(err).Panicf("Unable to authenticate")
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,8 +73,8 @@ type CLI struct {
 
 	// Commands
 	//	Exec    ExecCmd    `kong:"cmd,help='Execute command using specified AWS Role/Profile'"`
-	List ListCmd `kong:"cmd,help='List all accounts / role (default command)',default='1'"`
-	//	Expire  ExpireCmd  `kong:"cmd,help='Force expire of AWS Role/Profile credentials from keychain'"`
+	List    ListCmd    `kong:"cmd,help='List all accounts / role (default command)',default='1'"`
+	Expire  ExpireCmd  `kong:"cmd,help='Force expire of AWS OIDC credentials'"`
 	Version VersionCmd `kong:"cmd,help='Print version and exit'"`
 }
 


### PR DESCRIPTION
- Fix bug where even though the CreateTokenResponse was cached
    we were still doing OIDC
- Add `expire` command to delete OIDC cache
- Add support for auto-opening URL in browser