### PR TITLE
Remove console --use-sts, add --prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## [Unreleased]
 
 ### Changes
- * Now use macOS `login` Keychain instead of `AWSSSOCli`
+ * Now use macOS `login` Keychain instead of `AWSSSOCli` #150
  * All secure storage methods now store a single entry instead of multiple entries
+ * Replace `console --use-sts` with `console --prompt` #169
 
 ## [v1.4.0]
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Flags:
  * `--arn <arn>`, `-a` -- ARN of role to assume (`$AWS_SSO_ROLE_ARN`)
  * `--account <account>`, `-A` -- AWS AccountID of role to assume (`$AWS_SSO_ACCOUNT_ID`)
  * `--duration <minutes>`, `-d` -- AWS Session duration in minutes (default 60)
- * `--use-sts`, `-s` -- Use existing STS credentials to generate a URL
+ * `--prompt`, `-p` -- Force interactive prompt to select role
  * `--role <role>`, `-R` -- Name of AWS Role to assume (requires `--account`) (`$AWS_SSO_ROLE_NAME`)
 
 The generated URL is good for 15 minutes after it is created.
@@ -141,9 +141,10 @@ what to do with the resulting URL from the `console` command.
 
 Priority is given to:
 
+ * `--prompt`
  * `--arn` (`$AWS_SSO_ROLE_ARN`)
  * `--account` (`$AWS_SSO_ACCOUNT_ID`) and `--role` (`$AWS_SSO_ROLE_NAME`)
- * `--use-sts`
+ * `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` environment variables
  * Prompt user interactively
 
 ### eval


### PR DESCRIPTION
No need to require users to provide --use-sts as we should
automagically pull the necessary information from the shell
environment.

Add support for `--prompt` so you can always force using
the completer in the off-chance you want a console in a
different account/role.

Fixes: #169