### PR TITLE
Improve how we open URLs with eval and process/config

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ via AWS SSO CLI.
 Flags:
 
  * `--diff` -- Print a diff of changes to the config file instead of modifying it
+ * `--open` -- Override how to open URls: [open|clip] (required)
  * `--print` -- Print profile entries instead of modifying config file
 
 This generates a series of [named profile entries](
@@ -211,6 +212,10 @@ the user defined [Profile](docs/config.md#profile) option on a role by role basi
 For each profile generated, it will specify a [list of settings](
 https://docs.aws.amazon.com/sdkref/latest/guide/settings-global.html) as defined by
 the [ConfigVariables](docs/config.md#configvariables) setting in the `~/.aws-sso/config.yaml`.
+
+**Note:** Due to a limitation in the AWS tooling, `print` is not a supported `--url-action`
+when using the `$AWS_PROFILE` variable with AWS SSO CLI.  Hence, you must use `open` to auto-open
+URLs in your browser (recommended) or `clip` to automatically copy URLs to your clipboard.
 
 **Note:** You should run this command any time your list of AWS roles changes.
 
@@ -247,9 +252,8 @@ Priority is given to:
 of the `--refresh` flag.  The `$AWS_SSO_ROLE_NAME` and `$AWS_SSO_ACCOUNT_ID`
 are always ignored.
 
-**Note:** The `eval` command will never honor the `--url-action=print`
-option as this will intefere with bash/zsh/etc ability to evaluate
-the generated commands and will fall back to `--url-action=open`.
+**Note:** Using `--url-action=print` is supported, but you must be able to see the output
+of _STDERR_ to see the URL to open.
 
 **Note:** The `eval` command is not supported under Windows CommandPrompt or PowerShell.
 
@@ -302,6 +306,9 @@ Priority is given to:
 
 **Note:** The `process` command does not honor the `$AWS_SSO_ROLE_ARN`, `$AWS_SSO_ACCOUNT_ID`, or
 `$AWS_SSO_ROLE_NAME` environment variables.
+
+**Note:** Due to a limitation of the AWS tooling, setting `--url-action print` will cause an error
+because of a limitation of the AWS tooling which prevents it from working.
 
 ### cache
 

--- a/cmd/eval_cmd.go
+++ b/cmd/eval_cmd.go
@@ -51,11 +51,6 @@ func (cc *EvalCmd) Run(ctx *RunContext) error {
 		return unsetEnvVars(ctx)
 	}
 
-	// never print the URL since that breaks bash's eval
-	if ctx.Settings.UrlAction == "print" {
-		ctx.Settings.UrlAction = "open"
-	}
-
 	var role string
 	var accountid int64
 

--- a/cmd/process_cmd.go
+++ b/cmd/process_cmd.go
@@ -38,9 +38,8 @@ type ProcessCmd struct {
 func (cc *ProcessCmd) Run(ctx *RunContext) error {
 	var err error
 
-	// never print the URL since that breaks AWS's eval
 	if ctx.Settings.UrlAction == "print" {
-		ctx.Settings.UrlAction = "open"
+		return fmt.Errorf("Unsupported --url-action=print option")
 	}
 
 	role := ctx.Cli.Process.Role

--- a/docs/config.md
+++ b/docs/config.md
@@ -45,9 +45,9 @@ JsonStore: <path to json file>
 
 ProfileFormat: "<template>"
 ConfigVariables:
-	<Var1>: <Value1>
-	<Var2>: <Value2>
-	<VarN>: <ValueN>
+    <Var1>: <Value1>
+    <Var2>: <Value2>
+    <VarN>: <ValueN>
 
 AccountPrimaryTag:
     - <tag 1>
@@ -316,18 +316,15 @@ This option has no effect if `HistoryLimit` is set to 0.
 Specify which fields to display via the `list` command.  Valid options are:
 
  * `Id` -- Unique row identifier
+ * `AccountAlias` -- Account Name from AWS SSO
  * `AccountId` -- AWS Account Id
  * `AccountName` -- Account Name from config.yaml
- * `AccountAlias` -- Account Name from AWS SSO
- * `ARN` -- Role ARN
+ * `Arn` -- Role ARN
  * `DefaultRegion` -- Configured default region
  * `EmailAddress` -- Email address of root account associated with AWS Account
- * `ExpiresEpoch` -- Unix epoch time when cached STS creds expire
+ * `Expires` -- Unix epoch time when cached STS creds expire
  * `ExpiresStr` -- Hours and minutes until cached STS creds expire
+ * `Profile` -- Value used for `$AWS_SSO_PROFILE` and the profile name in `~/.aws/config`
  * `RoleName` -- Role name
- * `SSORegion` -- Region of AWS SSO instance
- * `StartUrl` -- AWS SSO Start Url
-<!--
- * `Profile` -- ???
- * `Via` -- Previous ARN of role to assume
--->
+ * `SSO` -- AWS SSO instance name
+ * `Via` -- Role Chain Via

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -61,7 +61,7 @@ func HandleUrl(action, browser, url, pre, post string) error {
 			err = fmt.Errorf("Unable to copy URL to clipboard: %s", err.Error())
 		}
 	case "print":
-		fmt.Printf("%s%s%s", pre, url, post)
+		os.Stderr.WriteString(fmt.Sprintf("%s%s%s", pre, url, post))
 	case "open":
 		if len(browser) == 0 {
 			err = open.Run(url)


### PR DESCRIPTION
 * `eval` now supports `--url-action=print` because we now print to
   STDERR
 * Clarify that `process` does _NOT_ support print, because the AWS
    tooling eats STDERR.
 * `config` now takes an `--open` flag for overriding `UrlAction`
    in the config file with the `--url-action` flag on the CLI.

Refs: #157