### PR TITLE
add history support #29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # AWS SSO CLI Changelog
 
+## Unreleased
+
+ * Add support for tracking recently used roles via History tag for exec & console #29
+
 ## [v1.2.2] - 2021-11-11
 
  * Add `AccountAlias` and `Expires` to list of fields that can be displayed via
@@ -70,7 +74,8 @@
 ## [v1.0.0] - 2021-07-15
 
 Initial release
-[Unreleased]: https://github.com/synfinatic/aws-sso-cli/compare/v1.2.1...main
+[Unreleased]: https://github.com/synfinatic/aws-sso-cli/compare/v1.2.2...main
+[v1.2.2]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v1.2.1
 [v1.2.1]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v1.2.1
 [v1.2.0]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v1.2.0
 [v1.1.0]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v1.1.0

--- a/README.md
+++ b/README.md
@@ -198,6 +198,16 @@ Flags:
  * `--account <account>` -- Filter results by AccountId
  * `--role <role>` -- Filter results by Role Name
 
+Note that the following tag keys are automatically defined for each role by AWS SSO CLI:
+
+ * `AccountID` -- AWS Account ID
+ * `Role` -- AWS Role Name
+ * `Email` -- Email address of root account associated with the AWS Account
+ * `AccountName` -- Account Name for any role defined in config.yaml
+ * `AccountAlias` --- AWS Account Alias defined by account administrator
+ * `History` -- Tag tracking if this role was recently used.  See `HistoryLimit` in config 
+		below for more details.
+
 ### Environment Variables
 
 The following environment variables are honored by `exec` and `console`:
@@ -245,6 +255,7 @@ ProfileFormat: <template>
 AccountPrimaryTag: <list of role tags>
 PromptColors:
     <Option>: <Color>
