### PR TITLE
avoid collision for `-R` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
  * `list -f` now sorts fields
  * Use cache for tracking when STS tokens expire
  * `exec` command now ignores arguments intended for the command being run #93
+ * Remove `-R` as a short version of `--sts-refresh` to avoid collision with exec role #92
 
 ## [v1.2.0] - 2021-10-29
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -85,7 +85,7 @@ type CLI struct {
 	LogLevel   string `kong:"optional,short='L',name='level',enum='error,warn,info,debug,trace,',help='Logging level [error|warn|info|debug|trace]'"`
 	UrlAction  string `kong:"optional,short='u',enum='open,print,clip,',help='How to handle URLs [open|print|clip]'"`
 	SSO        string `kong:"optional,short='S',help='AWS SSO Instance',env='AWS_SSO'"`
-	STSRefresh bool   `kong:"optional,short='R',help='Force refresh of STS Token Credentials'"`
+	STSRefresh bool   `kong:"optional,help='Force refresh of STS Token Credentials'"`
 
 	// Commands
 	Cache   CacheCmd   `kong:"cmd,help='Force reload of cached AWS SSO role info and config.yaml'"`


### PR DESCRIPTION
 * --sts-refresh was using -R.  Now only the long format is accepted
 * -R is now only used by `exec` to specify the role

Fixes: #92