### PR TITLE
Add exec ENV var check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
  * Move role cache data from SecureStore into json CacheStore #26
+ * `exec` command will abort if a conflicting AWS Env var is set #27
 
 ## [v1.0.1] - 2021-07-18
 

--- a/cmd/cache_store.go
+++ b/cmd/cache_store.go
@@ -70,9 +70,7 @@ func OpenCacheStore(fileName string) (*CacheStore, error) {
 	}
 
 	cacheBytes, err := ioutil.ReadFile(fileName)
-	if err != nil {
-		log.Warnf("Creating new cache file: %s", fileName)
-	} else {
+	if err == nil {
 		json.Unmarshal(cacheBytes, &cache)
 	}
 


### PR DESCRIPTION
- Error out if user has a conflicting ENV var set which might confuse
    some AWS tooling
- No longer log a warning when creating ~/.aws-sso/cache.json

Fixes: #27
Refs: #26