### PR TITLE
Fix AWS_SSO_SESSION_EXPIRATION with Via

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
  * `AWS_SSO` env var is now set with the `eval` and `exec` command #251
  * Fix broken auto-complete for non-Default AWS SSO instances #249
+ * Fix incorrect `AWS_SSO_SESSION_EXPIRATION` values #250
 
 ### Changes
 
@@ -15,7 +16,7 @@
 
  * Add a lot more `ProfileFormat` functions via sprig #244
  * `flush` command gives users more control over what is flushed
- * Add support for `SourceIdentity` for AssumeRole operations
+ * Add documentation for `SourceIdentity` for AssumeRole operations
  * Add `EnvVarTags` config file option #134
 
 ## [1.7.0] - 2022-01-09

--- a/sso/awssso.go
+++ b/sso/awssso.go
@@ -269,7 +269,7 @@ func (as *AWSSSO) CreateToken() error {
 		}
 	}
 
-	secs, _ := time.ParseDuration(fmt.Sprintf("%ds", *resp.ExpiresIn))
+	secs, _ := time.ParseDuration(fmt.Sprintf("%ds", *resp.ExpiresIn)) // seconds
 	as.Token = storage.CreateTokenResponse{
 		AccessToken:  aws.StringValue(resp.AccessToken),
 		ExpiresIn:    aws.Int64Value(resp.ExpiresIn),
@@ -531,7 +531,7 @@ func (as *AWSSSO) GetRoleCredentials(accountId int64, role string) (storage.Role
 		AccessKeyId:     aws.StringValue(output.Credentials.AccessKeyId),
 		SecretAccessKey: aws.StringValue(output.Credentials.SecretAccessKey),
 		SessionToken:    aws.StringValue(output.Credentials.SessionToken),
-		Expiration:      aws.TimeValue(output.Credentials.Expiration).Unix(),
+		Expiration:      aws.TimeValue(output.Credentials.Expiration).UnixMilli(),
 	}
 	return ret, nil
 }


### PR DESCRIPTION
When assuming a role, via `Via` the AWS_SSO_SESSION_EXPIRATION
would incorrectly report a date in the past instead of the
future because we were specifying secs instead of msec.

Fixes: #250