### PR TITLE
`tags` command will now use cache when SSO expired

### DIFF
--- a/cmd/json_store.go
+++ b/cmd/json_store.go
@@ -133,17 +133,18 @@ func (jc *JsonStore) DeleteCreateTokenResponse(key string) error {
 	return jc.saveCache()
 }
 
-// GetRoles reads the roles from the cache.  Returns error if missing or expired
+// GetRoles reads the roles from the cache.  Returns error if missing
 func (jc *JsonStore) GetRoles(roles *map[string][]RoleInfo) error {
 	if jc.Roles.CreatedAt == 0 {
 		return fmt.Errorf("No Roles available in cache")
 	}
-	if jc.Roles.Expired() {
-		return fmt.Errorf("Roles have expired")
-	}
-
 	*roles = jc.Roles.Roles
 	return nil
+}
+
+// GetRolesExpired returns true if the roles in the cache have expired
+func (jc *JsonStore) GetRolesExpired() bool {
+	return jc.Roles.Expired()
 }
 
 // SaveRoles saves the roles to the cache

--- a/cmd/list_cmd.go
+++ b/cmd/list_cmd.go
@@ -66,6 +66,11 @@ func (cc *ListCmd) Run(ctx *RunContext) error {
 
 	roles := map[string][]RoleInfo{}
 	err = ctx.Store.GetRoles(&roles)
+	if err == nil {
+		if ctx.Store.GetRolesExpired() {
+			err = fmt.Errorf("Role cache has expired.")
+		}
+	}
 
 	if err != nil || ctx.Cli.List.ForceUpdate {
 		roles = map[string][]RoleInfo{} // zero out roles if we are doing a --force-update

--- a/cmd/secure_store.go
+++ b/cmd/secure_store.go
@@ -38,6 +38,7 @@ type SecureStorage interface {
 
 	SaveRoles(map[string][]RoleInfo) error
 	GetRoles(*map[string][]RoleInfo) error
+	GetRolesExpired() bool
 	DeleteRoles() error
 }
 

--- a/cmd/tags_cmd.go
+++ b/cmd/tags_cmd.go
@@ -25,8 +25,9 @@ import (
 )
 
 type TagsCmd struct {
-	AccountId string `kong:"optional,name='account',short='A',help='Filter regsults based on AWS AccountID',env='AWS_SSO_ACCOUNTID'"`
-	Role      string `kong:"optional,name='role',short='R',help='Filter results based on AWS Role Name',env='AWS_SSO_ROLE'"`
+	AccountId   string `kong:"optional,name='account',short='A',help='Filter regsults based on AWS AccountID',env='AWS_SSO_ACCOUNTID'"`
+	Role        string `kong:"optional,name='role',short='R',help='Filter results based on AWS Role Name',env='AWS_SSO_ROLE'"`
+	ForceUpdate bool   `kong:"optional,name='force-update',help='Force account/role cache update'"`
 }
 
 func (cc *TagsCmd) Run(ctx *RunContext) error {
@@ -37,6 +38,9 @@ func (cc *TagsCmd) Run(ctx *RunContext) error {
 	err := ctx.Store.GetRoles(&allRoles)
 	if err != nil {
 		log.Fatalf("Unable to load roles from cache: %s", err.Error())
+	}
+	if ctx.Store.GetRolesExpired() {
+		log.Warn("Role cache may be out of date")
 	}
 
 	if ctx.Cli.Tags.AccountId != "" {


### PR DESCRIPTION
Fixes a bug where the tags command would error out when the
SSO token was expired.  Now we print a warnings and use
the cache

Some refactoring of code

Refs: #6