### PR TITLE
Remove `eval` and fix `exec` on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 ### New Features
  * Setup now prompts for `LogLevel`
  * Suppress bogus warning when saving Role credentials in `wincred` store #183
+ * Fix `eval` command on Windows using `export` instead of `set` #183
 
 ### Bugs Fixes 
  * Incorrect `--level` value now correctly tells user the correct name of the flag
+ * `exec` command now uses `cmd.exe` when no command is specified
 
 ## [v1.5.1] - 2021-12-15
 

--- a/README.md
+++ b/README.md
@@ -201,14 +201,18 @@ Priority is given to:
  * `--arn`
  * `--account` and `--role`
 
-**Note:** The `eval` command only honors the `$AWS_SSO_ROLE_ARN` in the context of the `--refresh` flag.
-The `$AWS_SSO_ROLE_NAME` and `$AWS_SSO_ACCOUNT_ID` are always ignored.
+**Note:** The `eval` command only honors the `$AWS_SSO_ROLE_ARN` in the context
+of the `--refresh` flag.  The `$AWS_SSO_ROLE_NAME` and `$AWS_SSO_ACCOUNT_ID`
+are always ignored.
 
 **Note:** The `eval` command will never honor the `--url-action=print`
 option as this will intefere with bash/zsh/etc ability to evaluate
 the generated commands and will fall back to `--url-action=open`.
 
-See [Environment Varables](#environment-varables) for more information about what varibles are set.
+**Note:** The `eval` command is not supported under Windows CommandPrompt or PowerShell.
+
+See [Environment Varables](#environment-varables) for more information about
+what varibles are set.
 
 ### exec
 

--- a/cmd/exec_cmd.go
+++ b/cmd/exec_cmd.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"text/template"
@@ -50,6 +51,11 @@ func (cc *ExecCmd) Run(ctx *RunContext) error {
 	err := checkAwsEnvironment()
 	if err != nil {
 		log.WithError(err).Fatalf("Unable to continue")
+	}
+
+	if runtime.GOOS == "windows" && ctx.Cli.Exec.Cmd == "" {
+		// Windows doesn't set $SHELL, so default to CommandPrompt
+		ctx.Cli.Exec.Cmd = "cmd.exe"
 	}
 
 	// Did user specify the ARN or account/role?

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -267,7 +267,7 @@ func GetRoleCredentials(ctx *RunContext, awssso *sso.AWSSSO, accountid int64, ro
 	var err error
 	creds, err = awssso.GetRoleCredentials(accountid, role)
 	if err != nil {
-		log.WithError(err).Fatalf("Unable to get role credentials for %s", role)
+		log.WithError(err).Fatalf("Unable to get role credentials for %s", arn)
 	}
 
 	log.Debugf("Retrieved role credentials from AWS SSO")

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,6 +1,7 @@
 # Frequently Asked Questions
 
  * [How do I delete all secrets from the macOS Keychain?](#how-do-i-delete-all-secrets-from-the-macos-keychain)
+ * [How good is the Windows support?](#how-good-is-the-windows-support)
  * [How does AWS SSO manage the $AWS\_DEFAULT\_REGION?](#how-does-aws-sso-manage-the-aws_default_region)
 
 ### How do I delete all secrets from the macOS keychain?
@@ -8,6 +9,26 @@
  1. Open `/Applications/Utilities/Keychain Access.app`
  2. Choose the `login` keychain
  3. Find the entry named `aws-sso-cli` and right click -> `Delete "aws-sso-cli"`
+
+### How good is the Windows support?
+
+In a word: alpha.
+
+Right now you are pretty much limited to using CommandPrompt (`cmd.exe`) instead
+of PowerShell or MINGW64/bash.  Not that you can't use PowerShell or bash, but
+there are a number of terminal related issues which cause `aws-sso` to behave
+incorrectly.  Would likely have to change how input processing other than for
+CLI arguments work for it to work with PowerShell or MINGW64/bash.
+
+[Tracking ticket](https://github.com/synfinatic/aws-sso-cli/issues/189)
+
+There is also the issue right now that the `eval` command does not work on Windows
+because it has no equivalant to the bash `eval` and there does not seem to be a
+reasonable way to generate and auto-execute batch files.  And of course, batch
+files must be written to disk and would contain the clear text secrets that
+`aws-sso` works very hard to never write to disk in clear text.
+
+[Tracking ticket](https://github.com/synfinatic/aws-sso-cli/issues/188)
 
 ### How does AWS SSO manage the $AWS\_DEFAULT\_REGION?
 
@@ -25,7 +46,7 @@ If the above are true, then AWS SSO will define both:
  * `$AWS_SSO_DEFAULT_REGION`
 
 to the default region as defined by `config.yaml`.  If the user changes
-roles and the two variables are set to the same region, then AWS SSO will 
+roles and the two variables are set to the same region, then AWS SSO will
 update the region.   If the user ever overrides the `$AWS_DEFAULT_REGION`
 value or deletes the `$AWS_SSO_DEFAULT_REGION` then AWS SSO will no longer
 manage the variable.

--- a/sso/cache.go
+++ b/sso/cache.go
@@ -486,6 +486,9 @@ func (r *Roles) GetRoleTags() *RoleTags {
 // Role returns the specified role as an AWSRoleFlat
 func (r *Roles) GetRole(accountId int64, roleName string) (*AWSRoleFlat, error) {
 	account := r.Accounts[accountId]
+	if account == nil {
+		return &AWSRoleFlat{}, fmt.Errorf("Invalid AWS AccountID: %d", accountId)
+	}
 	for thisRoleName, role := range account.Roles {
 		if thisRoleName == roleName {
 			flat := AWSRoleFlat{

--- a/storage/keyring.go
+++ b/storage/keyring.go
@@ -176,7 +176,7 @@ func (kr *KeyringStore) saveStorageData(s StorageData) error {
 	// Work around bogus errors wincred storage issue.  Sadly doesn't seem
 	// like we can tell if are using windcred, so just key off of the OS
 	// https://github.com/99designs/keyring/issues/99
-	if runtime.GOOS == "windows" && err.Error() == "The stub received bad data." {
+	if err != nil && runtime.GOOS == "windows" && err.Error() == "The stub received bad data." {
 		return nil
 	}
 	return err


### PR DESCRIPTION
- Can't use `eval` with Windows (#188)
- Default to `cmd.exe` for `exec` on Windows
- Detect invalid accountId with -A flag
- Improve docs for Windows in FAQ