### PR TITLE
Store role info in a JSON file, not secure store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+ * Move role cache data from SecureStore into json CacheStore #26
+
 ## [v1.0.1] - 2021-07-18
 
  * Add macOS/M1 support

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 BUILDINFOSDET ?=
 PROGRAM_ARGS ?=
 
-PROJECT_VERSION           := 1.0.1
+PROJECT_VERSION           := 1.1.0
 DOCKER_REPO               := synfinatic
 PROJECT_NAME              := aws-sso
 PROJECT_TAG               := $(shell git describe --tags 2>/dev/null $(git rev-list --tags --max-count=1))

--- a/cmd/cache_store.go
+++ b/cmd/cache_store.go
@@ -1,0 +1,131 @@
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type HistoryCache struct {
+	Roles []string
+}
+
+type RoleCache struct {
+	CreatedAt int64                 `json:"CreatedAt"`
+	Roles     map[string][]RoleInfo `json:"Roles"`
+}
+
+// used to store information that is not confidential
+type CacheStore struct {
+	filename string
+	History  HistoryCache `json:"History,omitempty"`
+	Roles    RoleCache    `json:"Roles,omitempty"`
+}
+
+// RoleCache
+// Returns true or false if the RoleInfoCache has expired
+func (rc *RoleCache) Expired() bool {
+	if rc.CreatedAt+CACHE_TTL < time.Now().Unix() {
+		return true
+	}
+	return false
+}
+
+// Converts the map of RoleInfo into a cache
+func RoleInfoCache(roles map[string][]RoleInfo) RoleCache {
+	cache := RoleCache{
+		CreatedAt: time.Now().Unix(),
+		Roles:     roles,
+	}
+	return cache
+}
+
+// CacheStore
+func OpenCacheStore(fileName string) (*CacheStore, error) {
+	cache := CacheStore{
+		filename: fileName,
+		History:  HistoryCache{},
+		Roles:    RoleCache{},
+	}
+
+	cacheBytes, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		log.Warnf("Creating new cache file: %s", fileName)
+	} else {
+		json.Unmarshal(cacheBytes, &cache)
+	}
+
+	return &cache, nil
+}
+
+// save the cache file, creating the directory if necessary
+func (cs *CacheStore) SaveCache() error {
+	log.Debugf("Saving CacheStore cache")
+	jbytes, err := json.MarshalIndent(cs, "", "  ")
+	if err != nil {
+		log.WithError(err).Errorf("Unable to marshal json")
+		return err
+	}
+	err = ensureDirExists(cs.filename)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(cs.filename, jbytes, 0600)
+}
+
+// GetRoles reads the roles from the cache.  Returns error if missing
+func (cs *CacheStore) GetRoles(roles *map[string][]RoleInfo) error {
+	if cs.Roles.CreatedAt == 0 {
+		return fmt.Errorf("No Roles available in cache")
+	}
+	*roles = cs.Roles.Roles
+	return nil
+}
+
+// GetRolesExpired returns true if the roles in the cache have expired
+func (cs *CacheStore) GetRolesExpired() bool {
+	return cs.Roles.Expired()
+}
+
+// SaveRoles saves the roles to the cache
+func (cs *CacheStore) SaveRoles(roles map[string][]RoleInfo) error {
+	cs.Roles = RoleInfoCache(roles)
+	return cs.SaveCache()
+}
+
+// DeleteRoles removes the roles from the cache
+func (cs *CacheStore) DeleteRoles() error {
+	cs.Roles = RoleCache{}
+	return cs.SaveCache()
+}
+
+// adds a role to the history list up to the max number of entries
+func (cs *CacheStore) AddHistory(item string, max int) {
+	cs.History.Roles = append([]string{item}, cs.History.Roles...) // push on top
+	for len(cs.History.Roles) > max {
+		// remove the oldest entry
+		cs.History.Roles = cs.History.Roles[:len(cs.History.Roles)-1]
+	}
+}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -36,6 +36,7 @@ type ConfigFile struct {
 	SSO         map[string]*SSOConfig `koanf:"SSOConfig" yaml:"SSOConfig,omitempty"`
 	DefaultSSO  string                `koanf:"DefaultSSO" yaml:"DefaultSSO,omitempty"`   // specify default SSO by key
 	SecureStore string                `koanf:"SecureStore" yaml:"SecureStore,omitempty"` // json or keyring
+	CacheStore  string                `koanf:"CacheStore" yaml:"CacheStore,omitempty"`   // insecure json cache
 	JsonStore   string                `koanf:"JsonStore" yaml:"JsonStore,omitempty"`
 	PrintUrl    bool                  `koanf:"PrintUrl" yaml:"PrintUrl,omitempty"`
 	Browser     string                `koanf:"Browser" yaml:"Browser,omitempty"`

--- a/cmd/exec_cmd.go
+++ b/cmd/exec_cmd.go
@@ -150,7 +150,7 @@ func updateRoleCache(ctx *RunContext, sso *SSOConfig, awssso *AWSSSO, roles *map
 			rroles[account] = append(rroles[account], r)
 		}
 	}
