### PR TITLE
add ConfigVariables option

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,6 @@ via AWS SSO CLI.
 Flags:
 
  * `--diff` -- Print a diff of changes to the config file instead of modifying it
- * `--output` -- Set the default output format.
-	Must be one of `json`, `yaml`, `yaml-stream`, `text`, `table`.  Default is `json`.
  * `--print` -- Print profile entries instead of modifying config file
 
 This generates a series of [named profile entries](
@@ -209,6 +207,10 @@ https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html) in
 the `$AWS_PROFILE` environment variable.  By default, each profile is named according
 to the [ProfileFormat](docs/config.md#profileformat) config option or overridden by
 the user defined [Profile](docs/config.md#profile) option on a role by role basis.
+
+For each profile generated, it will specify a [list of settings](
+https://docs.aws.amazon.com/sdkref/latest/guide/settings-global.html) as defined by
+the [ConfigVariables](docs/config.md#configvariables) setting in the `~/.aws-sso/config.yaml`.
 
 **Note:** You should run this command any time your list of AWS roles changes.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -29,15 +29,26 @@ SSOConfig:
 
 # See description below for these options
 DefaultRegion: <AWS_DEFAULT_REGION>
-Browser: <path to web browser>
 DefaultSSO: <name of AWS SSO>
-LogLevel: [error|warn|info|debug|trace]
-LogLines: [true|false]
+
+Browser: <path to web browser>
 UrlAction: [print|open|clip]
 ConsoleDuration: <minutes>
+
+LogLevel: [error|warn|info|debug|trace]
+LogLines: [true|false]
+HistoryLimit: <integer>
+HistoryMinutes: <integer>
+
 SecureStore: [file|keychain|kwallet|pass|secret-service|wincred|json]
 JsonStore: <path to json file>
+
 ProfileFormat: "<template>"
+ConfigVariables:
+	<Var1>: <Value1>
+	<Var2>: <Value2>
+	<VarN>: <ValueN>
+
 AccountPrimaryTag:
     - <tag 1>
     - <tag 2>
@@ -46,8 +57,6 @@ PromptColors:
     <Option 1>: <Color>
     <Option 2>: <Color>
     <Option N>: <Color>
-HistoryLimit: <integer>
-HistoryMinutes: <integer>
 ListFields:
     - <field 1>
     - <field 2>
@@ -131,6 +140,12 @@ accounts that are not included in your organization's AWS SSO scope or roles tha
 were not defined via an [AWS SSO Permission Set](
 https://docs.aws.amazon.com/singlesignon/latest/userguide/permissionsetsconcept.html).
 
+## DefaultSSO
+
+If you only have a single AWS SSO instance, then it doesn't really matter what you call it,
+but if you have two or more, than `Default` is automatically selected unless you manually
+specify it here, on the CLI (`--sso`), or via the `AWS_SSO` environment variable.
+
 ## Browser / UrlAction
 
 `UrlAction` gives you control over how AWS SSO and AWS Console URLs are opened in a browser:
@@ -141,12 +156,6 @@ https://docs.aws.amazon.com/singlesignon/latest/userguide/permissionsetsconcept.
 
 If `Browser` is not set, then your default browser will be used.  Note that
 your browser needs to support Javascript for the AWS SSO user interface.
-
-## DefaultSSO
-
-If you only have a single AWS SSO instance, then it doesn't really matter what you call it,
-but if you have two or more, than `Default` is automatically selected unless you manually
-specify it here, on the CLI (`--sso`), or via the `AWS_SSO` environment variable.
 
 ## LogLevel / LogLines
 
@@ -216,6 +225,16 @@ The following functions are available in your template:
 (`'`) the value because because `ProfileFormat` values often start with a `{`.
 
 For more information, [see the FAQ](FAQ.md#how-to-configure-profileformat).
+
+## ConfigVariables
+
+Define a set of [config settings](https://docs.aws.amazon.com/sdkref/latest/guide/settings-global.html)
+for each profile in your `~/.aws/config` file generated via the [config](../README.md#config) command.
+
+Some examples to consider:
+
+ * `sts_regional_endpoints: regional`
+ * `output: json`
 
 ## AccountPrimaryTag
 

--- a/sso/settings.go
+++ b/sso/settings.go
@@ -42,25 +42,26 @@ const (
 )
 
 type Settings struct {
-	configFile        string                // name of this file
-	cacheFile         string                // name of cache file; always passed in via CLI args
-	Cache             *Cache                `yaml:"-"` // our cache data
-	SSO               map[string]*SSOConfig `koanf:"SSOConfig" yaml:"SSOConfig,omitempty"`
-	DefaultSSO        string                `koanf:"DefaultSSO" yaml:"DefaultSSO,omitempty"`   // specify default SSO by key
-	SecureStore       string                `koanf:"SecureStore" yaml:"SecureStore,omitempty"` // json or keyring
-	DefaultRegion     string                `koanf:"DefaultRegion" yaml:"DefaultRegion,omitempty"`
-	ConsoleDuration   int64                 `koanf:"ConsoleDuration" yaml:"ConsoleDuration,omitempty"`
-	JsonStore         string                `koanf:"JsonStore" yaml:"JsonStore,omitempty"`
-	UrlAction         string                `koanf:"UrlAction" yaml:"UrlAction,omitempty"`
-	Browser           string                `koanf:"Browser" yaml:"Browser,omitempty"`
-	ProfileFormat     string                `koanf:"ProfileFormat" yaml:"ProfileFormat,omitempty"`
-	AccountPrimaryTag []string              `koanf:"AccountPrimaryTag" yaml:"AccountPrimaryTag,omitempty"`
-	PromptColors      PromptColors          `koanf:"PromptColors" yaml:"PromptColors,omitempty"` // go-prompt colors
-	LogLevel          string                `koanf:"LogLevel" yaml:"LogLevel,omitempty"`
-	LogLines          bool                  `koanf:"LogLines" yaml:"LogLines,omitempty"`
-	HistoryLimit      int64                 `koanf:"HistoryLimit" yaml:"HistoryLimit,omitempty"`
-	HistoryMinutes    int64                 `koanf:"HistoryMinutes" yaml:"HistoryMinutes,omitempty"`
-	ListFields        []string              `koanf:"ListFields" yaml:"ListFields,omitempty"`
+	configFile        string                 // name of this file
+	cacheFile         string                 // name of cache file; always passed in via CLI args
+	Cache             *Cache                 `yaml:"-"` // our cache data
+	SSO               map[string]*SSOConfig  `koanf:"SSOConfig" yaml:"SSOConfig,omitempty"`
+	DefaultSSO        string                 `koanf:"DefaultSSO" yaml:"DefaultSSO,omitempty"`   // specify default SSO by key
+	SecureStore       string                 `koanf:"SecureStore" yaml:"SecureStore,omitempty"` // json or keyring
+	DefaultRegion     string                 `koanf:"DefaultRegion" yaml:"DefaultRegion,omitempty"`
+	ConsoleDuration   int64                  `koanf:"ConsoleDuration" yaml:"ConsoleDuration,omitempty"`
+	JsonStore         string                 `koanf:"JsonStore" yaml:"JsonStore,omitempty"`
+	UrlAction         string                 `koanf:"UrlAction" yaml:"UrlAction,omitempty"`
+	Browser           string                 `koanf:"Browser" yaml:"Browser,omitempty"`
+	ProfileFormat     string                 `koanf:"ProfileFormat" yaml:"ProfileFormat,omitempty"`
+	AccountPrimaryTag []string               `koanf:"AccountPrimaryTag" yaml:"AccountPrimaryTag,omitempty"`
+	PromptColors      PromptColors           `koanf:"PromptColors" yaml:"PromptColors,omitempty"` // go-prompt colors
+	LogLevel          string                 `koanf:"LogLevel" yaml:"LogLevel,omitempty"`
+	LogLines          bool                   `koanf:"LogLines" yaml:"LogLines,omitempty"`
+	HistoryLimit      int64                  `koanf:"HistoryLimit" yaml:"HistoryLimit,omitempty"`
+	HistoryMinutes    int64                  `koanf:"HistoryMinutes" yaml:"HistoryMinutes,omitempty"`
+	ListFields        []string               `koanf:"ListFields" yaml:"ListFields,omitempty"`
+	ConfigVariables   map[string]interface{} `koanf:"ConfigVariables" yaml:"ConfigVariables,omitempty"`
 }
 
 type SSOConfig struct {


### PR DESCRIPTION
 * Remove `output` flag for `config`
 * Define `ConfigVariables` config map to allow aribtrary AWS global
    config options for each profile.

Fixes: #211