### PR TITLE
Add custom environment variable support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
  * Add a lot more `ProfileFormat` functions via sprig #244
  * `flush` command gives users more control over what is flushed
  * Add support for `SourceIdentity` for AssumeRole operations
+ * Add `EnvVarTags` config file option #134
 
 ## [1.7.0] - 2022-01-09
 

--- a/cmd/eval_cmd.go
+++ b/cmd/eval_cmd.go
@@ -47,10 +47,6 @@ func (cc *EvalCmd) Run(ctx *RunContext) error {
 		return fmt.Errorf("eval is not supported on Windows unless running under bash")
 	}
 
-	if ctx.Cli.Eval.Clear {
-		return unsetEnvVars(ctx)
-	}
-
 	var role string
 	var accountid int64
 
@@ -78,6 +74,11 @@ func (cc *EvalCmd) Run(ctx *RunContext) error {
 	region := ctx.Settings.GetDefaultRegion(accountid, role, ctx.Cli.Eval.NoRegion)
 
 	awssso := doAuth(ctx)
+
+	if ctx.Cli.Eval.Clear {
+		return unsetEnvVars(ctx)
+	}
+
 	for k, v := range execShellEnvs(ctx, awssso, accountid, role, region) {
 		if len(v) == 0 {
 			fmt.Printf("unset %s\n", k)
@@ -110,6 +111,10 @@ func unsetEnvVars(ctx *RunContext) error {
 	} else if os.Getenv("AWS_DEFAULT_REGION") != os.Getenv("AWS_SSO_DEFAULT_REGION") {
 		// clear the tracking variable if we don't match
 		envs = append(envs, "AWS_SSO_DEFAULT_REGION")
+	}
+
+	for _, env := range ctx.Settings.GetEnvVarTags() {
+		envs = append(envs, env)
 	}
 
 	for _, e := range envs {

--- a/cmd/exec_cmd.go
+++ b/cmd/exec_cmd.go
@@ -162,6 +162,11 @@ func execShellEnvs(ctx *RunContext, awssso *sso.AWSSSO, accountid int64, role, r
 		if err != nil {
 			log.Errorf("Unable to generate AWS_SSO_PROFILE: %s", err.Error())
 		}
+
+		// and any EnvVarTags
+		for k, v := range roleInfo.GetEnvVarTags(ctx.Settings) {
+			shellVars[k] = v
+		}
 	}
 
 	return shellVars

--- a/docs/config.md
+++ b/docs/config.md
@@ -62,6 +62,10 @@ ListFields:
     - <field 1>
     - <field 2>
     - <field N>
+EnvVarTags:
+    - <Tag1>
+    - <Tag2>
+    - <TagN>
 ```
 
 ## SSOConfig
@@ -339,3 +343,15 @@ Specify which fields to display via the `list` command.  Valid options are:
  * `RoleName` -- Role name
  * `SSO` -- AWS SSO instance name
  * `Via` -- Role Chain Via
+
+## EnvVarTags
+
+List of tag keys that should be set as a shell environment variable when
+using the `eval` or `exec` commands.
+
+**Note:** These environment variables are considered completely owned and
+controlled by `aws-sso` so any existing value will be overwritten.
+
+**Note:** This feature is not compatible when using roles using the 
+`$AWS_PROFILE` via the `config` command.
+

--- a/sso/cache_roles.go
+++ b/sso/cache_roles.go
@@ -386,3 +386,15 @@ func stringsJoin(x string, items ...string) string {
 func stringReplace(search, replace, str string) string {
 	return strings.ReplaceAll(str, search, replace)
 }
+
+// GetEnvVarTags returns a map containing a set of keys represening the
+// environment variable names and their values
+func (r *AWSRoleFlat) GetEnvVarTags(s *Settings) map[string]string {
+	ret := map[string]string{}
+	for k, v := range s.GetEnvVarTags() {
+		if val, ok := r.Tags[k]; ok {
+			ret[v] = val
+		}
+	}
+	return ret
+}

--- a/sso/cache_roles_test.go
+++ b/sso/cache_roles_test.go
@@ -199,3 +199,26 @@ func (suite *CacheRolesTestSuite) TestGetRoleByProfile() {
 	assert.NoError(t, err)
 	assert.Equal(t, "arn:aws:iam::707513610766:role/AWSReadOnlyAccess", flat.Arn)
 }
+
+func (suite *CacheRolesTestSuite) TestGetEnvVarTags() {
+	t := suite.T()
+	roles := suite.cache.SSO[suite.cache.ssoName].Roles
+	flat, err := roles.GetRoleByProfile("audit-admin", suite.settings)
+	assert.NoError(t, err)
+
+	settings := Settings{
+		EnvVarTags: []string{
+			"Role",
+			"Email",
+			"AccountName",
+			"FooBar", // doesn't exist
+		},
+	}
+
+	x := map[string]string{
+		"AWS_SSO_TAG_ROLE":        "AWSAdministratorAccess",
+		"AWS_SSO_TAG_EMAIL":       "control-tower-dev-aws+audit@ourcompany.com",
+		"AWS_SSO_TAG_ACCOUNTNAME": "Audit",
+	}
+	assert.Equal(t, x, flat.GetEnvVarTags(&settings))
+}

--- a/sso/settings.go
+++ b/sso/settings.go
@@ -62,6 +62,7 @@ type Settings struct {
 	HistoryMinutes    int64                  `koanf:"HistoryMinutes" yaml:"HistoryMinutes,omitempty"`
 	ListFields        []string               `koanf:"ListFields" yaml:"ListFields,omitempty"`
 	ConfigVariables   map[string]interface{} `koanf:"ConfigVariables" yaml:"ConfigVariables,omitempty"`
+	EnvVarTags        []string               `koanf:"EnvVarTags" yaml:"EnvVarTags,omitempty"`
 }
 
 type SSOConfig struct {
@@ -298,6 +299,15 @@ func (s *Settings) GetSelectedSSO(name string) (*SSOConfig, error) {
 		return c, nil
 	}
 	return &SSOConfig{}, fmt.Errorf("No available SSOConfig Provider")
+}
+
+// Returns the Tag name => Environment variable name
+func (s *Settings) GetEnvVarTags() map[string]string {
+	ret := map[string]string{}
+	for _, tag := range s.EnvVarTags {
+		ret[tag] = fmt.Sprintf("AWS_SSO_TAG_%s", strings.ToUpper(tag))
+	}
+	return ret
 }
 
 // Refresh should be called any time you load the SSOConfig into memory or add a role

--- a/sso/settings_test.go
+++ b/sso/settings_test.go
@@ -172,3 +172,15 @@ func (suite *SettingsTestSuite) TestOtherSSO() {
 
 	assert.Equal(t, "us-west-2", settings.GetDefaultRegion(182347455, "AWSAdministratorAccess", false))
 }
+
+func (suite *SettingsTestSuite) TestGetEnvVarTags() {
+	t := suite.T()
+
+	x := map[string]string{
+		"Role": "AWS_SSO_TAG_ROLE",
+		"Arn":  "AWS_SSO_TAG_ARN",
+		"Foo":  "AWS_SSO_TAG_FOO",
+	}
+	y := suite.settings.GetEnvVarTags()
+	assert.EqualValues(t, x, y)
+}

--- a/sso/testdata/settings.yaml
+++ b/sso/testdata/settings.yaml
@@ -59,3 +59,7 @@ AccountPrimaryTag:
   - AccountAlias
 LogLevel: warn
 DefaultRegion: us-west-2
+EnvVarTags:
+  - Role 
+  - Arn
+  - Foo


### PR DESCRIPTION
Any tag can now be an environment variable
with the eval and exec commands.

Fixes: #134