### PR TITLE
Simplify options for handling URLs and refactor internals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## [Unreleased]
 
  * Add customizable color support #79
+ * Simplify options for handling URLs and refactor internals #82
+ * Rework how defaults are handled/settings loaded
+ * Remove references to `duration` in config which don't do anything
+ * Add additional config file options:
+	- UrlAction
+	- LogLevel
+	- LogLines
+	- DefaultSSO
+ * Replace `--print-url` with `--url-action` #81
 
 ## [v1.2.0] - 2021-10-29
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 BUILDINFOSDET ?=
 PROGRAM_ARGS ?=
 
-PROJECT_VERSION           := 1.2.0
+PROJECT_VERSION           := 1.2.1
 DOCKER_REPO               := synfinatic
 PROJECT_NAME              := aws-sso
 PROJECT_TAG               := $(shell git describe --tags 2>/dev/null $(git rev-list --tags --max-count=1))
@@ -29,6 +29,7 @@ BUILDINFOS                := $(shell date +%FT%T%z)$(BUILDINFOSDET)
 HOSTNAME                  := $(shell hostname)
 LDFLAGS                   := -X "main.Version=$(PROJECT_VERSION)" -X "main.Delta=$(PROJECT_DELTA)" -X "main.Buildinfos=$(BUILDINFOS)" -X "main.Tag=$(PROJECT_TAG)" -X "main.CommitID=$(PROJECT_COMMIT)"
 OUTPUT_NAME               := $(DIST_DIR)$(PROJECT_NAME)-$(PROJECT_VERSION)  # default for current platform
+
 # supported platforms for `make release`
 WINDOWS_BIN               := $(DIST_DIR)$(PROJECT_NAME)-$(PROJECT_VERSION)-windows-amd64.exe
 WINDOWS32_BIN             := $(DIST_DIR)$(PROJECT_NAME)-$(PROJECT_VERSION)-windows-386.exe
@@ -37,11 +38,11 @@ LINUXARM64_BIN            := $(DIST_DIR)$(PROJECT_NAME)-$(PROJECT_VERSION)-linux
 DARWIN_BIN                := $(DIST_DIR)$(PROJECT_NAME)-$(PROJECT_VERSION)-darwin-amd64
 DARWINARM64_BIN           := $(DIST_DIR)$(PROJECT_NAME)-$(PROJECT_VERSION)-darwin-arm64
 
