### PR TITLE
Switch to a single keyring entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # AWS SSO CLI Changelog
 
+## [Unreleased]
+
+### Changes
+ * Now use macOS `login` Keychain instead of `AWSSSOCli`
+ * All secure storage methods now store a single entry instead of multiple entries
+
 ## [v1.4.0]
 
 ### Breaking Changes

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT_VERSION := 1.4.0
+PROJECT_VERSION := 1.5.0
 DOCKER_REPO     := synfinatic
 PROJECT_NAME    := aws-sso
 
@@ -50,6 +50,8 @@ DARWINARM64_BIN           := $(DIST_DIR)$(PROJECT_NAME)-$(PROJECT_VERSION)-darwi
 
 ALL: $(DIST_DIR)$(PROJECT_NAME) ## Build binary for this platform
 
+include help.mk  # place after ALL target and before all other targets
+
 $(DIST_DIR)$(PROJECT_NAME):	$(wildcard */*.go) .prepare
 	go build -ldflags='$(LDFLAGS)' -o $(DIST_DIR)$(PROJECT_NAME) cmd/*.go
 	@echo "Created: $(DIST_DIR)$(PROJECT_NAME)"
@@ -97,8 +99,6 @@ package: linux linux-arm64  ## Build deb/rpm packages
 tags: cmd/*.go sso/*.go  ## Create tags file for vim, etc
 	@echo Make sure you have Universal Ctags installed: https://github.com/universal-ctags/ctags
 	ctags -R
-
-include help.mk  # place after ALL target and before all other targets
 
 .build-release: windows windows32 linux linux-arm64 darwin darwin-arm64
 
@@ -158,6 +158,9 @@ vet: ## Run `go vet` on the code
 test: vet unittest lint ## Run important tests
 
 precheck: test test-fmt test-tidy ## Run all tests that happen in a PR
+
+# run everything but `lint` because that runs via it's own workflow
+.build-tests: vet unittest test-tidy test-fmt
 
 $(DIST_DIR):
 	@if test ! -d $(DIST_DIR); then mkdir -p $(DIST_DIR) ; fi
@@ -225,7 +228,7 @@ $(DARWINARM64_BIN): $(wildcard */*.go) .prepare
 $(OUTPUT_NAME): $(wildcard */*.go) .prepare
 	go build -ldflags='$(LDFLAGS)' -o $(OUTPUT_NAME) cmd/*.go
 
-docs: docs/default-region.png 
+docs: docs/default-region.png  ## Build document files
 
 docs/default-region.png:
 	dot -o docs/default-region.png -Tpng docs/default-region.dot

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -156,7 +156,10 @@ func main() {
 		}
 		log.Warnf("Using insecure json file for SecureStore: %s", sfile)
 	default:
-		cfg := storage.NewKeyringConfig(run_ctx.Settings.SecureStore, CONFIG_DIR)
+		cfg, err := storage.NewKeyringConfig(run_ctx.Settings.SecureStore, CONFIG_DIR)
+		if err != nil {
+			log.WithError(err).Fatalf("Unable to create SecureStore")
+		}
 		run_ctx.Store, err = storage.OpenKeyring(cfg)
 		if err != nil {
 			log.WithError(err).Fatalf("Unable to open SecureStore %s", run_ctx.Settings.SecureStore)

--- a/storage/keyring_test.go
+++ b/storage/keyring_test.go
@@ -1,0 +1,70 @@
+package storage
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKeyring(t *testing.T) {
+	d, err := os.MkdirTemp("", "test-keyring")
+	assert.NoError(t, err)
+	defer os.RemoveAll(d)
+
+	os.Setenv(ENV_SSO_FILE_PASSWORD, "justapassword")
+	c, err := NewKeyringConfig("file", d)
+	assert.NoError(t, err)
+
+	s, err := OpenKeyring(c)
+	assert.NoError(t, err)
+
+	data := NewStorageData()
+	rcd := RegisterClientData{
+		AuthorizationEndpoint: "https://foobar.com",
+		ClientId:              "ThisIsNotARealClientId",
+		ClientIdIssuedAt:      time.Now().Unix(),
+		ClientSecret:          "WeAllWishForGreatness",
+		ClientSecretExpiresAt: time.Now().Unix() + 1,
+		TokenEndpoint:         "IhavenoideawhatI'mdoing",
+	}
+	data.RegisterClientData["foo"] = rcd
+
+	err = s.saveStorageData(data)
+	assert.NoError(t, err)
+
+	data2 := NewStorageData()
+	err = s.getStorageData(&data2)
+	assert.NoError(t, err)
+	assert.Equal(t, data, data2)
+
+	err = s.SaveRegisterClientData("bar", rcd)
+	assert.NoError(t, err)
+	rcd2 := RegisterClientData{}
+
+	err = s.GetRegisterClientData("bar", &rcd2)
+	assert.NoError(t, err)
+	assert.Equal(t, rcd, rcd2)
+
+	err = s.GetRegisterClientData("cow", &rcd2)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
- No longer store multiple entries in macOS keychain/etc
- Switch to using macOS `login` KeyChain
- A lot fewer password prompt popups

Fixes: #150