### PR TITLE
Flush can remove IAM STS creds now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
  * `exec` command now ignores arguments intended for the command being run #93
  * Remove `-R` as a short version of `--sts-refresh` to avoid collision with exec role #92
  * Fix finding $HOME directory on Windows and make GetHomePath() cross platform #100
+ * Fix issue with AWS AccountID's with leading zeros.  #96
+ * Optionally delete STS credentials from secure store cache #104
 
 ## [v1.2.0] - 2021-10-29
 

--- a/README.md
+++ b/README.md
@@ -90,14 +90,14 @@ may generate warnings.
 ### Common Flags
 
  * `--help`, `-h` -- Builtin and context sensitive help
- * `--level <level>`, `-L` -- Change default log level: [error|warn|info|debug]
+ * `--level <level>`, `-L` -- Change default log level: [error|warn|info|debug|trace]
  * `--lines` -- Print file number with logs
  * `--config <file>`, `-c` -- Specify alternative config file
  * `--browser <path>`, `-b` -- Override default browser to open AWS SSO URL
  * `--url-action`, `-u` -- Print, open or put URLs in clipboard
  * `--region <region>, `-r` -- Specify the AWS_DEFAULT_REGION to use
  * `--sso <name>`, `-S` -- Specify non-default AWS SSO instance to use
- * `--sts-refresh`, `-R` -- Force refresh of STS Token Credentials
+ * `--sts-refresh` -- Force refresh of STS Token Credentials
 
 ### console
 
@@ -171,8 +171,12 @@ Arguments: `[<field> ...]`
 
 ### flush
 
-Flush any cached AWS SSO credentials.  By default, it only deletes the temorary
-Client Token which represents your AWS SSO session for the specified AWS SSO portal.
+Flush any cached AWS SSO/STS credentials.  By default, it only flushes the SSO
+credentials used to issue new STS tokens.
+
+Flags:
+
+ * `--all` -- Also delete any non-expired AWS STS credentials from secure store
 
 ### renew
 
@@ -236,7 +240,7 @@ JsonStore: <path to json file>
 ProfileFormat: <template>
 AccountPrimaryTag: <list of role tags>
 PromptColors:
-	<Option>: <Color>
+    <Option>: <Color>
 ```
 
 ### Accounts

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -91,7 +91,7 @@ type CLI struct {
 	Cache   CacheCmd   `kong:"cmd,help='Force reload of cached AWS SSO role info and config.yaml'"`
 	Console ConsoleCmd `kong:"cmd,help='Open AWS Console using specificed AWS Role/profile'"`
 	Exec    ExecCmd    `kong:"cmd,help='Execute command using specified AWS Role/Profile'"`
-	Flush   FlushCmd   `kong:"cmd,help='Force delete of AWS SSO credentials'"`
+	Flush   FlushCmd   `kong:"cmd,help='Flush AWS SSO/STS credentials from cache'"`
 	List    ListCmd    `kong:"cmd,help='List all accounts / role (default command)',default='1'"`
 	Renew   RenewCmd   `kong:"cmd,help='Print renewed AWS credentials for your shell'"`
 	Tags    TagsCmd    `kong:"cmd,help='List tags'"`


### PR DESCRIPTION
 - Add --all flag to also delete any non-expired STS token creds
    from the secure store
 - Update docs

Fixes: #104