### PR TITLE
Correctly set `AWS_SSO` env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [1.7.1] - Unreleased
 
+### Bug Fixes
+
+ * `AWS_SSO` env var is now set with the `eval` and `exec` command #251 
+
 ### Changes
 
  * `flush` now flushes the STS IAM Role credentials first by default #236

--- a/cmd/exec_cmd.go
+++ b/cmd/exec_cmd.go
@@ -132,6 +132,7 @@ func execShellEnvs(ctx *RunContext, awssso *sso.AWSSSO, accountid int64, role, r
 	credsPtr := GetRoleCredentials(ctx, awssso, accountid, role)
 	creds := *credsPtr
 
+	ssoName, _ := ctx.Settings.GetSelectedSSOName(ctx.Cli.SSO)
 	shellVars := map[string]string{
 		"AWS_ACCESS_KEY_ID":          creds.AccessKeyId,
 		"AWS_SECRET_ACCESS_KEY":      creds.SecretAccessKey,
@@ -140,7 +141,7 @@ func execShellEnvs(ctx *RunContext, awssso *sso.AWSSSO, accountid int64, role, r
 		"AWS_SSO_ROLE_NAME":          creds.RoleName,
 		"AWS_SSO_SESSION_EXPIRATION": creds.ExpireString(),
 		"AWS_SSO_ROLE_ARN":           utils.MakeRoleARN(creds.AccountId, creds.RoleName),
-		"AWS_SSO":                    ctx.Cli.SSO,
+		"AWS_SSO":                    ssoName,
 	}
 
 	if len(region) > 0 {

--- a/sso/settings_test.go
+++ b/sso/settings_test.go
@@ -65,16 +65,47 @@ func (suite *SettingsTestSuite) TestGetSelectedSSO() {
 	t := suite.T()
 
 	sso, err := suite.settings.GetSelectedSSO("Default")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "https://d-754545454.awsapps.com/start", sso.StartUrl)
 
+	sso, err = suite.settings.GetSelectedSSO("Another")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://d-755555555.awsapps.com/start", sso.StartUrl)
+
 	sso, err = suite.settings.GetSelectedSSO("Foobar")
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, "", sso.StartUrl)
 
 	sso, err = suite.settings.GetSelectedSSO("")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "https://d-754545454.awsapps.com/start", sso.StartUrl)
+}
+
+func (suite *SettingsTestSuite) TestGetSelectedSSOName() {
+	t := suite.T()
+
+	name, err := suite.settings.GetSelectedSSOName("Default")
+	assert.NoError(t, err)
+	assert.Equal(t, "Default", name)
+
+	name, err = suite.settings.GetSelectedSSOName("Foobar")
+	assert.Error(t, err)
+	assert.Equal(t, "", name)
+
+	name, err = suite.settings.GetSelectedSSOName("Another")
+	assert.NoError(t, err)
+	assert.Equal(t, "Another", name)
+
+	name, err = suite.settings.GetSelectedSSOName("")
+	assert.NoError(t, err)
+	assert.Equal(t, "Default", name)
+
+	// what if user removes this value from the config file?
+	s := *suite.settings
+	s.DefaultSSO = ""
+	name, err = (&s).GetSelectedSSOName("")
+	assert.NoError(t, err)
+	assert.Equal(t, "Default", name)
 }
 
 func (suite *SettingsTestSuite) TestCreatedAt() {

--- a/sso/testdata/settings.yaml
+++ b/sso/testdata/settings.yaml
@@ -39,7 +39,7 @@ SSOConfig:
                   Type: Sub Account
     Another:
         SSORegion: us-east-1
-        StartUrl: https://d-754545454.awsapps.com/start
+        StartUrl: https://d-755555555.awsapps.com/start
         Accounts:
             182347455:
                 Name: Whatever


### PR DESCRIPTION
We were incorrectly leaving this blank so it was being
unset in `eval` and set to an empty string in `exec`

Fixes: #251