+ALL: $(wildcard */*.go) .prepare ## Build binary for this platform
+	go build -ldflags='$(LDFLAGS)' -o $(DIST_DIR)$(PROJECT_NAME) cmd/*.go
+	@echo "Created: $(DIST_DIR)$(PROJECT_NAME)"
 
-
-ALL: $(OUTPUT_NAME) ## Build binary.  Needs to be a supported plaform as defined above
-
-tags: cmd/*.go sso/*.go
+tags: cmd/*.go sso/*.go  ## Create tags file for vim, etc
 	@echo Make sure you have Universal Ctags installed: https://github.com/universal-ctags/ctags
 	ctags -R
 
@@ -53,7 +54,7 @@ release: clean .build-release ## Build all our release binaries
 	cd dist && shasum -a 256 * | gpg --clear-sign >release.sig
 
 .PHONY: run
-run: cmd/*.go  sso/*.go ## build and run cria using $PROGRAM_ARGS
+run: cmd/*.go  sso/*.go ## build and run using $PROGRAM_ARGS
 	go run cmd/*.go $(PROGRAM_ARGS)
 
 .PHONY: delve

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ then this won't work for you.
 AWS SSO CLI makes it easy to manage your shell environment variables allowing
 you to access the AWS API using CLI tools.  Unlike the official AWS tooling,
 the `aws-sso` command does not require defining named profiles in your
-`~/.aws/config` (or anywhere else for that matter) for each and every role you 
+`~/.aws/config` (or anywhere else for that matter) for each and every role you
 wish to assume and use.
 
 Instead, it focuses on making it easy to select a role via CLI arguments or
@@ -94,7 +94,7 @@ may generate warnings.
  * `--lines` -- Print file number with logs
  * `--config <file>`, `-c` -- Specify alternative config file
  * `--browser <path>`, `-b` -- Override default browser to open AWS SSO URL
- * `--url`, `-u` -- Print URL instead of opening in browser
+ * `--url-action`, `-u` -- Print, open or put URLs in clipboard
  * `--sso <name>`, `-S` -- Specify non-default AWS SSO instance to use
 
 ### console
@@ -105,14 +105,15 @@ in the terminal or copied into the Copy & Paste buffer of your computer.
 
 Flags:
 
- * `--clipboard`, `-c` -- Copy URL to clipboard instead of opening it
- * `--print`, `-p` -- Print URL instead of opening it
  * `--duration <minutes>`, `-d` -- AWS Session duration in minutes (default 60)
  * `--arn <arn>` -- ARN of role to assume
  * `--account <account>` -- AWS AccountID of role to assume
  * `--role <role>` -- Name of AWS Role to assume (requires `--account`)
 
-Note that the generated URL is good for 15 minutes after it is created.
+The generated URL is good for 15 minutes after it is created.
+
+The common flag `--url-action` is used both for AWS SSO authentication as well as
+what to do with the resulting URL from the `console` command.
 
 ### exec
 
@@ -206,10 +207,9 @@ but this can be overridden by setting `$AWS_SSO_CONFIG` in your shell or via the
 
 ```yaml
 SSOConfig:
-    <Name of AWS SSO>:  # `Default` is the AWS SSO instance with highest priority
+    <Name of AWS SSO>:
         SSORegion: <AWS Region>
         StartUrl: <URL for AWS SSO Portal>
-        Duration: <minutes>  # Set default duration time of AWS credentials
         Accounts:  # optional block for specifying tags & overrides
             <AccountId>:
                 Name: <Friendly Name of Account>
@@ -221,21 +221,19 @@ SSOConfig:
                        Tags:  # tags specific for this role (will override account level tags)
                           <Key1>: <Value1>
                           <Key2>: <Value2>
-                       Duration: 120  # override default duration time in minutes
 
-Browser: <override path to browser>
-PrintUrl: [false|true]  # print URL instead of opening it in the browser
+Browser: <path to web browser>
+DefaultSSO: <name of AWS SSO>
+LogLevel: [error|warn|info|debug|trace]
+LogLines: [true|false]
+UrlAction: [print|open|clip]
 SecureStore: [json|file|keychain|kwallet|pass|secret-service|wincred]
-JsonStore: <optional path to json file>
+JsonStore: <path to json file>
 ProfileFormat: <template>
 AccountPrimaryTag: <list of role tags>
 PromptColors:
 	<Option>: <Color>
 ```
-
-If you only have a single AWS SSO instance, then it doesn't really matter what you call it,
-but if you have two or more, than `Default` is automatically selected unless you manually
-specify it on the CLI (`--sso`) or via the `AWS_SSO` environment variable.
 
 ### Accounts
 
@@ -250,10 +248,35 @@ By default the following key/values are available as tags to your roles:
  * EmailAddress (root account email)
  * RoleName
 
-### Browser 
+### Browser / UrlAction
+
+`UrlAction` gives you control over how AWS SSO and AWS Console URLs are opened in a browser:
+
+ * `print` -- Prints the URL in your terminal
+ * `open` -- Opens the URL in your default browser or the browser you specified via `--browser` or `Browser`
+ * `clip` -- Copies the URL to your clipboard
 
 If `Browser` is not set, then your default browser will be used.  Note that
 your browser needs to support Javascript for the AWS SSO user interface.
+
+### DefaultSSO
+
+If you only have a single AWS SSO instance, then it doesn't really matter what you call it,
+but if you have two or more, than `Default` is automatically selected unless you manually
+specify it here, on the CLI (`--sso`), or via the `AWS_SSO` environment variable.
+
+### LogLevel / LogLines
+
+By default, the `LogLevel` is 'warn'.  You can override it here or via `--log-level` with one
+of the following values:
+
+ * error
+ * warn
+ * info
+ * debug
+ * trace
+
+`LogLines` includes the file name/line and module name with each log for advanced debugging.
 
 ### SecureStore / JsonStore
 
@@ -318,7 +341,6 @@ the following tags are searched (first match is used):
 
 Set `AccountPrimaryTag` to an empty list to disable this feature.
 
-
 ### PromptColors
 
 `PromptColors` takes a map of prompt options and color options allowing you to have
@@ -331,7 +353,7 @@ Valid options:
 
  * `DescriptionBGColor`
  * `DescriptionTextColor`
- * `InputBGColor` 
+ * `InputBGColor`
  * `InputTextColor`
  * `PrefixBackgroundColor`
  * `PrefixTextColor`

--- a/cmd/tags_cmd.go
+++ b/cmd/tags_cmd.go
@@ -36,7 +36,7 @@ func (cc *TagsCmd) Run(ctx *RunContext) error {
 	if ctx.Cli.Tags.ForceUpdate {
 		s := set.SSO[ctx.Cli.SSO]
 		awssso := sso.NewAWSSSO(s.SSORegion, s.StartUrl, &ctx.Store)
-		err := awssso.Authenticate(ctx.Settings.PrintUrl, ctx.Settings.Browser)
+		err := awssso.Authenticate(ctx.Settings.UrlAction, ctx.Settings.Browser)
 		if err != nil {
 			log.WithError(err).Fatalf("Unable to authenticate")
 		}

--- a/sso/options.go
+++ b/sso/options.go
@@ -45,25 +45,6 @@ type PromptColors struct {
 	SuggestionTextColor          string
 }
 
-var DEFAULT_COLOR_CONFIG map[string]interface{} = map[string]interface{}{
-	"PromptColors.DescriptionBGColor":           "Turquoise",
-	"PromptColors.DescriptionTextColor":         "Black",
-	"PromptColors.InputBGColor":                 "DefaultColor",
-	"PromptColors.InputTextColor":               "DefaultColor",
-	"PromptColors.PrefixBackgroundColor":        "DefaultColor",
-	"PromptColors.PrefixTextColor":              "Blue",
-	"PromptColors.PreviewSuggestionBGColor":     "DefaultColor",
-	"PromptColors.PreviewSuggestionTextColor":   "Green",
-	"PromptColors.ScrollbarBGColor":             "Cyan",
-	"PromptColors.ScrollbarThumbColor":          "DarkGray",
-	"PromptColors.SelectedDescriptionBGColor":   "Cyan",
-	"PromptColors.SelectedDescriptionTextColor": "White",
-	"PromptColors.SelectedSuggestionBGColor":    "Turquoise",
-	"PromptColors.SelectedSuggestionTextColor":  "Black",
-	"PromptColors.SuggestionBGColor":            "Cyan",
-	"PromptColors.SuggestionTextColor":          "White",
-}
-
 type ColorOptionFunction func(prompt.Color) prompt.Option
 
 var PROMPT_COLOR_FUNCS map[string]ColorOptionFunction = map[string]ColorOptionFunction{

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -19,10 +19,44 @@ package utils
  */
 
 import (
+	"fmt"
 	"os"
 	"strings"
+
+	"github.com/atotto/clipboard"
+	log "github.com/sirupsen/logrus"
+	"github.com/skratchdot/open-golang/open" // default opener
 )
 
 func GetHomePath(path string) string {
 	return strings.Replace(path, "~", os.Getenv("HOME"), 1)
+}
+
+func HandleUrl(action, browser, url, pre, post string) error {
+	var err error
+	switch action {
+	case "clip":
+		err = clipboard.WriteAll(url)
+		if err == nil {
+			fmt.Printf("Please open URL copied to clipboard.\n")
+		}
+	case "print":
+		fmt.Printf("%s%s%s", pre, url, post)
+	case "open":
+		if len(browser) == 0 {
+			err = open.Run(url)
+			browser = "default browser"
+		} else {
+			err = open.RunWith(url, browser)
+		}
+		if err != nil {
+			err = fmt.Errorf("Unable to open %s with %s: %s", url, browser, err.Error())
+		} else {
+			log.Infof("Opening URL in %s", browser)
+		}
+	default:
+		err = fmt.Errorf("Unknown --url-action option: %s", action)
+	}
+
+	return err
 }


### PR DESCRIPTION
 * Rework how defaults are handled/settings loaded
 * Remove references to `duration` in config which don't do anything
 * Add additional config file options:
       - UrlAction
       - LogLevel
       - LogLines
       - DefaultSSO
 * Replace `--print-url` with `--url-action` #81

Fixes: #82, #81