### PR TITLE
Fix broken default command

### DIFF
--- a/cmd/console_cmd.go
+++ b/cmd/console_cmd.go
@@ -37,15 +37,17 @@ import (
 const AWS_FEDERATED_URL = "https://signin.aws.amazon.com/federation"
 
 type ConsoleCmd struct {
-	Region          string `kong:"optional,name='region',help='AWS Region',env='AWS_DEFAULT_REGION',predictor='region'"`
-	AccessKeyId     string `kong:"optional,env='AWS_ACCESS_KEY_ID',hidden"`
-	AccountId       int64  `kong:"optional,name='account',short='A',help='AWS AccountID of role to assume',env='AWS_SSO_ACCOUNTID',predictor='accountId'"`
-	Arn             string `kong:"optional,short='a',help='ARN of role to assume',env='AWS_SSO_ROLE_ARN',predictor='arn'"`
-	Duration        int64  `kong:"optional,short='d',help='AWS Session duration in minutes (default 60)',default=60,env='AWS_SSO_DURATION'"`
-	Role            string `kong:"optional,short='R',help='Name of AWS Role to assume',env='AWS_SSO_ROLE',predictor='role'"`
-	SecretAccessKey string `kong:"optional,env='AWS_SECRET_ACCESS_KEY',hidden"`
-	SessionToken    string `kong:"optional,env='AWS_SESSION_TOKEN',hidden"`
-	UseEnv          bool   `kong:"optional,short='e',help='Use existing ENV vars to generate URL'"`
+	Region   string `kong:"help='AWS Region',env='AWS_DEFAULT_REGION',predictor='region'"`
+	Duration int64  `kong:"short='d',help='AWS Session duration in minutes (default 60)',default=60,env='AWS_SSO_DURATION'"`
+	UseEnv   bool   `kong:"short='e',help='Use existing ENV vars to generate URL'"`
+
+	Arn       string `kong:"short='a',help='ARN of role to assume',env='AWS_SSO_ROLE_ARN',predictor='arn',xor='arn-1',xor='arn-2'"`
+	AccountId int64  `kong:"name='account',short='A',help='AWS AccountID of role to assume',env='AWS_SSO_ACCOUNTID',predictor='accountId',xor='arn-1'"`
+	Role      string `kong:"short='R',help='Name of AWS Role to assume',env='AWS_SSO_ROLE',predictor='role',xor='arn-2'"`
+
+	AccessKeyId     string `kong:"env='AWS_ACCESS_KEY_ID',hidden"`
+	SecretAccessKey string `kong:"env='AWS_SECRET_ACCESS_KEY',hidden"`
+	SessionToken    string `kong:"env='AWS_SESSION_TOKEN',hidden"`
 }
 
 func (cc *ConsoleCmd) Run(ctx *RunContext) error {

--- a/cmd/exec_cmd.go
+++ b/cmd/exec_cmd.go
@@ -38,9 +38,9 @@ type ExecCmd struct {
 	// AWS Params
 	Region    string `kong:"help='AWS Region',env='AWS_DEFAULT_REGION',predictor='region'"`
 	Duration  int64  `kong:"short='d',help='AWS Session duration in minutes (default 60)',default=60,env='AWS_SSO_DURATION'"`
-	Arn       string `kong:"short='a',help='ARN of role to assume',env='AWS_SSO_ROLE_ARN',predictor='arn'"`
-	AccountId int64  `kong:"name='account',short='A',help='AWS AccountID of role to assume',env='AWS_SSO_ACCOUNTID',predictor='accountId'"`
-	Role      string `kong:"short='R',help='Name of AWS Role to assume',env='AWS_SSO_ROLE',predictor='role'"`
+	Arn       string `kong:"short='a',help='ARN of role to assume',env='AWS_SSO_ROLE_ARN',predictor='arn',xor='arn-1',xor='arn-2'"`
+	AccountId int64  `kong:"name='account',short='A',help='AWS AccountID of role to assume',env='AWS_SSO_ACCOUNTID',predictor='accountId',xor='arn-1'"`
+	Role      string `kong:"short='R',help='Name of AWS Role to assume',env='AWS_SSO_ROLE',predictor='role',xor='arn-2'"`
 
 	// Exec Params
 	Cmd  string   `kong:"arg,optional,name='command',help='Command to execute',env='SHELL'"`

--- a/cmd/flush_cmd.go
+++ b/cmd/flush_cmd.go
@@ -24,7 +24,7 @@ import (
 
 // FlushCmd defines the Kong args for the flush command
 type FlushCmd struct {
-	All bool `kong:"optional,name='all',help='Also flush individual STS tokens'"`
+	All bool `kong:"help='Also flush individual STS tokens'"`
 }
 
 // Run executes the flush command

--- a/cmd/list_cmd.go
+++ b/cmd/list_cmd.go
@@ -45,8 +45,8 @@ var allListFields = map[string]string{
 }
 
 type ListCmd struct {
-	ListFields bool     `kong:"optional,name='list-fields',short='f',help='List available fields'"`
-	Fields     []string `kong:"optional,arg,help='Fields to display',env='AWS_SSO_FIELDS',predictor='fieldList'"`
+	ListFields bool     `kong:"optional,short='f',help='List available fields',xor='fields'"`
+	Fields     []string `kong:"optional,arg,help='Fields to display',env='AWS_SSO_FIELDS',predictor='fieldList',xor='fields'"`
 }
 
 // what should this actually do?
@@ -77,6 +77,15 @@ func (cc *ListCmd) Run(ctx *RunContext) error {
 
 	printRoles(ctx, fields)
 
+	return nil
+}
+
+// DefaultCmd has no args, and just prints the default fields and exists because
+// as of Kong 0.2.18 you can't have a default command which takes args
+type DefaultCmd struct{}
+
+func (cc *DefaultCmd) Run(ctx *RunContext) error {
+	printRoles(ctx, ctx.Settings.ListFields)
 	return nil
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -91,10 +91,11 @@ type CLI struct {
 	// Commands
 	Cache              CacheCmd                     `kong:"cmd,help='Force reload of cached AWS SSO role info and config.yaml'"`
 	Console            ConsoleCmd                   `kong:"cmd,help='Open AWS Console using specificed AWS Role/profile'"`
-	Exec               ExecCmd                      `kong:"cmd,help='Execute command using specified AWS Role/Profile'"`
+	Default            DefaultCmd                   `kong:"cmd,hidden,default='1'"` // list command without args
 	Eval               EvalCmd                      `kong:"cmd,help='Print AWS Environment vars for use with eval $(aws-sso eval ...)'"`
+	Exec               ExecCmd                      `kong:"cmd,help='Execute command using specified AWS Role/Profile'"`
 	Flush              FlushCmd                     `kong:"cmd,help='Flush AWS SSO/STS credentials from cache'"`
-	List               ListCmd                      `kong:"cmd,help='List all accounts / role (default command)',default='1'"`
+	List               ListCmd                      `kong:"cmd,help='List all accounts / role (default command)'"`
 	Tags               TagsCmd                      `kong:"cmd,help='List tags'"`
 	Time               TimeCmd                      `kong:"cmd,help='Print out much time before STS Token expires'"`
 	Version            VersionCmd                   `kong:"cmd,help='Print version and exit'"`

--- a/cmd/tags_cmd.go
+++ b/cmd/tags_cmd.go
@@ -26,9 +26,9 @@ import (
 )
 
 type TagsCmd struct {
-	AccountId   int64  `kong:"optional,name='account',short='A',help='Filter regsults based on AWS AccountID'"`
-	Role        string `kong:"optional,name='role',short='R',help='Filter results based on AWS Role Name'"`
-	ForceUpdate bool   `kong:"optional,name='force-update',help='Force account/role cache update'"`
+	AccountId   int64  `kong:"name='account',short='A',help='Filter results based on AWS AccountID'"`
+	Role        string `kong:"short='R',help='Filter results based on AWS Role Name'"`
+	ForceUpdate bool   `kong:"help='Force account/role cache update'"`
 }
 
 func (cc *TagsCmd) Run(ctx *RunContext) error {

--- a/sso/settings.go
+++ b/sso/settings.go
@@ -190,7 +190,6 @@ func (s *Settings) Save(configFile string, overwrite bool) error {
 
 	configDir := utils.GetHomePath(filepath.Dir(configFile))
 	configFile = filepath.Join(configDir, filepath.Base(configFile))
-	log.Errorf("configFile: %s", configFile)
 	if err = utils.EnsureDirExists(configFile); err != nil {
 		return err
 	}


### PR DESCRIPTION
 * Kong 0.2.18 broke the default command, so fix that
 * Remove lots of redundant Kong config params (optional, name)
 * Remove error used for debugging
 * use promptui.Select for AWS Region
 * Add support for setting the aws default region for an SSO provider