-	ctx.Store.SaveRoles(*roles)
+	ctx.Cache.SaveRoles(*roles)
 
 	// now update our config.yaml
 	changes, err := sso.UpdateRoles(*roles)

--- a/cmd/list_cmd.go
+++ b/cmd/list_cmd.go
@@ -65,9 +65,9 @@ func (cc *ListCmd) Run(ctx *RunContext) error {
 	}
 
 	roles := map[string][]RoleInfo{}
-	err = ctx.Store.GetRoles(&roles)
+	err = ctx.Cache.GetRoles(&roles)
 	if err == nil {
-		if ctx.Store.GetRolesExpired() {
+		if ctx.Cache.GetRolesExpired() {
 			err = fmt.Errorf("Role cache has expired.")
 		}
 	}
@@ -97,7 +97,7 @@ func (cc *ListCmd) Run(ctx *RunContext) error {
 				roles[account] = append(roles[account], r)
 			}
 		}
-		ctx.Store.SaveRoles(roles)
+		ctx.Cache.SaveRoles(roles)
 
 		// now update our config.yaml
 		changes, err := sso.UpdateRoles(roles)

--- a/cmd/tags_cmd.go
+++ b/cmd/tags_cmd.go
@@ -35,11 +35,11 @@ func (cc *TagsCmd) Run(ctx *RunContext) error {
 	sso.Refresh()
 
 	allRoles := map[string][]RoleInfo{}
-	err := ctx.Store.GetRoles(&allRoles)
+	err := ctx.Cache.GetRoles(&allRoles)
 	if err != nil {
 		log.Fatalf("Unable to load roles from cache: %s", err.Error())
 	}
-	if ctx.Store.GetRolesExpired() {
+	if ctx.Cache.GetRolesExpired() {
 		log.Warn("Role cache may be out of date")
 	}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -18,17 +18,29 @@ package main
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const (
-	CACHE_TTL = 60 * 60 * 24 // 1 day in seconds
+import (
+	"fmt"
+	"os"
+	"path"
 )
 
-// Define the interface for storing our AWS SSO data
-type SecureStorage interface {
-	SaveRegisterClientData(string, RegisterClientData) error
-	GetRegisterClientData(string, *RegisterClientData) error
-	DeleteRegisterClientData(string) error
-
-	SaveCreateTokenResponse(string, CreateTokenResponse) error
-	GetCreateTokenResponse(string, *CreateTokenResponse) error
-	DeleteCreateTokenResponse(string) error
+// ensures the given directory exists for the filename
+// used by JsonStore and InsecureStore
+func ensureDirExists(filename string) error {
+	storeDir := path.Dir(filename)
+	f, err := os.Open(storeDir)
+	if err != nil {
+		err = os.MkdirAll(storeDir, 0700)
+		if err != nil {
+			return fmt.Errorf("Unable to create %s: %s", storeDir, err.Error())
+		}
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("Unable to stat %s: %s", storeDir, err.Error())
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s exists and is not a directory!", storeDir)
+	}
+	return nil
 }


### PR DESCRIPTION
We shouldn't always prompt users for their password when we just
need to read our cached list of Roles.  Now that information
is stored in ~/.aws-sso/cache.json

Fixes: #26