### PR TITLE
Add missing tags when not defining roles in config.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  * Add support for tracking recently used roles via History tag for exec & console #29
  * Continue to improve unit tests
  * Fix bugs in `tags` command when using -A or -R to filter results
+ * Fix missing tags when not defining roles in config.yaml #116
 
 ## [v1.2.2] - 2021-11-11
 

--- a/sso/cache.go
+++ b/sso/cache.go
@@ -263,8 +263,13 @@ func (c *Cache) NewRoles(as *AWSSSO, config *SSOConfig) (*Roles, error) {
 		}
 		for _, role := range roles {
 			r.Accounts[accountId].Roles[role.RoleName] = &AWSRole{
-				Arn:  utils.MakeRoleARN(accountId, role.RoleName),
-				Tags: map[string]string{},
+				Arn: utils.MakeRoleARN(accountId, role.RoleName),
+				Tags: map[string]string{
+					"AccountID":    aInfo.AccountId,
+					"AccountAlias": aInfo.AccountName,
+					"Email":        aInfo.EmailAddress,
+					"Role":         role.RoleName,
+				},
 			}
 			// need to copy over the Expires & History fields from our current cache
 			if _, ok := c.Roles.Accounts[accountId]; ok {


### PR DESCRIPTION
Tags were missing when the role wasn't defined in the config.yaml
because we only filled out some values when iterating through the cache.

Fixes: #116