### PR TITLE
Add support for `AWS_SSO_PROFILE` env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
  * Started writing some unit tests
  * Do SSO authentication after role selection to improve performance
     even when we have cached creds
+ * Add support for `AWS_SSO_PROFILE` env var and `ProfileFormat` in config #48
 
 ## [v1.1.0] - 2021-08-22
 

--- a/cmd/select.go
+++ b/cmd/select.go
@@ -94,9 +94,9 @@ func (tc *TagsCompleter) Executor(args string) {
 
 		ssoRoles := tc.roleTags.GetMatchingRoles(argsMap)
 		if len(ssoRoles) == 0 {
-			log.Fatalf("No matching roles")
+			log.Fatalf("Invalid selection: No matching roles.")
 		} else if len(ssoRoles) > 1 {
-			log.Fatalf("Invalid selection: %v", ssoRoles)
+			log.Fatalf("Invalid selection: Too many roles match selected values.")
 		}
 		roleArn = ssoRoles[0]
 	}

--- a/sso/config.go
+++ b/sso/config.go
@@ -34,13 +34,14 @@ type AWSProfile struct {
 }
 
 type ConfigFile struct {
-	SSO         map[string]*SSOConfig `koanf:"SSOConfig" yaml:"SSOConfig,omitempty"`
-	DefaultSSO  string                `koanf:"DefaultSSO" yaml:"DefaultSSO,omitempty"`   // specify default SSO by key
-	SecureStore string                `koanf:"SecureStore" yaml:"SecureStore,omitempty"` // json or keyring
-	CacheStore  string                `koanf:"CacheStore" yaml:"CacheStore,omitempty"`   // insecure json cache
-	JsonStore   string                `koanf:"JsonStore" yaml:"JsonStore,omitempty"`
-	PrintUrl    bool                  `koanf:"PrintUrl" yaml:"PrintUrl,omitempty"`
-	Browser     string                `koanf:"Browser" yaml:"Browser,omitempty"`
+	SSO           map[string]*SSOConfig `koanf:"SSOConfig" yaml:"SSOConfig,omitempty"`
+	DefaultSSO    string                `koanf:"DefaultSSO" yaml:"DefaultSSO,omitempty"`   // specify default SSO by key
+	SecureStore   string                `koanf:"SecureStore" yaml:"SecureStore,omitempty"` // json or keyring
+	CacheStore    string                `koanf:"CacheStore" yaml:"CacheStore,omitempty"`   // insecure json cache
+	JsonStore     string                `koanf:"JsonStore" yaml:"JsonStore,omitempty"`
+	PrintUrl      bool                  `koanf:"PrintUrl" yaml:"PrintUrl,omitempty"`
+	Browser       string                `koanf:"Browser" yaml:"Browser,omitempty"`
+	ProfileFormat string                `koanf:"ProfileFormat" yaml:"ProfileFormat,omitempty"`
 }
 
 type SSOConfig struct {


### PR DESCRIPTION
- Add support for AWS_SSO_PROFILE which can be configured
    via ProfileFormat in the config file.
- Update README docs in general

Refs: #48