### PR TITLE
Add support for building rpm/deb packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:20.04 AS base
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y git golang && apt-get clean
+RUN mkdir -p /root/dist && \
+    cd /root && git clone https://github.com/kentik/pkg.git && \
+    cd pkg && go build . && mv pkg /usr/bin/pkg
+
+FROM base as builder
+ENV VERSION=1.0.0
+COPY package.sh /root
+CMD /root/package.sh

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,13 @@ $(HOMEBREW):  homebrew/template.rb  ## no-help
 		echo "*** Error downloading $(DOWNLOAD_URL) ***" ; \
 	fi
 
+.PHONY: package
+package:  ## Build deb/rpm packages
+	docker build -t aws-sso-cli-builder:latest .
+	docker run --rm \
+		-v $$(pwd)/dist:/root/dist \
+		-e VERSION=$(PROJECT_VERSION) aws-sso-cli-builder:latest
+
 tags: cmd/*.go sso/*.go  ## Create tags file for vim, etc
 	@echo Make sure you have Universal Ctags installed: https://github.com/universal-ctags/ctags
 	ctags -R
@@ -94,7 +101,7 @@ include help.mk  # place after ALL target and before all other targets
 
 .build-release: windows windows32 linux linux-arm64 darwin darwin-arm64
 
-release: clean .build-release homebrew ## Build all our release binaries
+release: clean .build-release package ## Build all our release binaries
 	cd dist && shasum -a 256 * | gpg --clear-sign >release.sig.txt
 
 .PHONY: run

--- a/README.md
+++ b/README.md
@@ -64,17 +64,19 @@ been granted access!
 
  * Option 1: [Download binary](https://github.com/synfinatic/aws-sso-cli/releases)
     1. Copy to appropriate location and `chmod 755`
- * Option 2: Build from source:
+ * Option 2: [Download RPM or DEB package](https://github.com/synfinatic/aws-sso-cli/releases)
+    1. Use your package manager to install (Linux only)
+ * Option 3: Install via [Homebrew](https://brew.sh)
+    1. Run `brew install synfinatic/aws-sso-cli/aws-sso-cli`
+ * Option 4: Build from source:
     1. Install [GoLang](https://golang.org) and GNU Make
     1. Clone this repo
     1. Run `make` (or `gmake` for GNU Make)
     1. Your binary will be created in the `dist` directory
     1. Run `make install` to install in /usr/local/bin
- * Option 3: Install via [Homebrew](https://brew.sh)
-    1. Run `brew install synfinatic/aws-sso-cli/aws-sso-cli`
 
-Note that the release binaries are not signed at this time so MacOS and Windows systems
-may generate warnings.
+Note that the release binaries are not officially signed at this time so MacOS
+and Windows systems may generate warnings.
 
 ## Commands
 
@@ -231,12 +233,13 @@ SSOConfig:
                             <Key1>: <Value1>
                             <Key2>: <Value2>
 
+# See description below for these options
 Browser: <path to web browser>
 DefaultSSO: <name of AWS SSO>
 LogLevel: [error|warn|info|debug|trace]
 LogLines: [true|false]
 UrlAction: [print|open|clip]
-SecureStore: [json|file|keychain|kwallet|pass|secret-service|wincred]
+SecureStore: [file|keychain|kwallet|pass|secret-service|wincred|json]
 JsonStore: <path to json file>
 ProfileFormat: <template>
 AccountPrimaryTag: <list of role tags>

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+: ${VERSION?}
+
+function package() {
+    local CPU=$1
+    cat <<EOF >/root/package.yaml
+meta:
+  description: AWS SSO CLI
+  vendor: Aaron Turner
+  maintainer: Aaron Turner
+files:
+  "/usr/bin/aws-sso":
+    file: /root/dist/aws-sso-${VERSION}-linux-${CPU}
+    mode: "0755"
+    user: "root"
+
+EOF
+}
+
+package amd64
+
+pushd /root/dist
+pkg --name=aws-sso-cli --version=$VERSION --arch=x86_64 --deb ../package.yaml
+pkg --name=aws-sso-cli --version=$VERSION --arch=x86_64 --rpm ../package.yaml
+popd


### PR DESCRIPTION
Using Docker for this is overkill/stupid, but the
`pkg` tool doesn't install via `go install` so for now
this is the most repeatable.

Fixes: #52