### PR TITLE
Honor `DefaultSSO` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
  * Consistently pad AccountID with zeros whenever necessary
  * Detect role chain loops using `Via` #194
  * AccountAlias/AccountName tags are inconsistenly applied/missing #201
+ * Honor config.yaml `DefaultSSO` #209
 
 ## [1.6.0] - 2021-12-24
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -80,6 +80,7 @@ var DEFAULT_CONFIG map[string]interface{} = map[string]interface{}{
 	"ConsoleDuration":                           60,
 	"UrlAction":                                 "open",
 	"LogLevel":                                  "info",
+	"DefaultSSO":                                "Default",
 }
 
 type CLI struct {
@@ -89,7 +90,7 @@ type CLI struct {
 	Lines      bool   `kong:"help='Print line number in logs'"`
 	LogLevel   string `kong:"short='L',name='level',help='Logging level [error|warn|info|debug|trace] (default: info)'"`
 	UrlAction  string `kong:"short='u',help='How to handle URLs [open|print|clip] (default: open)'"`
-	SSO        string `kong:"short='S',help='AWS SSO Instance',default='Default',env='AWS_SSO',predictor='sso'"`
+	SSO        string `kong:"short='S',help='AWS SSO Instance',env='AWS_SSO',predictor='sso'"`
 	STSRefresh bool   `kong:"help='Force refresh of STS Token Credentials'"`
 
 	// Commands


### PR DESCRIPTION
We were not honoring the `DefaultSSO` value in the
config file and were always falling back to `Default`

Fixes: #209