### PR TITLE
Fix autocomplete for `-a <arn>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
  * Fix missing --url-action and  --browser #113
  * Don't print out URL when sending to browser/clipboard for security
+ * Escape colon in ARN's for `-a` flag to work around the colon being a 
+    word delimiter for bash (auto)complete. #135
 
 ## [v1.3.0] - 2021-11-14
 

--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"io/ioutil"
+	"strings"
 
 	"github.com/goccy/go-yaml"
 	"github.com/posener/complete"
@@ -111,7 +112,15 @@ func (p *Predictor) RoleComplete() complete.Predictor {
 
 // ArnComplete returns a list of all the valid AWS Role ARNs we have in the cache
 func (p *Predictor) ArnComplete() complete.Predictor {
-	return complete.PredictSet(p.arns...)
+	arns := []string{}
+
+	// The `:` character is considered a word delimiter by bash complete
+	// so we need to escape them
+	for _, a := range p.arns {
+		arns = append(arns, strings.ReplaceAll(a, ":", "\\:"))
+	}
+
+	return complete.PredictSet(arns...)
 }
 
 // RegionsComplete returns a list of all the valid AWS Regions


### PR DESCRIPTION
Need to escape colons for ARN's for autocomplete.

Fixes: #135