### PR TITLE
cache multiple SSO Instances correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
  * Honor config.yaml `DefaultSSO` #209
  * Setup now defaults to `warn` log level instead of `info` #214
  * `console` command did not know when you are using a non-Default SSO instance #208
+ * cache now handles multiple AWS SSO Instances correctly which fixes numerous issues #219
 
 ### Changes
  * Reduce number of warnings #205

--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -76,7 +76,8 @@ func NewPredictor(cacheFile, configFile string) *Predictor {
 
 	uniqueRoles := map[string]bool{}
 
-	for i, a := range c.Roles.Accounts {
+	cache := c.GetSSO()
+	for i, a := range cache.Roles.Accounts {
 		id, _ := utils.AccountIdToString(i)
 		p.accountids = append(p.accountids, id)
 		for role, r := range a.Roles {

--- a/cmd/exec_cmd.go
+++ b/cmd/exec_cmd.go
@@ -191,7 +191,8 @@ func execShellEnvs(ctx *RunContext, awssso *sso.AWSSSO, accountid int64, role, r
 
 	// Set the AWS_SSO_PROFILE env var using our template
 	var templ *template.Template
-	if roleInfo, err := ctx.Settings.Cache.Roles.GetRole(accountid, role); err != nil {
+	cache := ctx.Settings.Cache.GetSSO()
+	if roleInfo, err := cache.Roles.GetRole(accountid, role); err != nil {
 		// this error should never happen
 		log.Errorf("Unable to find role in cache.  Unable to set AWS_SSO_PROFILE")
 	} else {

--- a/cmd/flush_cmd.go
+++ b/cmd/flush_cmd.go
@@ -46,7 +46,8 @@ func (cc *FlushCmd) Run(ctx *RunContext) error {
 	}
 
 	if ctx.Cli.Flush.All {
-		for _, role := range ctx.Settings.Cache.Roles.GetAllRoles() {
+		cache := ctx.Settings.Cache.GetSSO()
+		for _, role := range cache.Roles.GetAllRoles() {
 			if !role.IsExpired() {
 				if err = ctx.Store.DeleteRoleCredentials(role.Arn); err != nil {
 					log.WithError(err).Errorf("Unable to delete STS token for %s", role.Arn)

--- a/cmd/list_cmd.go
+++ b/cmd/list_cmd.go
@@ -91,7 +91,7 @@ func (cc *DefaultCmd) Run(ctx *RunContext) error {
 
 // Print all our roles
 func printRoles(ctx *RunContext, fields []string) {
-	roles := ctx.Settings.Cache.Roles
+	roles := ctx.Settings.Cache.GetSSO().Roles
 	tr := []gotable.TableStruct{}
 	idx := 0
 
@@ -123,6 +123,7 @@ func printRoles(ctx *RunContext, fields []string) {
 		}
 	}
 
+	fmt.Printf("List of AWS roles for SSO Instance: %s\n", ctx.Settings.DefaultSSO)
 	if err := gotable.GenerateTable(tr, fields); err != nil {
 		log.WithError(err).Fatalf("Unable to generate report")
 	}

--- a/cmd/tags_cmd.go
+++ b/cmd/tags_cmd.go
@@ -34,6 +34,7 @@ type TagsCmd struct {
 
 func (cc *TagsCmd) Run(ctx *RunContext) error {
 	set := ctx.Settings
+	cache := ctx.Settings.Cache.GetSSO()
 	if ctx.Cli.Tags.ForceUpdate {
 		s := set.SSO[ctx.Cli.SSO]
 		awssso := sso.NewAWSSSO(s, &ctx.Store)
@@ -68,7 +69,7 @@ func (cc *TagsCmd) Run(ctx *RunContext) error {
 
 	// If user has specified an account (or account + role) then limit
 	if ctx.Cli.Tags.AccountId != 0 {
-		for _, fRole := range set.Cache.Roles.GetAccountRoles(ctx.Cli.Tags.AccountId) {
+		for _, fRole := range cache.Roles.GetAccountRoles(ctx.Cli.Tags.AccountId) {
 			if ctx.Cli.Tags.Role == "" {
 				roles = append(roles, fRole)
 			} else {
@@ -78,13 +79,13 @@ func (cc *TagsCmd) Run(ctx *RunContext) error {
 			}
 		}
 	} else if ctx.Cli.Tags.Role != "" {
-		for _, v := range set.Cache.Roles.GetAllRoles() {
+		for _, v := range cache.Roles.GetAllRoles() {
 			if v.RoleName == ctx.Cli.Tags.Role {
 				roles = append(roles, v)
 			}
 		}
 	} else {
-		roles = set.Cache.Roles.GetAllRoles()
+		roles = cache.Roles.GetAllRoles()
 	}
 
 	for _, fRole := range roles {

--- a/sso/testdata/cache.json
+++ b/sso/testdata/cache.json
@@ -1,245 +1,250 @@
 {
-  "CreatedAt": 1635913188,
   "ConfigCreatedAt": 1635710861,
-  "Roles": {
-    "Accounts": {
-      "258234615182": {
-        "Alias": "OurCompany Control Tower Playground",
-        "Name": "OurCompany Control Tower Playground",
-        "EmailAddress": "control-tower-dev-aws@ourcompany.com",
-        "Tags": {
-          "Type": "Main Account"
-        },
-        "Roles": {
-          "AWSAdministratorAccess": {
-            "Arn": "arn:aws:iam::258234615182:role/AWSAdministratorAccess",
+  "Version": 3,
+  "SSO": {
+    "Default": {
+      "LastUpdate": 1635913188,
+      "Roles": {
+        "Accounts": {
+          "258234615182": {
+            "Alias": "OurCompany Control Tower Playground",
+            "Name": "OurCompany Control Tower Playground",
+            "EmailAddress": "control-tower-dev-aws@ourcompany.com",
             "Tags": {
-              "AccountAlias": "OurCompany Control Tower Playground",
-              "AccountID": "258234615182",
-              "AccountName": "OurCompany Control Tower Playground",
-              "Email": "control-tower-dev-aws@ourcompany.com",
-              "Foo": "Bar",
-              "Role": "AWSAdministratorAccess",
-              "Test": "value",
               "Type": "Main Account"
+            },
+            "Roles": {
+              "AWSAdministratorAccess": {
+                "Arn": "arn:aws:iam::258234615182:role/AWSAdministratorAccess",
+                "Tags": {
+                  "AccountAlias": "OurCompany Control Tower Playground",
+                  "AccountID": "258234615182",
+                  "AccountName": "OurCompany Control Tower Playground",
+                  "Email": "control-tower-dev-aws@ourcompany.com",
+                  "Foo": "Bar",
+                  "Role": "AWSAdministratorAccess",
+                  "Test": "value",
+                  "Type": "Main Account"
+                }
+              },
+              "AWSOrganizationsFullAccess": {
+                "Arn": "arn:aws:iam::258234615182:role/AWSOrganizationsFullAccess",
+                "Tags": {
+                  "AccountAlias": "OurCompany Control Tower Playground",
+                  "AccountID": "258234615182",
+                  "AccountName": "OurCompany Control Tower Playground",
+                  "Email": "control-tower-dev-aws@ourcompany.com",
+                  "Role": "AWSOrganizationsFullAccess"
+                }
+              },
+              "AWSPowerUserAccess": {
+                "Arn": "arn:aws:iam::258234615182:role/AWSPowerUserAccess",
+                "Tags": {
+                  "AccountAlias": "OurCompany Control Tower Playground",
+                  "AccountID": "258234615182",
+                  "AccountName": "OurCompany Control Tower Playground",
+                  "Email": "control-tower-dev-aws@ourcompany.com",
+                  "Role": "AWSPowerUserAccess"
+                }
+              },
+              "AWSReadOnlyAccess": {
+                "Arn": "arn:aws:iam::258234615182:role/AWSReadOnlyAccess",
+                "Tags": {
+                  "AccountAlias": "OurCompany Control Tower Playground",
+                  "AccountID": "258234615182",
+                  "AccountName": "OurCompany Control Tower Playground",
+                  "Email": "control-tower-dev-aws@ourcompany.com",
+                  "Role": "AWSReadOnlyAccess"
+                }
+              },
+              "AWSServiceCatalogEndUserAccess": {
+                "Arn": "arn:aws:iam::258234615182:role/AWSServiceCatalogEndUserAccess",
+                "Tags": {
+                  "AccountAlias": "OurCompany Control Tower Playground",
+                  "AccountID": "258234615182",
+                  "AccountName": "OurCompany Control Tower Playground",
+                  "Email": "control-tower-dev-aws@ourcompany.com",
+                  "Role": "AWSServiceCatalogEndUserAccess"
+                }
+              },
+              "DoNothingRole": {
+                "Arn": "arn:aws:iam::258234615182:role/DoNothingRole",
+                "Tags": {
+                  "AccountAlias": "OurCompany Control Tower Playground",
+                  "AccountID": "258234615182",
+                  "AccountName": "OurCompany Control Tower Playground",
+                  "Email": "control-tower-dev-aws@ourcompany.com",
+                  "Role": "DoNothingRole"
+                }
+              },
+              "SSO-ProductionDevelopersRO": {
+                "Arn": "arn:aws:iam::258234615182:role/SSO-ProductionDevelopersRO",
+                "Tags": {
+                  "AccountAlias": "OurCompany Control Tower Playground",
+                  "AccountID": "258234615182",
+                  "AccountName": "OurCompany Control Tower Playground",
+                  "Email": "control-tower-dev-aws@ourcompany.com",
+                  "Role": "SSO-ProductionDevelopersRO"
+                }
+              }
             }
           },
-          "AWSOrganizationsFullAccess": {
-            "Arn": "arn:aws:iam::258234615182:role/AWSOrganizationsFullAccess",
+          "833365043586": {
+            "Alias": "Log archive",
+            "Name": "Log archive",
+            "EmailAddress": "control-tower-dev-aws+log@ourcompany.com",
             "Tags": {
-              "AccountAlias": "OurCompany Control Tower Playground",
-              "AccountID": "258234615182",
-              "AccountName": "OurCompany Control Tower Playground",
-              "Email": "control-tower-dev-aws@ourcompany.com",
-              "Role": "AWSOrganizationsFullAccess"
+              "Type": "Sub Account"
+            },
+            "Roles": {
+              "AWSAdministratorAccess": {
+                "Arn": "arn:aws:iam::833365043586:role/AWSAdministratorAccess",
+                "Tags": {
+                  "AccountAlias": "Log archive",
+                  "AccountID": "833365043586",
+                  "AccountName": "Log archive",
+                  "Email": "control-tower-dev-aws+log@ourcompany.com",
+                  "Role": "AWSAdministratorAccess"
+                }
+              },
+              "AWSPowerUserAccess": {
+                "Arn": "arn:aws:iam::833365043586:role/AWSPowerUserAccess",
+                "Tags": {
+                  "AccountAlias": "Log archive",
+                  "AccountID": "833365043586",
+                  "AccountName": "Log archive",
+                  "Email": "control-tower-dev-aws+log@ourcompany.com",
+                  "Role": "AWSPowerUserAccess"
+                }
+              },
+              "AWSReadOnlyAccess": {
+                "Arn": "arn:aws:iam::833365043586:role/AWSReadOnlyAccess",
+                "Tags": {
+                  "AccountAlias": "Log archive",
+                  "AccountID": "833365043586",
+                  "AccountName": "Log archive",
+                  "Email": "control-tower-dev-aws+log@ourcompany.com",
+                  "Role": "AWSReadOnlyAccess"
+                }
+              },
+              "SSO-ProductionDevelopersRO": {
+                "Arn": "arn:aws:iam::833365043586:role/SSO-ProductionDevelopersRO",
+                "Tags": {
+                  "AccountAlias": "Log archive",
+                  "AccountID": "833365043586",
+                  "AccountName": "Log archive",
+                  "Email": "control-tower-dev-aws+log@ourcompany.com",
+                  "Role": "SSO-ProductionDevelopersRO"
+                }
+              }
+            },
+            "DefaultRegion": "eu-north-1"
+          },
+          "502470824893": {
+            "Alias": "Audit",
+            "Name": "Audit",
+            "EmailAddress": "control-tower-dev-aws+audit@ourcompany.com",
+            "Tags": {
+              "Type": "Sub Account"
+            },
+            "Roles": {
+              "AWSAdministratorAccess": {
+                "Arn": "arn:aws:iam::502470824893:role/AWSAdministratorAccess",
+                "Tags": {
+                  "AccountAlias": "Audit",
+                  "AccountID": "502470824893",
+                  "AccountName": "Audit",
+                  "Email": "control-tower-dev-aws+audit@ourcompany.com",
+                  "Role": "AWSAdministratorAccess"
+                }
+              },
+              "AWSPowerUserAccess": {
+                "Arn": "arn:aws:iam::502470824893:role/AWSPowerUserAccess",
+                "Tags": {
+                  "AccountAlias": "Audit",
+                  "AccountID": "502470824893",
+                  "AccountName": "Audit",
+                  "Email": "control-tower-dev-aws+audit@ourcompany.com",
+                  "Role": "AWSPowerUserAccess"
+                }
+              },
+              "AWSReadOnlyAccess": {
+                "Arn": "arn:aws:iam::502470824893:role/AWSReadOnlyAccess",
+                "Tags": {
+                  "AccountAlias": "Audit",
+                  "AccountID": "502470824893",
+                  "AccountName": "Audit",
+                  "Email": "control-tower-dev-aws+audit@ourcompany.com",
+                  "Role": "AWSReadOnlyAccess"
+                }
+              },
+              "SSO-ProductionDevelopersRO": {
+                "Arn": "arn:aws:iam::502470824893:role/SSO-ProductionDevelopersRO",
+                "Tags": {
+                  "AccountAlias": "Audit",
+                  "AccountID": "502470824893",
+                  "AccountName": "Audit",
+                  "Email": "control-tower-dev-aws+audit@ourcompany.com",
+                  "Role": "SSO-ProductionDevelopersRO"
+                }
+              }
             }
           },
-          "AWSPowerUserAccess": {
-            "Arn": "arn:aws:iam::258234615182:role/AWSPowerUserAccess",
+          "707513610766": {
+            "Alias": "control-tower-dev-sub1-aws",
+            "Name": "Dev Account",
+            "EmailAddress": "test+control-tower-sub1@ourcompany.com",
             "Tags": {
-              "AccountAlias": "OurCompany Control Tower Playground",
-              "AccountID": "258234615182",
-              "AccountName": "OurCompany Control Tower Playground",
-              "Email": "control-tower-dev-aws@ourcompany.com",
-              "Role": "AWSPowerUserAccess"
-            }
-          },
-          "AWSReadOnlyAccess": {
-            "Arn": "arn:aws:iam::258234615182:role/AWSReadOnlyAccess",
-            "Tags": {
-              "AccountAlias": "OurCompany Control Tower Playground",
-              "AccountID": "258234615182",
-              "AccountName": "OurCompany Control Tower Playground",
-              "Email": "control-tower-dev-aws@ourcompany.com",
-              "Role": "AWSReadOnlyAccess"
-            }
-          },
-          "AWSServiceCatalogEndUserAccess": {
-            "Arn": "arn:aws:iam::258234615182:role/AWSServiceCatalogEndUserAccess",
-            "Tags": {
-              "AccountAlias": "OurCompany Control Tower Playground",
-              "AccountID": "258234615182",
-              "AccountName": "OurCompany Control Tower Playground",
-              "Email": "control-tower-dev-aws@ourcompany.com",
-              "Role": "AWSServiceCatalogEndUserAccess"
-            }
-          },
-          "DoNothingRole": {
-            "Arn": "arn:aws:iam::258234615182:role/DoNothingRole",
-            "Tags": {
-              "AccountAlias": "OurCompany Control Tower Playground",
-              "AccountID": "258234615182",
-              "AccountName": "OurCompany Control Tower Playground",
-              "Email": "control-tower-dev-aws@ourcompany.com",
-              "Role": "DoNothingRole"
-            }
-          },
-          "SSO-ProductionDevelopersRO": {
-            "Arn": "arn:aws:iam::258234615182:role/SSO-ProductionDevelopersRO",
-            "Tags": {
-              "AccountAlias": "OurCompany Control Tower Playground",
-              "AccountID": "258234615182",
-              "AccountName": "OurCompany Control Tower Playground",
-              "Email": "control-tower-dev-aws@ourcompany.com",
-              "Role": "SSO-ProductionDevelopersRO"
+              "Type": "Sub Account"
+            },
+            "Roles": {
+              "AWSAdministratorAccess": {
+                "Arn": "arn:aws:iam::707513610766:role/AWSAdministratorAccess",
+                "Tags": {
+                  "AccountAlias": "control-tower-dev-sub1-aws",
+                  "AccountID": "707513610766",
+                  "AccountName": "Dev Account",
+                  "Email": "test+control-tower-sub1@ourcompany.com",
+                  "Role": "AWSAdministratorAccess"
+                }
+              },
+              "AWSPowerUserAccess": {
+                "Arn": "arn:aws:iam::707513610766:role/AWSPowerUserAccess",
+                "Tags": {
+                  "AccountAlias": "control-tower-dev-sub1-aws",
+                  "AccountID": "707513610766",
+                  "AccountName": "Dev Account",
+                  "Email": "test+control-tower-sub1@ourcompany.com",
+                  "Role": "AWSPowerUserAccess"
+                }
+              },
+              "AWSReadOnlyAccess": {
+                "Arn": "arn:aws:iam::707513610766:role/AWSReadOnlyAccess",
+                "Tags": {
+                  "AccountAlias": "control-tower-dev-sub1-aws",
+                  "AccountID": "707513610766",
+                  "AccountName": "Dev Account",
+                  "Email": "test+control-tower-sub1@ourcompany.com",
+                  "Role": "AWSReadOnlyAccess"
+                }
+              },
+              "SSO-ProductionDevelopersRO": {
+                "Arn": "arn:aws:iam::707513610766:role/SSO-ProductionDevelopersRO",
+                "Tags": {
+                  "AccountAlias": "control-tower-dev-sub1-aws",
+                  "AccountID": "707513610766",
+                  "AccountName": "Dev Account",
+                  "Email": "test+control-tower-sub1@ourcompany.com",
+                  "Role": "SSO-ProductionDevelopersRO"
+                }
+              }
             }
           }
-        }
-      },
-      "833365043586": {
-        "Alias": "Log archive",
-        "Name": "Log archive",
-        "EmailAddress": "control-tower-dev-aws+log@ourcompany.com",
-        "Tags": {
-          "Type": "Sub Account"
         },
-        "Roles": {
-          "AWSAdministratorAccess": {
-            "Arn": "arn:aws:iam::833365043586:role/AWSAdministratorAccess",
-            "Tags": {
-              "AccountAlias": "Log archive",
-              "AccountID": "833365043586",
-              "AccountName": "Log archive",
-              "Email": "control-tower-dev-aws+log@ourcompany.com",
-              "Role": "AWSAdministratorAccess"
-            }
-          },
-          "AWSPowerUserAccess": {
-            "Arn": "arn:aws:iam::833365043586:role/AWSPowerUserAccess",
-            "Tags": {
-              "AccountAlias": "Log archive",
-              "AccountID": "833365043586",
-              "AccountName": "Log archive",
-              "Email": "control-tower-dev-aws+log@ourcompany.com",
-              "Role": "AWSPowerUserAccess"
-            }
-          },
-          "AWSReadOnlyAccess": {
-            "Arn": "arn:aws:iam::833365043586:role/AWSReadOnlyAccess",
-            "Tags": {
-              "AccountAlias": "Log archive",
-              "AccountID": "833365043586",
-              "AccountName": "Log archive",
-              "Email": "control-tower-dev-aws+log@ourcompany.com",
-              "Role": "AWSReadOnlyAccess"
-            }
-          },
-          "SSO-ProductionDevelopersRO": {
-            "Arn": "arn:aws:iam::833365043586:role/SSO-ProductionDevelopersRO",
-            "Tags": {
-              "AccountAlias": "Log archive",
-              "AccountID": "833365043586",
-              "AccountName": "Log archive",
-              "Email": "control-tower-dev-aws+log@ourcompany.com",
-              "Role": "SSO-ProductionDevelopersRO"
-            }
-          }
-        },
-        "DefaultRegion": "eu-north-1"
-      },
-      "502470824893": {
-        "Alias": "Audit",
-        "Name": "Audit",
-        "EmailAddress": "control-tower-dev-aws+audit@ourcompany.com",
-        "Tags": {
-          "Type": "Sub Account"
-        },
-        "Roles": {
-          "AWSAdministratorAccess": {
-            "Arn": "arn:aws:iam::502470824893:role/AWSAdministratorAccess",
-            "Tags": {
-              "AccountAlias": "Audit",
-              "AccountID": "502470824893",
-              "AccountName": "Audit",
-              "Email": "control-tower-dev-aws+audit@ourcompany.com",
-              "Role": "AWSAdministratorAccess"
-            }
-          },
-          "AWSPowerUserAccess": {
-            "Arn": "arn:aws:iam::502470824893:role/AWSPowerUserAccess",
-            "Tags": {
-              "AccountAlias": "Audit",
-              "AccountID": "502470824893",
-              "AccountName": "Audit",
-              "Email": "control-tower-dev-aws+audit@ourcompany.com",
-              "Role": "AWSPowerUserAccess"
-            }
-          },
-          "AWSReadOnlyAccess": {
-            "Arn": "arn:aws:iam::502470824893:role/AWSReadOnlyAccess",
-            "Tags": {
-              "AccountAlias": "Audit",
-              "AccountID": "502470824893",
-              "AccountName": "Audit",
-              "Email": "control-tower-dev-aws+audit@ourcompany.com",
-              "Role": "AWSReadOnlyAccess"
-            }
-          },
-          "SSO-ProductionDevelopersRO": {
-            "Arn": "arn:aws:iam::502470824893:role/SSO-ProductionDevelopersRO",
-            "Tags": {
-              "AccountAlias": "Audit",
-              "AccountID": "502470824893",
-              "AccountName": "Audit",
-              "Email": "control-tower-dev-aws+audit@ourcompany.com",
-              "Role": "SSO-ProductionDevelopersRO"
-            }
-          }
-        }
-      },
-      "707513610766": {
-        "Alias": "control-tower-dev-sub1-aws",
-        "Name": "Dev Account",
-        "EmailAddress": "test+control-tower-sub1@ourcompany.com",
-        "Tags": {
-          "Type": "Sub Account"
-        },
-        "Roles": {
-          "AWSAdministratorAccess": {
-            "Arn": "arn:aws:iam::707513610766:role/AWSAdministratorAccess",
-            "Tags": {
-              "AccountAlias": "control-tower-dev-sub1-aws",
-              "AccountID": "707513610766",
-              "AccountName": "Dev Account",
-              "Email": "test+control-tower-sub1@ourcompany.com",
-              "Role": "AWSAdministratorAccess"
-            }
-          },
-          "AWSPowerUserAccess": {
-            "Arn": "arn:aws:iam::707513610766:role/AWSPowerUserAccess",
-            "Tags": {
-              "AccountAlias": "control-tower-dev-sub1-aws",
-              "AccountID": "707513610766",
-              "AccountName": "Dev Account",
-              "Email": "test+control-tower-sub1@ourcompany.com",
-              "Role": "AWSPowerUserAccess"
-            }
-          },
-          "AWSReadOnlyAccess": {
-            "Arn": "arn:aws:iam::707513610766:role/AWSReadOnlyAccess",
-            "Tags": {
-              "AccountAlias": "control-tower-dev-sub1-aws",
-              "AccountID": "707513610766",
-              "AccountName": "Dev Account",
-              "Email": "test+control-tower-sub1@ourcompany.com",
-              "Role": "AWSReadOnlyAccess"
-            }
-          },
-          "SSO-ProductionDevelopersRO": {
-            "Arn": "arn:aws:iam::707513610766:role/SSO-ProductionDevelopersRO",
-            "Tags": {
-              "AccountAlias": "control-tower-dev-sub1-aws",
-              "AccountID": "707513610766",
-              "AccountName": "Dev Account",
-              "Email": "test+control-tower-sub1@ourcompany.com",
-              "Role": "SSO-ProductionDevelopersRO"
-            }
-          }
-        }
+        "SSORegion": "us-east-1",
+        "StartUrl": "https://d-754545454.awsapps.com/start",
+        "DefaultRegion": ""
       }
-    },
-    "SSORegion": "us-east-1",
-    "StartUrl": "https://d-754545454.awsapps.com/start",
-    "DefaultRegion": ""
+    }
   }
 }


### PR DESCRIPTION
The cache was only tracking a single SSO instance worth of roles which
caused numerous issues with the `exec` and `list` commands (and really
any time the user didn't specify the accountid/rolename on the CLI)
where it would use the last cached SSO instance list of roles rather
than the selected SSO instance (`--sso`).

Fixes: #219