### PR TITLE
Via role option is now a tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### New Features
+ * The `Via` role option is now a searchable tag #199
+ * The `tags` command now returns the keys in sorted order
+
+### Bug Fixes
+ * Consistently pad AccountID with zeros whenever necessary
+
 ## [1.6.0] - 2021-12-24
 
 ### Breaking Changes
@@ -13,7 +20,7 @@
  * Add support for role chaining using `Via` tag #38
  * Cache file is now versioned for better compatibility across versions of `aws-sso` #195
 
-### Bugs Fixes 
+### Bug Fixes 
  * Incorrect `--level` value now correctly tells user the correct name of the flag
  * `exec` command now uses `cmd.exe` when no command is specified
 

--- a/cmd/exec_cmd.go
+++ b/cmd/exec_cmd.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
-	"strconv"
 	"strings"
 	"text/template"
 
@@ -124,7 +123,8 @@ func firstItem(items []string) string {
 }
 
 func accountIdToStr(id int64) string {
-	return strconv.FormatInt(id, 10)
+	i, _ := utils.AccountIdToString(id)
+	return i
 }
 
 // Executes Cmd+Args in the context of the AWS Role creds

--- a/cmd/tags_cmd.go
+++ b/cmd/tags_cmd.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"fmt"
+	"sort"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/synfinatic/aws-sso-cli/sso"
@@ -57,6 +58,10 @@ func (cc *TagsCmd) Run(ctx *RunContext) error {
 
 		if err := set.Cache.Expired(s); err != nil {
 			log.Warn(err.Error())
+			c := &CacheCmd{}
+			if err = c.Run(ctx); err != nil {
+				return err
+			}
 		}
 	}
 	roles := []*sso.AWSRoleFlat{}
@@ -84,8 +89,13 @@ func (cc *TagsCmd) Run(ctx *RunContext) error {
 
 	for _, fRole := range roles {
 		fmt.Printf("%s\n", fRole.Arn)
-		for k, v := range fRole.Tags {
-			fmt.Printf("  %s: %s\n", k, v)
+		keys := make([]string, 0, len(fRole.Tags))
+		for k := range fRole.Tags {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Printf("  %s: %s\n", k, fRole.Tags[k])
 		}
 		fmt.Printf("\n")
 	}

--- a/sso/settings.go
+++ b/sso/settings.go
@@ -24,7 +24,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	// "github.com/davecgh/go-spew/spew"
@@ -403,7 +402,7 @@ func (a *SSOAccount) GetAllTags(id int64) map[string]string {
 		"AccountName": accountName,
 	}
 	if id > 0 {
-		accountId := strconv.FormatInt(id, 10)
+		accountId, _ := utils.AccountIdToString(id)
 		tags["AccountId"] = accountId
 	}
 	if a.DefaultRegion != "" {


### PR DESCRIPTION
 * Via role option is now a searchable tag
 * Consistently always zero pad AccountIDs
 * Tags are now returned in sorted order via the `tags` command

Fixes: #199