### PR TITLE
Add `time` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
  * Move role cache data from SecureStore into json CacheStore #26
  * `exec` command will abort if a conflicting AWS Env var is set #27
+ * Add `time` command to report how much time before the current STS token expires #28
 
 ## [v1.0.1] - 2021-07-18
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,6 +69,7 @@ type CLI struct {
 	Flush   FlushCmd   `kong:"cmd,help='Force delete of AWS SSO credentials'"`
 	List    ListCmd    `kong:"cmd,help='List all accounts / role (default command)',default='1'"`
 	Tags    TagsCmd    `kong:"cmd,help='List tags'"`
+	Time    TimeCmd    `kong:"cmd,help='Print out much time before STS Token expires'"`
 	Version VersionCmd `kong:"cmd,help='Print version and exit'"`
 }
 

--- a/cmd/time_cmd.go
+++ b/cmd/time_cmd.go
@@ -1,0 +1,50 @@
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021 Aaron Turner  <aturner at synfin dot net>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+type TimeCmd struct{}
+
+func (cc *TimeCmd) Run(ctx *RunContext) error {
+	expires, isset := os.LookupEnv("AWS_SESSION_EXPIRATION")
+	if !isset {
+		return nil // no output if nothing is set
+	}
+
+	t, err := time.Parse("2006-01-02 15:04:05 -0700 MST", expires)
+	if err != nil {
+		return fmt.Errorf("Unable to parse AWS_SESSION_EXPIRATION: %s", err.Error())
+	}
+
+	d := time.Until(t)
+	if d <= 0 {
+		fmt.Printf("EXPIRED")
+		return nil
+	}
+
+	// Just return the number of MMm or HHhMMm
+	fmt.Printf("%s", strings.Replace(d.Round(time.Minute).String(), "0s", "", 1))
+	return nil
+}


### PR DESCRIPTION
Report how many HHhMMm or MMm the current STS token has.
Returns nothing if there is no AWS_SESSION_EXPIRATION in the
shell environment

Fixes: #28