+HistoryLimit: <integer>
 ```
 
 ### Accounts
@@ -402,6 +413,10 @@ Valid high intensity colors:
  * Turquoise
  * White
 
+### HistoryLimit
+
+Limits the number of recently used roles tracked via the History tag.
+Default is last 10 unique roles.  Set to 0 to disable.
 
 ## Environment Varables
 

--- a/cmd/console_cmd.go
+++ b/cmd/console_cmd.go
@@ -122,6 +122,9 @@ func (cc *ConsoleCmd) Run(ctx *RunContext) error {
 
 // opens the AWS console or just prints the URL
 func openConsole(ctx *RunContext, awssso *sso.AWSSSO, accountid int64, role, region string) error {
+	ctx.Settings.Cache.AddHistory(utils.MakeRoleARN(accountid, role), ctx.Settings.HistoryLimit)
+	ctx.Settings.Cache.Save(false)
+
 	creds := GetRoleCredentials(ctx, awssso, accountid, role)
 
 	return openConsoleAccessKey(ctx, creds, ctx.Cli.Console.Duration, region)

--- a/cmd/exec_cmd.go
+++ b/cmd/exec_cmd.go
@@ -128,6 +128,8 @@ func accountIdToStr(id int64) string {
 
 // Executes Cmd+Args in the context of the AWS Role creds
 func execCmd(ctx *RunContext, awssso *sso.AWSSSO, accountid int64, role, region string) error {
+	ctx.Settings.Cache.AddHistory(utils.MakeRoleARN(accountid, role), ctx.Settings.HistoryLimit)
+	ctx.Settings.Cache.Save(false)
 
 	// ready our command and connect everything up
 	cmd := exec.Command(ctx.Cli.Exec.Cmd, ctx.Cli.Exec.Args...)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -74,6 +74,7 @@ var DEFAULT_CONFIG map[string]interface{} = map[string]interface{}{
 	"LogLevel":                                  "info",
 	"LogLines":                                  false,
 	"DefaultRegion":                             "us-east-1",
+	"HistoryLimit":                              10,
 }
 
 type CLI struct {

--- a/cmd/select.go
+++ b/cmd/select.go
@@ -44,8 +44,8 @@ type TagsCompleter struct {
 
 func NewTagsCompleter(ctx *RunContext, s *sso.SSOConfig, exec CompleterExec) *TagsCompleter {
 	set := ctx.Settings
-	roleTags := set.Cache.Roles.GetRoleTagsSelect()
-	allTags := set.Cache.Roles.GetAllTagsSelect()
+	roleTags := set.Cache.GetRoleTagsSelect()
+	allTags := set.Cache.GetAllTagsSelect()
 
 	return &TagsCompleter{
 		ctx:      ctx,
@@ -183,7 +183,7 @@ func completeTags(roleTags *sso.RoleTags, allTags *sso.TagsList, accountPrimaryT
 			}
 		}
 	} else if nextValue == "" {
-		// We have a 'nextKey', so search for Tags which match
+		// We have a 'nextKey', so search for Tag values which match
 		values := (*allTags).UniqueValues(nextKey)
 		if len(values) > 0 {
 			// found exact match for our nextKey
@@ -235,7 +235,7 @@ func completeTags(roleTags *sso.RoleTags, allTags *sso.TagsList, accountPrimaryT
 			}
 		}
 	} else {
-		// We have a 'nextValue', so search for Tags which match
+		// We have a 'nextValue', so search for Tag values which match
 		for _, checkValue := range allTags.UniqueValues(nextKey) {
 			if strings.Contains(strings.ToLower(checkValue), strings.ToLower(nextValue)) {
 				testSet := map[string]string{}

--- a/cmd/tags_cmd.go
+++ b/cmd/tags_cmd.go
@@ -77,7 +77,7 @@ func (cc *TagsCmd) Run(ctx *RunContext) error {
 	}
 
 	for _, fRole := range roles {
-		fmt.Printf("%s\n  AccountId: %d\n  RoleName: %s\n", fRole.Arn, fRole.AccountId, fRole.RoleName)
+		fmt.Printf("%s\n", fRole.Arn)
 		for k, v := range fRole.Tags {
 			fmt.Printf("  %s: %s\n", k, v)
 		}

--- a/sso/cache_test.go
+++ b/sso/cache_test.go
@@ -1,0 +1,45 @@
+package sso
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type CacheTestSuite struct {
+	suite.Suite
+}
+
+func TestCacheTestSuite(t *testing.T) {
+	s := &CacheTestSuite{}
+	suite.Run(t, s)
+}
+
+func (suite *CacheTestSuite) TestAddHistory() {
+	t := suite.T()
+
+	c := &Cache{
+		History: []string{},
+		Roles:   &Roles{},
+	}
+
+	c.AddHistory("foo", 1)
+	assert.Len(t, c.History, 1)
+	assert.Contains(t, c.History, "foo")
+
+	c.AddHistory("bar", 1)
+	assert.Len(t, c.History, 1)
+	assert.Contains(t, c.History, "bar")
+
+	c.AddHistory("foo", 2)
+	assert.Len(t, c.History, 2)
+	assert.Contains(t, c.History, "bar")
+	assert.Contains(t, c.History, "foo")
+
+	// this should be a no-op
+	c.AddHistory("foo", 2)
+	assert.Len(t, c.History, 2)
+	assert.Contains(t, c.History, "foo")
+	assert.Contains(t, c.History, "bar")
+}

--- a/sso/options.go
+++ b/sso/options.go
@@ -95,6 +95,9 @@ func (s *Settings) DefaultOptions(exit prompt.ExitChecker) []prompt.Option {
 		prompt.OptionPrefix("> "),
 		prompt.OptionCompletionOnDown(),
 		prompt.OptionShowCompletionAtStart(),
+		// go-prompt history isn't that useful except for accesing the "last", but
+		// seems more dangerous than it is worth IMHO, so it's disabled
+		// prompt.OptionHistory(s.Cache.History),
 	}
 }
 

--- a/sso/settings.go
+++ b/sso/settings.go
@@ -55,6 +55,7 @@ type Settings struct {
 	PromptColors      PromptColors          `koanf:"PromptColors" yaml:"PromptColors,omitempty"` // go-prompt colors
 	LogLevel          string                `koanf:"LogLevel" yaml:"LogLevel,omitempty"`
 	LogLines          bool                  `koanf:"LogLines" yaml:"LogLines,omitempty"`
+	HistoryLimit      int                   `koanf:"HistoryLimit" yaml:"HistoryLimit,omitempty"`
 	ssoName           string                // SSO name passed in via CLI
 }
 


### PR DESCRIPTION
New `History` tag is used to track the last X recently
used unique ARN's.  Add `HistoryLimit` config file option
to control number of entries.