### PR TITLE
fix role chaining session name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT_VERSION := 1.5.2
+PROJECT_VERSION := 1.6.0
 DOCKER_REPO     := synfinatic
 PROJECT_NAME    := aws-sso
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2,7 +2,8 @@
 
  * [How do I delete all secrets from the macOS Keychain?](#how-do-i-delete-all-secrets-from-the-macos-keychain)
  * [How good is the Windows support?](#how-good-is-the-windows-support)
- * [How does AWS SSO manage the $AWS\_DEFAULT\_REGION?](#how-does-aws-sso-manage-the-aws_default_region)
+ * [Does AWS SSO CLI support Role Chaining?](#does-aws-sso-cli-support-role-chaining)
+ * [How does AWS SSO CLI manage the $AWS\_DEFAULT\_REGION?](#how-does-aws-sso-cli-manage-the-aws_default_region)
 
 ### How do I delete all secrets from the macOS keychain?
 
@@ -30,7 +31,13 @@ files must be written to disk and would contain the clear text secrets that
 
 [Tracking ticket](https://github.com/synfinatic/aws-sso-cli/issues/188)
 
-### How does AWS SSO manage the $AWS\_DEFAULT\_REGION?
+### Does AWS SSO CLI support role chaining?
+
+Yes.  You can use `aws-sso` to assume roles in other AWS accounts or
+roles that are not managed via AWS SSO Permission Sets.  For more
+information on this, see the [Via](config.md#Via) configuration option.
+
+### How does AWS SSO CLI manage the $AWS\_DEFAULT\_REGION?
 
 AWS SSO will leave the `$AWS_DEFAULT_REGION` environment variable alone
 unless the following are all true:

--- a/docs/config.md
+++ b/docs/config.md
@@ -24,6 +24,7 @@ SSOConfig:
                         Tags:  # tags specific for this role (will override account level tags)
                             <Key1>: <Value1>
                             <Key2>: <Value2>
+                        Via: <Previous Role>  # optional, for role chaining
 
 # See description below for these options
 DefaultRegion: <AWS_DEFAULT_REGION>
@@ -61,20 +62,20 @@ the default unless overridden with `DefaultSSO`.
 
 The `SSOConfig` config block is required.
 
-## StartUrl
+### StartUrl
 
 Each AWS SSO instance has a unique start URL hosted by AWS for interacting with your
 SSO provider (Okta/OneLogin/etc).  Should be in the format of `https://xxxxxxx.awsapps.com/start`.
 
 The `StartUrl` is required.
 
-## SSORegion
+### SSORegion
 
 Each AWS SSO instance is configured in a specific AWS region which needs to be set here.
 
 The `SSORegion` is required.
 
-## DefaultRegion
+### DefaultRegion
 
 The `DefaultRegion` allows you to define a value for the `$AWS_DEFAULT_REGION` when switching to a role.
 Note that, aws-sso will NEVER change an existing `$AWS_DEFAULT_REGION` set by the user.
@@ -86,11 +87,43 @@ Note that, aws-sso will NEVER change an existing `$AWS_DEFAULT_REGION` set by th
  1. `SSOConfig -> <Name of AWS SSO>`
  1. Top level of the file
 
-## Accounts
+### Accounts
 
 The `Accounts` block is completely optional!  The only purpose of this block
 is to allow you to add additional tags (key/value pairs) to your accounts/roles
 to make them easier to select.
+
+#### Name
+
+Alternate name of the account.  Shown as `AccountName` for the list command.
+Not to be confused with the `AccountAlias` which is defined by the account owner
+in AWS.
+
+#### Tags
+
+List of key / value pairs, used by `aws-sso` in prompt mode.  Any tag placed at
+the account level will be applied to all roles in that account.
+
+#### Roles
+
+The `Roles` block is optional, except for roles you which to assume via role chaining.
+
+##### Tags
+
+List of key / value pairs, used by `aws-sso` in prompt mode.  Any tag placed at
+the role level will be applied to only that role.
+
+##### Via
+
+Impliments the concept of [role chaining](
+https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html).
+
+`Via` defines which role to assume before calling [sts:AssumeRole](
+https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) in order
+to switch to the specified role.  This allows you to define and assume roles in AWS
+accounts that are not included in your organization's AWS SSO scope or roles that
+were not defined via an [AWS SSO Permission Set](
+https://docs.aws.amazon.com/singlesignon/latest/userguide/permissionsetsconcept.html).
 
 ## Browser / UrlAction
 

--- a/sso/awssso.go
+++ b/sso/awssso.go
@@ -493,10 +493,13 @@ func (as *AWSSSO) GetRoleCredentials(accountId int64, role string) (storage.Role
 	}))
 	stsSession := sts.New(mySession)
 
+	previousAccount, _ := utils.AccountIdToString(creds.AccountId)
+	previousRole := fmt.Sprintf("%s@%s", creds.RoleName, previousAccount)
+
 	input := sts.AssumeRoleInput{
 		//		DurationSeconds: aws.Int64(900),
 		RoleArn:         aws.String(utils.MakeRoleARN(accountId, role)),
-		RoleSessionName: aws.String(fmt.Sprintf("Via_%s_%s", aId, role)),
+		RoleSessionName: aws.String(previousRole),
 	}
 	if configRole.ExternalId != "" {
 		// Optional vlaue: https://docs.aws.amazon.com/sdk-for-go/api/service/sts/#AssumeRoleInput


### PR DESCRIPTION
- Role Session Name for role chaining now provides the previous role
- Add docs for role chaining and Role config
- Bump version to v1.6.0
- Add entry to FAQ for role chaining

Fixes: #38