### PR TITLE
Do not manage the AWS_DEFAULT_REGION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  * Update interactive selected item color schme to stand our better. #138
  * Add `eval --clear`
  * `eval` no longer prints URLs #145
+ * Remove `--region` and `DefaultRegion` #149
 
 ## [v1.3.1] - 2021-11-15
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@
 [![Report Card](https://goreportcard.com/badge/github.com/synfinatic/aws-sso-cli)](https://goreportcard.com/report/github.com/synfinatic/aws-sso-cli)
 [![GitHub license](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://raw.githubusercontent.com/synfinatic/aws-sso-cli/main/LICENSE)
 
+ * [About](#about)
+ * [What does AWS SSO CLI do?](#what-does-aws-sso-cli-do)
+ * [Demo](#demo)
+ * [Installation](#installation)
+ * [Security](#security)
+ * [Commands](#commands)
+ * [Configuration](#configuration)
+ * [Environment Varables](#environment-varables)
+ * [Release History](#release-history)
+ * [License](#license)
+
 ## About
 
 AWS SSO CLI is a secure replacement for using the [aws configure sso](
@@ -113,7 +124,6 @@ in the terminal or copied into the Copy & Paste buffer of your computer.
 
 Flags:
 
- * `--region <region>`, `-r` -- Specify the `$AWS_DEFAULT_REGION` to use
  * `--arn <arn>`, `-a` -- ARN of role to assume (`$AWS_SSO_ROLE_ARN`)
  * `--account <account>`, `-A` -- AWS AccountID of role to assume (`$AWS_SSO_ACCOUNTID`)
  * `--duration <minutes>`, `-d` -- AWS Session duration in minutes (default 60) (`$AWS_SSO_DURATION`)
@@ -136,7 +146,6 @@ Suggested use (bash): `eval $(aws-sso eval <args>)`
 
 Flags:
 
- * `--region <region>`, `-r` -- Specify the `$AWS_DEFAULT_REGION` to use
  * `--arn <arn>`, `-a` -- ARN of role to assume (`$AWS_SSO_ROLE_ARN`)
  * `--account <account>`, `-A` -- AWS AccountID of role to assume (`$AWS_SSO_ACCOUNTID`)
  * `--duration <minutes>`, `-d` -- AWS Session duration in minutes (default 60) (`$AWS_SSO_DURATION`)
@@ -155,7 +164,6 @@ commands.
 
 Flags:
 
- * `--region <region>, `-r` -- Specify the `$AWS_DEFAULT_REGION` to use
  * `--arn <arn>`, `-a` -- ARN of role to assume (`$AWS_SSO_ROLE_ARN`)
  * `--account <account>`, `-A` -- AWS AccountID of role to assume (`$AWS_SSO_ACCOUNTID`)
  * `--duration <minutes>`, `-d` -- AWS Session duration in minutes (default 60) (`$AWS_SSO_DURATION`)
@@ -176,7 +184,6 @@ The following environment variables are automatically set by `exec`:
  * `AWS_ROLE_NAME` -- The name of the IAM role
  * `AWS_ROLE_ARN` -- The full ARN of the IAM role
  * `AWS_SESSION_EXPIRATION`  -- The date and time when the IAM role credentials will expire
- * `AWS_DEFAULT_REGION` -- Region to use AWS with
  * `AWS_SSO_PROFILE` -- User customizable varible using a template
 
 ### cache
@@ -247,7 +254,6 @@ for this to take effect.
 
 The following environment variables are honored by `exec` and `console`:
 
- * `AWS_DEFAULT_REGION` -- Region to use AWS with
  * `AWS_SSO_DURATION` -- Default number of minutes to request for session lifetime
  * `AWS_SSO_ROLE_ARN` -- Specify the ARN to assume
  * `AWS_SSO_ACCOUNTID` -- Specify the AWS AccountID for the role to assume
@@ -267,13 +273,11 @@ SSOConfig:
         Accounts:  # optional block for specifying tags & overrides
             <AccountId>:
                 Name: <Friendly Name of Account>
-                DefaultRegion: <AWS_DEFAULT_REGION>
                 Tags:  # tags for all roles in the account
                     <Key1>: <Value1>
                     <Key2>: <Value2>
                 Roles:
                     <Role Name>:
-                        DefaultRegion: <AWS_DEFAULT_REGION>
                         Tags:  # tags specific for this role (will override account level tags)
                             <Key1>: <Value1>
                             <Key2>: <Value2>
@@ -386,7 +390,6 @@ The following variables are accessible from the `AWSRoleFlat` struct:
  * `Arn` -- AWS ARN for this role
  * `RoleName` -- The role name
  * `Profile` -- Manually configured AWS_SSO_PROFILE value for this role
- * `DefaultRegion` -- The manually configured default region for this role
  * `SSORegion` -- The AWS Region where AWS SSO is enabled in your account
  * `StartUrl` -- The AWS SSO start URL for your account
  * `Tags` -- Map of additional custom key/value pairs
@@ -482,7 +485,6 @@ Specify which fields to display via the `list` command.  Valid options are:
  * `AccountName` -- Account Name from config.yaml
  * `AccountAlias` -- Account Name from AWS SSO
  * `ARN` -- Role ARN
- * `DefaultRegion` -- Configured default region
  * `EmailAddress` -- Email address of root account associated with AWS Account
  * `ExpiresEpoch` -- Unix epoch time when cached STS creds expire
  * `ExpiresStr` -- Hours and minutes until cached STS creds expire
@@ -499,7 +501,6 @@ Specify which fields to display via the `list` command.  Valid options are:
 The following environment variables are honored by `aws-sso`:
 
  * `AWS_SSO_FILE_PASSPHRASE` -- Passphrase to use with the `file` SecureStore
- * `AWS_DEFAULT_REGION` -- Will pass this value to any new shell created by `exec`
  * `AWS_SSO_CONFIG` -- Specify an alternate path to the `aws-sso` config file
 	(default: `~/.aws-sso/config.yaml`)
  * `AWS_SSO_BROWSER` -- Override default browser for AWS SSO login
@@ -507,6 +508,11 @@ The following environment variables are honored by `aws-sso`:
 
 The `file` SecureStore will use the `AWS_SSO_FILE_PASSPHRASE` environment
 variable for the passphrase if it is set. (Not recommended.)
+
+## Release History
+
+ * [Releases](releases)
+ * [Changelog](CHANGELOG.md)
 
 ## License
 

--- a/cmd/eval_cmd.go
+++ b/cmd/eval_cmd.go
@@ -30,7 +30,6 @@ import (
 
 type EvalCmd struct {
 	// AWS Params
-	Region    string `kong:"help='AWS Region',env='AWS_DEFAULT_REGION',predictor='region'"`
 	Duration  int64  `kong:"short='d',help='AWS Session duration in minutes (default 60)',default=60,env='AWS_SSO_DURATION'"`
 	Arn       string `kong:"short='a',help='ARN of role to assume',env='AWS_SSO_ROLE_ARN',predictor='arn',xor='arn-1',xor='arn-2'"`
 	AccountId int64  `kong:"name='account',short='A',help='AWS AccountID of role to assume',env='AWS_SSO_ACCOUNTID',predictor='accountId',xor='arn-1'"`
@@ -54,7 +53,6 @@ func (cc *EvalCmd) Run(ctx *RunContext) error {
 	// if CLI args are speecified, use that
 	role := ctx.Cli.Eval.Role
 	account := ctx.Cli.Eval.AccountId
-	region := ctx.Cli.Eval.Region
 
 	if len(ctx.Cli.Eval.Arn) > 0 {
 		account, role, err = utils.ParseRoleARN(ctx.Cli.Eval.Arn)
@@ -78,12 +76,8 @@ func (cc *EvalCmd) Run(ctx *RunContext) error {
 		log.Infof("Refreshing current AWS Role credentials")
 	}
 
-	if len(region) == 0 {
-		region = ctx.Settings.GetDefaultRegion(account, role)
-	}
-
 	awssso := doAuth(ctx)
-	for k, v := range execShellEnvs(ctx, awssso, account, role, region) {
+	for k, v := range execShellEnvs(ctx, awssso, account, role) {
 		if strings.Contains(v, " ") {
 			fmt.Printf("export %s=\"%s\"\n", k, v)
 		} else {
@@ -102,7 +96,6 @@ func unsetEnvVars() {
 		"AWS_ROLE_NAME",
 		"AWS_ROLE_ARN",
 		"AWS_SESSION_EXPIRATION",
-		"AWS_DEFAULT_REGION",
 		"AWS_SSO_PROFILE",
 	}
 	for _, e := range envs {

--- a/cmd/list_cmd.go
+++ b/cmd/list_cmd.go
@@ -30,15 +30,14 @@ import (
 
 // keys match AWSRoleFlat header and value is the description
 var allListFields = map[string]string{
-	"Id":            "Column Index",
-	"Arn":           "AWS Role Resource Name",
-	"AccountId":     "AWS AccountID",
-	"AccountName":   "Configured Account Name",
-	"AccountAlias":  "AWS Account Alias",
-	"DefaultRegion": "Default AWS Region",
-	"EmailAddress":  "Root email for AWS account",
-	"ExpiresStr":    "Time until STS creds expire",
-	"Expires":       "Unix Epoch when STS creds expire",
+	"Id":           "Column Index",
+	"Arn":          "AWS Role Resource Name",
+	"AccountId":    "AWS AccountID",
+	"AccountName":  "Configured Account Name",
+	"AccountAlias": "AWS Account Alias",
+	"EmailAddress": "Root email for AWS account",
+	"ExpiresStr":   "Time until STS creds expire",
+	"Expires":      "Unix Epoch when STS creds expire",
 	//	"Profile":       "AWS_PROFILE",
 	"RoleName": "AWS Role Name",
 	//	"Via":           "Role Chain Via",

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -73,7 +73,6 @@ var DEFAULT_CONFIG map[string]interface{} = map[string]interface{}{
 	"PromptColors.SelectedSuggestionTextColor":  "White",
 	"PromptColors.SuggestionBGColor":            "Cyan",
 	"PromptColors.SuggestionTextColor":          "White",
-	"DefaultRegion":                             "us-east-1",
 	"HistoryLimit":                              10,
 	"ListFields":                                []string{"AccountId", "AccountAlias", "RoleName", "ExpiresStr"},
 }

--- a/cmd/select.go
+++ b/cmd/select.go
@@ -31,7 +31,7 @@ import (
 	"github.com/synfinatic/aws-sso-cli/utils"
 )
 
-type CompleterExec = func(*RunContext, *sso.AWSSSO, int64, string, string) error
+type CompleterExec = func(*RunContext, *sso.AWSSSO, int64, string) error
 
 type TagsCompleter struct {
 	ctx      *RunContext
@@ -106,9 +106,8 @@ func (tc *TagsCompleter) Executor(args string) {
 	if err != nil {
 		log.Fatalf("Unable to parse %s: %s", roleArn, err.Error())
 	}
-	region := tc.ctx.Settings.GetDefaultRegion(aId, rName)
 	awsSSO := doAuth(tc.ctx)
-	err = tc.exec(tc.ctx, awsSSO, aId, rName, region)
+	err = tc.exec(tc.ctx, awsSSO, aId, rName)
 	if err != nil {
 		log.Fatalf("Unable to exec: %s", err.Error())
 	}

--- a/cmd/setup_cmd.go
+++ b/cmd/setup_cmd.go
@@ -62,7 +62,7 @@ func (cc *SetupCmd) Run(ctx *RunContext) error {
 
 func setupWizard(ctx *RunContext) error {
 	var err error
-	var instanceName, startURL, ssoRegion, awsRegion, urlAction string
+	var instanceName, startURL, ssoRegion, urlAction string
 
 	// Name our SSO instance
 	prompt := promptui.Prompt{
@@ -93,23 +93,6 @@ func setupWizard(ctx *RunContext) error {
 		return err
 	}
 
-	// Pick the AWS region to use
-	defaultRegions := []string{"None"}
-	defaultRegions = append(defaultRegions, AvailableAwsSSORegions...)
-
-	sel = promptui.Select{
-		Label:        "Default region for connecting to AWS (DefaultRegion)",
-		Items:        defaultRegions,
-		HideSelected: false,
-	}
-	if _, awsRegion, err = sel.Run(); err != nil {
-		return err
-	}
-
-	if awsRegion == "None" {
-		awsRegion = ""
-	}
-
 	// How should we deal with URLs?
 	sel = promptui.Select{
 		Label: "Default action to take with URLs (UrlAction)",
@@ -125,9 +108,8 @@ func setupWizard(ctx *RunContext) error {
 		UrlAction:  urlAction,
 	}
 	s.SSO[ctx.Cli.SSO] = &sso.SSOConfig{
-		SSORegion:     ssoRegion,
-		StartUrl:      startURL,
-		DefaultRegion: awsRegion,
+		SSORegion: ssoRegion,
+		StartUrl:  startURL,
 	}
 	return s.Save(ctx.Cli.ConfigFile, false)
 }

--- a/sso/cache_test.go
+++ b/sso/cache_test.go
@@ -68,7 +68,6 @@ func (suite *CacheTestSuite) TestGetRole() {
 	assert.Equal(t, "control-tower-dev-sub1-aws", r.AccountAlias)
 	assert.Equal(t, "test+control-tower-sub1@ourcompany.com", r.EmailAddress)
 	assert.Equal(t, "", r.Profile)
-	assert.Equal(t, "", r.DefaultRegion)
 	assert.Equal(t, "us-east-1", r.SSORegion)
 	assert.Equal(t, "https://d-754545454.awsapps.com/start", r.StartUrl)
 

--- a/sso/settings.go
+++ b/sso/settings.go
@@ -49,7 +49,6 @@ type Settings struct {
 	SSO               map[string]*SSOConfig `koanf:"SSOConfig" yaml:"SSOConfig,omitempty"`
 	DefaultSSO        string                `koanf:"DefaultSSO" yaml:"DefaultSSO,omitempty"`   // specify default SSO by key
 	SecureStore       string                `koanf:"SecureStore" yaml:"SecureStore,omitempty"` // json or keyring
-	DefaultRegion     string                `koanf:"DefaultRegion" yaml:"DefaultRegion,omitempty"`
 	JsonStore         string                `koanf:"JsonStore" yaml:"JsonStore,omitempty"`
 	UrlAction         string                `koanf:"UrlAction" yaml:"UrlAction,omitempty"`
 	Browser           string                `koanf:"Browser" yaml:"Browser,omitempty"`
@@ -63,44 +62,25 @@ type Settings struct {
 }
 
 type SSOConfig struct {
-	settings      *Settings             // pointer back up
-	SSORegion     string                `koanf:"SSORegion" yaml:"SSORegion"`
-	StartUrl      string                `koanf:"StartUrl" yaml:"StartUrl"`
-	Accounts      map[int64]*SSOAccount `koanf:"Accounts" yaml:"Accounts,omitempty"`
-	DefaultRegion string                `koanf:"DefaultRegion" yaml:"DefaultRegion,omitempty"`
+	settings  *Settings             // pointer back up
+	SSORegion string                `koanf:"SSORegion" yaml:"SSORegion"`
+	StartUrl  string                `koanf:"StartUrl" yaml:"StartUrl"`
+	Accounts  map[int64]*SSOAccount `koanf:"Accounts" yaml:"Accounts,omitempty"`
 }
 
 type SSOAccount struct {
-	config        *SSOConfig          // pointer back up
-	Name          string              `koanf:"Name" yaml:"Name,omitempty"` // Admin configured Account Name
-	Tags          map[string]string   `koanf:"Tags" yaml:"Tags,omitempty" `
-	Roles         map[string]*SSORole `koanf:"Roles" yaml:"Roles,omitempty"`
-	DefaultRegion string              `koanf:"DefaultRegion" yaml:"DefaultRegion,omitempty"`
+	config *SSOConfig          // pointer back up
+	Name   string              `koanf:"Name" yaml:"Name,omitempty"` // Admin configured Account Name
+	Tags   map[string]string   `koanf:"Tags" yaml:"Tags,omitempty" `
+	Roles  map[string]*SSORole `koanf:"Roles" yaml:"Roles,omitempty"`
 }
 
 type SSORole struct {
-	account       *SSOAccount       // pointer back up
-	ARN           string            `yaml:"ARN"`
-	Profile       string            `koanf:"Profile" yaml:"Profile,omitempty"`
-	Tags          map[string]string `koanf:"Tags" yaml:"Tags,omitempty"`
-	DefaultRegion string            `koanf:"DefaultRegion" yaml:"DefaultRegion,omitempty"`
-	Via           string            `koanf:"Via" yaml:"Via,omitempty"`
-}
-
-// GetDefaultRegion returns the user defined AWS_DEFAULT_REGION for the specified role
-func (s *Settings) GetDefaultRegion(accountId int64, roleName string) string {
-	roleFlat, err := s.Cache.Roles.GetRole(accountId, roleName)
-	if err != nil {
-		if s.SSO[s.DefaultSSO].DefaultRegion != "" {
-			return s.SSO[s.DefaultSSO].DefaultRegion
-		} else {
-			return s.DefaultRegion
-		}
-	}
-	if roleFlat.DefaultRegion != "" {
-		return roleFlat.DefaultRegion
-	}
-	return s.DefaultRegion
+	account *SSOAccount       // pointer back up
+	ARN     string            `yaml:"ARN"`
+	Profile string            `koanf:"Profile" yaml:"Profile,omitempty"`
+	Tags    map[string]string `koanf:"Tags" yaml:"Tags,omitempty"`
+	Via     string            `koanf:"Via" yaml:"Via,omitempty"`
 }
 
 var DEFAULT_ACCOUNT_PRIMARY_TAGS []string = []string{
@@ -368,9 +348,6 @@ func (a *SSOAccount) GetAllTags(id int64) map[string]string {
 		accountId := strconv.FormatInt(id, 10)
 		tags["AccountId"] = accountId
 	}
-	if a.DefaultRegion != "" {
-		tags["DefaultRegion"] = a.DefaultRegion
-	}
 	for k, v := range a.Tags {
 		tags[k] = v
 	}
@@ -397,9 +374,6 @@ func (r *SSORole) GetAllTags() map[string]string {
 	tags["RoleName"] = r.GetRoleName()
 	tags["AccountId"] = r.GetAccountId()
 
-	if r.DefaultRegion != "" {
-		tags["DefaultRegion"] = r.DefaultRegion
-	}
 	for k, v := range r.Tags {
 		tags[k] = v
 	}


### PR DESCRIPTION
 * Do not ever touch or look at AWS_DEFAULT_REGION.  Let users
    manage that normally as their existing tooling does.  This removes:
    * `--region` flag
    * `DefaultRegion` config setting at all levels
    * Setting/clearing the `$AWS_DEFAULT_REGION` env variable
 * Add a TOC to the README

Fixes: #149
Refs: #132