### PR TITLE
console command now supports $AWS_PROFILE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@
  * Improve ProfileFormat documentation
  * Add `config` command to manage `~/.aws/config` #157
  * Add Quick Start Guide
+ * `console` command now works with any credentials using `$AWS_PROFILE` #234
 
 ### Bug Fixes
 
  * Fix broken FirstItem and StringsJoin ProfileFormat functions
  * Default ProfileFormat now zero-pads the AWS AccountID
+ * Fix crash with invalid History tags
 
 ### Changes
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Priority is given to:
  * `--arn` (`$AWS_SSO_ROLE_ARN`)
  * `--account` (`$AWS_SSO_ACCOUNT_ID`) and `--role` (`$AWS_SSO_ROLE_NAME`)
  * `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` environment variables
+ * `AWS_PROFILE` environment variable (works with both SSO and static profiles)
  * Prompt user interactively
 
 ### config

--- a/sso/cache.go
+++ b/sso/cache.go
@@ -206,9 +206,13 @@ func (c *Cache) deleteOldHistory() {
 			if r, ok := a.Roles[role]; ok {
 				// figure out if this history item has expired
 				values := strings.SplitN(r.Tags["History"], ",", 2)
+				if len(values) != 2 {
+					log.Errorf("Too few fields for %s History Tag: '%s'", r.Arn, r.Tags["History"])
+					continue
+				}
 				lastTime, err := strconv.ParseInt(values[1], 10, 64)
 				if err != nil {
-					log.Errorf("Unable to parse History Tag '%s': %s", r.Tags["History"], err.Error())
+					log.Errorf("Unable to parse %s History Tag '%s': %s", r.Arn, r.Tags["History"], err.Error())
 					continue
 				}
 

--- a/sso/cache_roles_test.go
+++ b/sso/cache_roles_test.go
@@ -179,3 +179,18 @@ func (suite *CacheRolesTestSuite) TestProfileName() {
 	assert.NoError(t, err)
 	assert.Equal(t, "OurCompany_Control_Tower_Playground:AWSAdministratorAccess", p)
 }
+
+func (suite *CacheRolesTestSuite) TestGetRoleByProfile() {
+	t := suite.T()
+	roles := suite.cache.SSO[suite.cache.ssoName].Roles
+	flat, err := roles.GetRoleByProfile("audit-admin", suite.settings)
+	assert.NoError(t, err)
+	assert.Equal(t, "arn:aws:iam::502470824893:role/AWSAdministratorAccess", flat.Arn)
+
+	_, err = roles.GetRoleByProfile("foobar", suite.settings)
+	assert.Error(t, err)
+
+	flat, err = roles.GetRoleByProfile("Dev Account/AWSReadOnlyAccess", suite.settings)
+	assert.NoError(t, err)
+	assert.Equal(t, "arn:aws:iam::707513610766:role/AWSReadOnlyAccess", flat.Arn)
+}

--- a/sso/cache_test.go
+++ b/sso/cache_test.go
@@ -171,9 +171,9 @@ func (suite *CacheTestSuite) TestGetAllTags() {
 	cache := suite.cache.GetSSO()
 
 	tl := cache.Roles.GetAllTags()
-	assert.Equal(t, 8, len(*tl))
+	assert.Equal(t, 9, len(*tl))
 	tl = suite.cache.GetAllTagsSelect()
-	assert.Equal(t, 8, len(*tl))
+	assert.Equal(t, 9, len(*tl))
 }
 
 func (suite *CacheTestSuite) TestGetRoleTags() {

--- a/sso/testdata/cache.json
+++ b/sso/testdata/cache.json
@@ -150,6 +150,7 @@
             "Roles": {
               "AWSAdministratorAccess": {
                 "Arn": "arn:aws:iam::502470824893:role/AWSAdministratorAccess",
+                "Profile": "audit-admin",
                 "Tags": {
                   "AccountAlias": "Audit",
                   "AccountID": "502470824893",


### PR DESCRIPTION
After all other existing checks, look to see if $AWS_PROFILE
is set and if so, use those credentials to open the console with.

Since not all profiles are necesssarily AWS SSO profiles, we will
try using the Go SDK if necessary to load our credentials instead
of the creds we have cached.

Fixes: #234