### PR TITLE
`console` command now honors non-Default AWS SSO instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
  * AccountAlias/AccountName tags are inconsistenly applied/missing #201
  * Honor config.yaml `DefaultSSO` #209
  * Setup now defaults to `warn` log level instead of `info` #214
+ * `console` command did not know when you are using a non-Default SSO instance #208
 
 ## [1.6.0] - 2021-12-24
 

--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ The following environment variables are specific to `aws-sso`:
  * `AWS_SSO_SESSION_EXPIRATION`  -- The date and time when the IAM role credentials will expire
  * `AWS_SSO_DEFAULT_REGION` -- Tracking variable for `AWS_DEFAULT_REGION`
  * `AWS_SSO_PROFILE` -- User customizable varible using the [ProfileFormat](#profileformat) template
+ * `AWS_SSO` -- AWS SSO instance name
 
 ## Release History
 

--- a/cmd/eval_cmd.go
+++ b/cmd/eval_cmd.go
@@ -103,6 +103,7 @@ func unsetEnvVars(ctx *RunContext) error {
 		"AWS_SSO_ROLE_ARN",
 		"AWS_SSO_SESSION_EXPIRATION",
 		"AWS_SSO_PROFILE",
+		"AWS_SSO",
 	}
 
 	// clear the region if

--- a/cmd/exec_cmd.go
+++ b/cmd/exec_cmd.go
@@ -82,7 +82,7 @@ func (cc *ExecCmd) Run(ctx *RunContext) error {
 		return err
 	}
 	if err = ctx.Settings.Cache.Expired(sso); err != nil {
-		log.Warnf(err.Error())
+		log.Infof(err.Error())
 		c := &CacheCmd{}
 		if err = c.Run(ctx); err != nil {
 			return err
@@ -165,6 +165,7 @@ func execShellEnvs(ctx *RunContext, awssso *sso.AWSSSO, accountid int64, role, r
 		"AWS_SSO_ROLE_NAME":          creds.RoleName,
 		"AWS_SSO_SESSION_EXPIRATION": creds.ExpireString(),
 		"AWS_SSO_ROLE_ARN":           utils.MakeRoleARN(creds.AccountId, creds.RoleName),
+		"AWS_SSO":                    ctx.Cli.SSO,
 	}
 
 	if len(region) > 0 {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -90,7 +90,7 @@ type CLI struct {
 	Lines      bool   `kong:"help='Print line number in logs'"`
 	LogLevel   string `kong:"short='L',name='level',help='Logging level [error|warn|info|debug|trace] (default: info)'"`
 	UrlAction  string `kong:"short='u',help='How to handle URLs [open|print|clip] (default: open)'"`
-	SSO        string `kong:"short='S',help='AWS SSO Instance',env='AWS_SSO',predictor='sso'"`
+	SSO        string `kong:"short='S',help='Override default AWS SSO Instance',env='AWS_SSO',predictor='sso'"`
 	STSRefresh bool   `kong:"help='Force refresh of STS Token Credentials'"`
 
 	// Commands

--- a/sso/settings.go
+++ b/sso/settings.go
@@ -197,7 +197,7 @@ func LoadSettings(configFile, cacheFile string, defaults map[string]interface{},
 	// load the cache
 	var err error
 	if s.Cache, err = OpenCache(s.cacheFile, s); err != nil {
-		log.Warnf("%s", err.Error())
+		log.Infof("%s", err.Error())
 	}
 
 	return s, nil


### PR DESCRIPTION
Users using `--sso` with `eval` or `exec` and then running
`console` would find the latter command would fail because
it did not know which AWS SSO instance was used with the
previous command.

We now set AWS_SSO environment variable so this value is
automatically tracked with `console`, `list`, etc.

Fixes: #208