### PR TITLE
Add TOC and more pedantic abouve ENV vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  * Update interactive selected item color schme to stand our better. #138
  * Add `eval --clear`
  * `eval` no longer prints URLs #145
+ * `exec` now updates the ENV vars of the exec variable rather than our process
 
 ## [v1.3.1] - 2021-11-15
 

--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,3 @@ $(DARWINARM64_BIN): $(wildcard */*.go) .prepare
 
 $(OUTPUT_NAME): $(wildcard */*.go) .prepare
 	go build -ldflags='$(LDFLAGS)' -o $(OUTPUT_NAME) cmd/*.go
-
-workflow.png: workflow.dot
-	dot -oworkflow.png -Tpng workflow.dot
-

--- a/README.md
+++ b/README.md
@@ -3,6 +3,18 @@
 [![Report Card](https://goreportcard.com/badge/github.com/synfinatic/aws-sso-cli)](https://goreportcard.com/report/github.com/synfinatic/aws-sso-cli)
 [![GitHub license](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://raw.githubusercontent.com/synfinatic/aws-sso-cli/main/LICENSE)
 
+ * [About](#about)
+ * [What does AWS SSO CLI do?](#what-does-aws-sso-cli-do)
+ * [Demo](#demo)
+ * [Installation](#installation)
+ * [Security](#security)
+ * [Commands](#commands)
+ * [Configuration](#configuration)
+ * [Environment Varables](#environment-varables)
+ * [Release History](#release-history)
+ * [License](#license)
+
+
 ## About
 
 AWS SSO CLI is a secure replacement for using the [aws configure sso](
@@ -507,6 +519,12 @@ The following environment variables are honored by `aws-sso`:
 
 The `file` SecureStore will use the `AWS_SSO_FILE_PASSPHRASE` environment
 variable for the passphrase if it is set. (Not recommended.)
+
+## Release History
+
+ * [Releases](https://github.com/synfinatic/aws-sso-cli/releases)
+ * [Changelog](CHANGELOG.md)
+
 
 ## License
 

--- a/cmd/exec_cmd.go
+++ b/cmd/exec_cmd.go
@@ -136,10 +136,13 @@ func execCmd(ctx *RunContext, awssso *sso.AWSSSO, accountid int64, role, region 
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
+	cmd.Env = os.Environ() // copy our current environment to the executor
 
+	// add the variables we need for AWS to the executor without polluting our
+	// own process
 	for k, v := range execShellEnvs(ctx, awssso, accountid, role, region) {
 		log.Debugf("Setting %s = %s", k, v)
-		os.Setenv(k, v)
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", k, v))
 	}
 	// just do it!
 	return cmd.Run()


### PR DESCRIPTION
- Add a TOC to the README
- Don't pollute our own process ENV when `exec`
- Remove copypasta from Makefile