### PR TITLE
Use config file for browser & secure store info

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ to your shell environment.
 ### Common Flags
 
  * `--help`, `-h` -- Builtin and context sensitive help
- * `--loglevel <level>`, `-L` -- Change default log level: [error|warn|info|debug]
+ * `--level <level>`, `-L` -- Change default log level: [error|warn|info|debug]
  * `--lines` -- Print file number with logs
  * `--config <file>`, `-c` -- Specify alternative config file
  * `--browser <path>`, `-b` -- Override default browser to open AWS SSO URL
@@ -108,10 +108,12 @@ SSOConfig:
 							<Key2>: <Value2>
 					  Duration: 120  # override default duration time in minutes
 
-SecureStore: [json|keychain]
+Browser: <override path to browser>
+PrintUrl: false|true  # print URL instead of opening it in default browser
+
+SecureStore: [json|keychain]  # keychain is only valid on OSX
 Json:
 	File: <Path to JSON secure store file>
-PrintUrl: false|true  # print Url insetad of opening it?
 ```
 
 ## License

--- a/cmd/awssso.go
+++ b/cmd/awssso.go
@@ -112,12 +112,13 @@ func (as *AWSSSO) Authenticate(printUrl bool, browser string) error {
 
 	if !printUrl {
 		if len(browser) == 0 {
-			err = open.Start(auth.VerificationUriComplete)
+			err = open.Run(auth.VerificationUriComplete)
+			browser = "default browser"
 		} else {
-			err = open.StartWith(auth.VerificationUriComplete, browser)
+			err = open.RunWith(auth.VerificationUriComplete, browser)
 		}
 		if err != nil {
-			log.WithError(err).Errorf("Unable to open %s", auth.VerificationUriComplete)
+			log.WithError(err).Fatalf("Unable to open %s with %s", auth.VerificationUriComplete, browser)
 		}
 	} else {
 		fmt.Printf("Please open the following URL in your browser:\n\n%s\n\n",

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -38,6 +38,8 @@ type ConfigFile struct {
 	SecureStore  string                `koanf:"SecureStore" yaml:"SecureStore,omitempty"` // json or keyring
 	JsonStore    JsonStoreConfig       `koanf:"Json" yaml:"Json,omitempty"`
 	KeyringStore KeyringStoreConfig    `koanf:"Keyring" yaml:"Keyring,omitempty"`
+	PrintUrl     bool                  `koanf:"PrintUrl" yaml:"PrintUrl,omitempty"`
+	Browser      string                `koanf:"Browser" yaml:"Browser,omitempty"`
 }
 
 type SSOConfig struct {

--- a/cmd/exec_cmd.go
+++ b/cmd/exec_cmd.go
@@ -84,7 +84,7 @@ func (cc *ExecCmd) Run(ctx *RunContext) error {
 func doAuth(ctx *RunContext) *AWSSSO {
 	sso := ctx.Config.SSO[ctx.Cli.SSO]
 	awssso := NewAWSSSO(sso.SSORegion, sso.StartUrl, &ctx.Store)
-	err := awssso.Authenticate(ctx.Cli.PrintUrl, ctx.Cli.Browser)
+	err := awssso.Authenticate(ctx.Config.PrintUrl, ctx.Config.Browser)
 	if err != nil {
 		log.WithError(err).Fatalf("Unable to authenticate")
 	}

--- a/cmd/list_cmd.go
+++ b/cmd/list_cmd.go
@@ -71,7 +71,7 @@ func (cc *ListCmd) Run(ctx *RunContext) error {
 		roles = map[string][]RoleInfo{} // zero out roles if we are doing a --force-update
 		sso := ctx.Config.SSO[ctx.Cli.SSO]
 		awssso := NewAWSSSO(sso.SSORegion, sso.StartUrl, &ctx.Store)
-		err = awssso.Authenticate(ctx.Cli.PrintUrl, ctx.Cli.Browser)
+		err = awssso.Authenticate(ctx.Config.PrintUrl, ctx.Config.Browser)
 		if err != nil {
 			log.WithError(err).Fatalf("Unable to authenticate")
 		}


### PR DESCRIPTION
- You can now set defaults for the browser/PrintUrl in the config file
- secure store info is now only set via config file
- update readme