### PR TITLE
Add support for `ListFields` in config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,15 @@ Flags:
 
 Arguments: `[<field> ...]`
 
-The arguments are a list of fields to display in the report.
+The arguments are a list of fields to display in the report.  Overrides the
+defaults and/or the specified `ListFields` in the `config.yaml`.
+
+Default fields:
+
+ * `AccountId`
+ * `AccountAlias`
+ * `RoleName`
+ * `ExpiresStr`
 
 ### flush
 
@@ -257,27 +265,31 @@ UrlAction: [print|open|clip]
 SecureStore: [file|keychain|kwallet|pass|secret-service|wincred|json]
 JsonStore: <path to json file>
 ProfileFormat: <template>
-AccountPrimaryTag: 
+AccountPrimaryTag:
     - <tag 1>
     - <tag 2>
     - <tag N>
 PromptColors:
     <Option>: <Color>
 HistoryLimit: <integer>
+ListFields:
+	- <field 1>
+	- <field 2>
+	- <field N>
 ```
 
 ### SSOConfig
 
-This is the top level block for your AWS SSO instances.  Typically an organization 
+This is the top level block for your AWS SSO instances.  Typically an organization
 will have a single AWS SSO instance for all of their accounts under a single AWS master
-payer account.  If you have more than one AWS SSO instance, then `Default` will be 
+payer account.  If you have more than one AWS SSO instance, then `Default` will be
 the default unless overridden with `DefaultSSO`.
 
 The `SSOConfig` config block is required.
 
 ### StartUrl
 
-Each AWS SSO instance has a unique start URL hosted by AWS for interacting with your 
+Each AWS SSO instance has a unique start URL hosted by AWS for interacting with your
 SSO provider (Okta/OneLogin/etc).
 
 The `StartUrl` is required.
@@ -436,6 +448,27 @@ Valid high intensity colors:
 
 Limits the number of recently used roles tracked via the History tag.
 Default is last 10 unique roles.  Set to 0 to disable.
+
+#### ListFields
+
+Specify which fields to display via the `list` command.  Valid options are:
+
+ * `Id` -- Unique row identifier
+ * `AccountId` -- AWS Account Id
+ * `AccountName` -- Account Name from config.yaml
+ * `AccountAlias` -- Account Name from AWS SSO
+ * `ARN` -- Role ARN
+ * `DefaultRegion` -- Configured default region
+ * `EmailAddress` -- Email address of root account associated with AWS Account
+ * `ExpiresEpoch` -- Unix epoch time when cached STS creds expire
+ * `ExpiresStr` -- Hours and minutes until cached STS creds expire
+ * `RoleName` -- Role name
+ * `SSORegion` -- Region of AWS SSO instance
+ * `StartUrl` -- AWS SSO Start Url
+<!--
+ * `Profile` -- ???
+ * `Via` -- Previous ARN of role to assume
+-->
 
 ## Environment Varables
 

--- a/cmd/list_cmd.go
+++ b/cmd/list_cmd.go
@@ -28,15 +28,6 @@ import (
 	"github.com/synfinatic/gotable"
 )
 
-// Fields match those in AWSRoleFlat.  Used when user doesn't have the `fields` in
-// their YAML config file or provided list on the CLI
-var defaultListFields = []string{
-	"AccountId",
-	"AccountAlias",
-	"RoleName",
-	"ExpiresStr",
-}
-
 // keys match AWSRoleFlat header and value is the description
 var allListFields = map[string]string{
 	"Id":            "Column Index",
@@ -79,7 +70,7 @@ func (cc *ListCmd) Run(ctx *RunContext) error {
 		}
 	}
 
-	fields := defaultListFields
+	fields := ctx.Settings.ListFields
 	if len(ctx.Cli.List.Fields) > 0 {
 		fields = ctx.Cli.List.Fields
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -75,6 +75,7 @@ var DEFAULT_CONFIG map[string]interface{} = map[string]interface{}{
 	"LogLines":                                  false,
 	"DefaultRegion":                             "us-east-1",
 	"HistoryLimit":                              10,
+	"ListFields":                                []string{"AccountId", "AccountAlias", "RoleName", "ExpiresStr"},
 }
 
 type CLI struct {

--- a/sso/cache.go
+++ b/sso/cache.go
@@ -216,8 +216,8 @@ type AWSRoleFlat struct {
 	AccountName   string            `json:"AccountName" header:"AccountName"`
 	AccountAlias  string            `json:"AccountAlias" header:"AccountAlias"`
 	EmailAddress  string            `json:"EmailAddress" header:"EmailAddress"`
-	Expires       int64             `json:"Expires"`            // used in cache
-	ExpiresStr    string            `json:"-" header:"Expires"` // used by `list` command
+	Expires       int64             `json:"Expires" header:"ExpiresEpoch"`
+	ExpiresStr    string            `json:"-" header:"Expires"`
 	Arn           string            `json:"Arn" header:"ARN"`
 	RoleName      string            `json:"RoleName" header:"Role"`
 	Profile       string            `json:"Profile" header:"Profile"`

--- a/sso/settings.go
+++ b/sso/settings.go
@@ -56,6 +56,7 @@ type Settings struct {
 	LogLines          bool                  `koanf:"LogLines" yaml:"LogLines,omitempty"`
 	HistoryLimit      int                   `koanf:"HistoryLimit" yaml:"HistoryLimit,omitempty"`
 	ssoName           string                // SSO name passed in via CLI
+	ListFields        []string              `koanf:"ListFields" yaml:"ListFields,omitempty"`
 }
 
 type SSOConfig struct {


### PR DESCRIPTION
Users can now override the fields being displayed via the `ListFields`
option in the config.yaml.

Fixes: #113