### PR TITLE
Add `AccountPrimaryTag` config var & metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
  * Add support for `renew` command to refresh AWS credentials in a shell #63
  * Rename `--refresh` flag to be `--sts-refresh`
  * Remove `--force-refresh` flag from `list` command
+ * Add role metadata when selecting roles #66
 
 ## [v1.1.0] - 2021-08-22
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ PrintUrl: [false|true]  # print URL instead of opening it in the browser
 SecureStore: [json|file|keychain|kwallet|pass|secret-service|wincred]
 JsonStore: <path to json file>
 ProfileFormat: <template>
+AccountPrimaryTag: <list of role tags>
 ```
 
 If `Browser` is not set, then your default browser will be used.  Note that
@@ -280,6 +281,20 @@ The following functions are available in your template:
 **Note:** Unlike most values stored in the `config.yaml`, because `ProfileFormat`
 values often start with a `{` you will need to quote the value for it to be valid
 YAML.
+
+### AccountPrimaryTag
+
+When selecting a role, if you first select by role name (via the `Role` tag) you will
+be presented with a list of matching ARNs to select. The `AccountPrimaryTag` automatically
+includes another tag name and value as the description to aid in role selection.  By default
+the following tags are searched (first match is used):
+
+ * AccountName
+ * AccountAlias
+ * Email
+
+Set `AccountPrimaryTag` to an empty list to disable this feature.
+
 
 ## Environment Varables
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -102,7 +102,7 @@ func main() {
 	}
 
 	// Update our structs
-	update_config(run_ctx.Config, cli)
+	updateConfig(run_ctx.Config, cli)
 
 	// validate the SSO Provider
 	if run_ctx.Cli.SSO != "" {
@@ -158,14 +158,24 @@ func main() {
 	}
 }
 
+var DefaultAccountPrimaryTags []string = []string{
+	"AccountName",
+	"AccountAlias",
+	"Email",
+}
+
 // Some CLI args are for overriding the config.  Do that here.
-func update_config(config *sso.ConfigFile, cli CLI) {
+func updateConfig(config *sso.ConfigFile, cli CLI) {
 	config.GetDefaultSSO().Refresh(getHomePath(cli.ConfigFile))
 	if cli.PrintUrl {
 		config.PrintUrl = true
 	}
 	if cli.Browser != "" {
 		config.Browser = cli.Browser
+	}
+
+	if len(config.AccountPrimaryTag) == 0 {
+		config.AccountPrimaryTag = append(config.AccountPrimaryTag, DefaultAccountPrimaryTags...)
 	}
 }
 

--- a/sso/config.go
+++ b/sso/config.go
@@ -35,14 +35,15 @@ type AWSProfile struct {
 }
 
 type ConfigFile struct {
-	SSO           map[string]*SSOConfig `koanf:"SSOConfig" yaml:"SSOConfig,omitempty"`
-	DefaultSSO    string                `koanf:"DefaultSSO" yaml:"DefaultSSO,omitempty"`   // specify default SSO by key
-	SecureStore   string                `koanf:"SecureStore" yaml:"SecureStore,omitempty"` // json or keyring
-	CacheStore    string                `koanf:"CacheStore" yaml:"CacheStore,omitempty"`   // insecure json cache
-	JsonStore     string                `koanf:"JsonStore" yaml:"JsonStore,omitempty"`
-	PrintUrl      bool                  `koanf:"PrintUrl" yaml:"PrintUrl,omitempty"`
-	Browser       string                `koanf:"Browser" yaml:"Browser,omitempty"`
-	ProfileFormat string                `koanf:"ProfileFormat" yaml:"ProfileFormat,omitempty"`
+	SSO               map[string]*SSOConfig `koanf:"SSOConfig" yaml:"SSOConfig,omitempty"`
+	DefaultSSO        string                `koanf:"DefaultSSO" yaml:"DefaultSSO,omitempty"`   // specify default SSO by key
+	SecureStore       string                `koanf:"SecureStore" yaml:"SecureStore,omitempty"` // json or keyring
+	CacheStore        string                `koanf:"CacheStore" yaml:"CacheStore,omitempty"`   // insecure json cache
+	JsonStore         string                `koanf:"JsonStore" yaml:"JsonStore,omitempty"`
+	PrintUrl          bool                  `koanf:"PrintUrl" yaml:"PrintUrl,omitempty"`
+	Browser           string                `koanf:"Browser" yaml:"Browser,omitempty"`
+	ProfileFormat     string                `koanf:"ProfileFormat" yaml:"ProfileFormat,omitempty"`
+	AccountPrimaryTag []string              `koanf:"AccountPrimaryTag" yaml:"AccountPrimaryTag"`
 }
 
 type SSOConfig struct {

--- a/sso/tags.go
+++ b/sso/tags.go
@@ -111,6 +111,14 @@ func (t *TagsList) UniqueValues(key string) []string {
 // RoleTags provides an interface to find roles which match a set of tags
 type RoleTags map[string]map[string]string // ARN => TagKey => Value
 
+func (r *RoleTags) GetRoleTags(role string) map[string]string {
+	rtags := *r
+	if v, ok := rtags[role]; ok {
+		return v
+	}
+	return map[string]string{}
+}
+
 // GetMatchingRoles returns the roles which match all the tags
 func (r *RoleTags) GetMatchingRoles(tags map[string]string) []string {
 	matches := []string{}


### PR DESCRIPTION
Now when selecting a Role ARN directly, the description
contains a user-specified tag key/value wtih reasonable defaults
in order to aid selecting of the role.

Refs: #66