### PR TITLE
fix `eval` when printing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [Unreleased]
 
  * Update interactive selected item color schme to stand our better. #138
+ * Add `eval --clear`
+ * `eval` no longer prints URLs #145
 
 ## [v1.3.1] - 2021-11-15
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Flags:
  * `--duration <minutes>`, `-d` -- AWS Session duration in minutes (default 60) (`$AWS_SSO_DURATION`)
  * `--role <role>`, `-R` -- Name of AWS Role to assume (requires `--account`) (`$AWS_SSO_ROLE`)
 
+**Note:** The `eval` command will never honor the `--url-action=print`
+option as this will intefere with bash/zsh/etc ability to evaluate 
+the generated commands and will fall back to `--url-action=open`.
+
 ### exec
 
 Exec allows you to execute a command with the necessary [AWS environment variables](

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -56,7 +56,7 @@ func HandleUrl(action, browser, url, pre, post string) error {
 	case "clip":
 		err = clipboard.WriteAll(url)
 		if err == nil {
-			fmt.Printf("Please open URL copied to clipboard.\n")
+			log.Infof("Please open URL copied to clipboard.\n")
 		} else {
 			err = fmt.Errorf("Unable to copy URL to clipboard: %s", err.Error())
 		}
@@ -72,7 +72,7 @@ func HandleUrl(action, browser, url, pre, post string) error {
 		if err != nil {
 			err = fmt.Errorf("Unable to open URL with %s: %s", browser, err.Error())
 		} else {
-			fmt.Printf("Opening URL in %s.\n", browser)
+			log.Infof("Opening URL in %s.\n", browser)
 		}
 	default:
 		err = fmt.Errorf("Unknown --url-action option: '%s'", action)


### PR DESCRIPTION
 * No longer print urls with `eval`
 * `eval` now supported the `--clear` flag

Fixes: #145