### PR TITLE
Rename refresh => cache and add renew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
     even when we have cached creds
  * Add support for `AWS_SSO_PROFILE` env var and `ProfileFormat` in config #48
  * Auto-detect when local cache it out of date and refresh #59
- * Add support for `refresh` command to force refresh AWS SSO data 
+ * Add support for `cache` command to force refresh AWS SSO data
+ * Add support for `renew` command to refresh AWS credentials in a shell #63
  * Rename `--refresh` flag to be `--sts-refresh`
  * Remove `--force-refresh` flag from `list` command
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,12 @@ ensure that it is executable (`chmod 755 <path>`) and owned by root (`chown root
 
 ## Commands
 
+ * `cache` -- Force refresh of AWS SSO role information
  * `console` -- Open AWS Console in a browser with the selected role
  * `exec` -- Exec a command with the selected role
  * `list` -- List all accounts & roles
  * `expire` -- Force expire of AWS SSO credentials
- * `refresh` -- Force refresh of AWS SSO role information
+ * `renew` -- Renew current AWS SSO credentials
  * `tags` -- List manually created tags for each role
  * `version` -- Print the version of aws-sso
 
@@ -134,6 +135,14 @@ The following environment variables are automatically set by `exec`:
  * `AWS_DEFAULT_REGION` -- Region to use AWS with
  * `AWS_SSO_PROFILE` -- User customizable varible using a template
 
+### cache
+
+AWS SSO CLI caches information about your AWS Accounts, Roles and Tags for better
+perfomance.  By default it will refresh this information after 24 hours, but you
+can force this data to be refreshed immediately.
+
+Cache data is also automatically updated anytime the `config.yaml` file is modified.
+
 ### list
 
 List will list all of the AWS Roles you can assume with the metadata/tags available
@@ -151,13 +160,13 @@ Arguments: `[<field> ...]`
 Flush any cached AWS SSO credentials.  By default, it only deletes the temorary
 Client Token which represents your AWS SSO session for the specified AWS SSO portal.
 
-### refresh
+### renew
 
-AWS SSO CLI caches information about your AWS Accounts, Roles and Tags for better
-perfomance.  By default it will refresh this information after 24 hours, but you
-can force this data to be refreshed immediately.
+Generate a series of `export VARIABLE=VALUE` lines suitable for sourcing into your
+shell.  Allows obtaining new AWS credentials when your current session has expired without
+starting a new shell.
 
-Cache data is also automatically updated anytime the `config.yaml` file is modified.
+Suggested use (bash): `eval $(aws-sso renew)`
 
 ### tags
 

--- a/cmd/cache_cmd.go
+++ b/cmd/cache_cmd.go
@@ -1,0 +1,44 @@
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type CacheCmd struct{}
+
+func (cc *CacheCmd) Run(ctx *RunContext) error {
+	log.Info("Refreshing local cache...")
+
+	awssso := doAuth(ctx)
+	err := ctx.Cache.Refresh(awssso, ctx.Config.SSO[ctx.Cli.SSO])
+	if err != nil {
+		return fmt.Errorf("Unable to refresh role cache: %s", err.Error())
+	}
+	err = ctx.Cache.Save()
+	if err != nil {
+		return fmt.Errorf("Unable to save role cache: %s", err.Error())
+	}
+
+	log.Info("Cache has been refreshed.")
+	return nil
+}

--- a/cmd/list_cmd.go
+++ b/cmd/list_cmd.go
@@ -67,8 +67,8 @@ func (cc *ListCmd) Run(ctx *RunContext) error {
 	}
 
 	if err = ctx.Cache.Expired(ctx.Config.GetDefaultSSO()); err != nil {
-		r := &RefreshCmd{}
-		if err = r.Run(ctx); err != nil {
+		c := &CacheCmd{}
+		if err = c.Run(ctx); err != nil {
 			log.WithError(err).Errorf("Unable to refresh local cache")
 		}
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,11 +68,12 @@ type CLI struct {
 	STSRefresh bool   `kong:"optional,short='R',help='Force refresh of STS Token Credentials'"`
 
 	// Commands
+	Cache   CacheCmd   `kong:"cmd,help='Force reload of cached AWS SSO role info and config.yaml'"`
 	Console ConsoleCmd `kong:"cmd,help='Open AWS Console using specificed AWS Role/profile'"`
 	Exec    ExecCmd    `kong:"cmd,help='Execute command using specified AWS Role/Profile'"`
 	Flush   FlushCmd   `kong:"cmd,help='Force delete of AWS SSO credentials'"`
 	List    ListCmd    `kong:"cmd,help='List all accounts / role (default command)',default='1'"`
-	Refresh RefreshCmd `kong:"cmd,help='Force refresh of AWS SSO role info and config.yaml'"`
+	Renew   RenewCmd   `kong:"cmd,help='Print renewed AWS credentials for your shell'"`
 	Tags    TagsCmd    `kong:"cmd,help='List tags'"`
 	Time    TimeCmd    `kong:"cmd,help='Print out much time before STS Token expires'"`
 	Version VersionCmd `kong:"cmd,help='Print version and exit'"`


### PR DESCRIPTION
- `refresh` command is just `cache` now, because it's a bit too generic
    naming
- `renew` command allows obtaining updated new AWS creds when your old
  creds have expired

Refs: #63