### PR TITLE
Console can now use ENV vars to generate URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+ * `console` command now can use ENV vars via --useenv #41
+ * Fix bugs in `console` with invalid CLI parsing
+
 ## [v1.1.0] - 2021-08-22
 
  * Move role cache data from SecureStore into json CacheStore #26

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 BUILDINFOSDET ?=
 PROGRAM_ARGS ?=
 
-PROJECT_VERSION           := 1.1.0
+PROJECT_VERSION           := 1.2.0
 DOCKER_REPO               := synfinatic
 PROJECT_NAME              := aws-sso
 PROJECT_TAG               := $(shell git describe --tags 2>/dev/null $(git rev-list --tags --max-count=1))


### PR DESCRIPTION
you can now chain `exec` and `console` commands

Fixes: #41