### PR TITLE
Fix auto-complete when DefaultSSO != Default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Bug Fixes
 
- * `AWS_SSO` env var is now set with the `eval` and `exec` command #251 
+ * `AWS_SSO` env var is now set with the `eval` and `exec` command #251
+ * Fix broken auto-complete for non-Default AWS SSO instances #249
 
 ### Changes
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -10,6 +10,7 @@
  * [Example of multiple AWS SSO instances](#example-of-multiple-aws-sso-instances)
  * [What are the purpose of the Tags?](#what-are-the-purpose-of-the-tags)
  * [Which SecureStore should I use?](#which-securestore-should-i-use)
+ * [Using non-default AWS SSO instances with auto-complete](#using-non-default-aws-sso-instances-with-auto-complete)
 
 ### How do I delete all secrets from the macOS keychain?
 
@@ -211,3 +212,25 @@ Is there another secure storage backend you would like to see AWS SSO CLI
 support?  If so, please [open a feature request](
 https://github.com/synfinatic/aws-sso-cli/issues/new?assignees=&labels=enhancement&template=feature_request.md)
 and let me know!
+
+
+### Using non-default AWS SSO instances with auto-complete
+
+The handling of the auto-completion of the `-A`, `-R`, and `-a` flags happens
+before processing of the command line arguments so you can not use the `--sso` / `-S`
+flag to specify a non-default AWS SSO instance.  The result is it will always
+present your [DefaultSSO](config.md#defaultsso) list of accounts and roles.
+
+If you wish to use auto-complete with a different AWS SSO instance, you must
+first set the `AWS_SSO` environment variable in your shell:
+
+```bash
+$ export AWS_SSO=OtherInstance
+$ aws eval ...
+```
+
+Note, the following shorter version of specifying it as a single command does not work:
+
+```bash
+$ AWS_SSO=OtherInstance aws-sso eval ...
+```

--- a/sso/cache.go
+++ b/sso/cache.go
@@ -55,7 +55,7 @@ func OpenCache(f string, s *Settings) (*Cache, error) {
 		ConfigCreatedAt: 0,
 		Version:         1, // use an invalid default version for cache files without a version
 		SSO:             map[string]*SSOCache{},
-		ssoName:         s.DefaultSSO,
+		ssoName:         s.DefaultSSO, // default to the config file default
 	}
 
 	var err error


### PR DESCRIPTION
Users who chose something other than to set `DefaultSSO: Default`
would find that auto-complete would present the wrong values or
in the case of no `Default` instance, no options at all.

We now load the config file and find the user specificed DefaultSSO
and load those values from the cache.

Fixes: #249