### PR TITLE
prompt users for hostname instead of URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changes
 
  * `flush` now flushes the STS IAM Role credentials first by default #236
+ * Guided setup now uses the hostname or FQDN instead of full URL for the SSO StartURL #258
 
 ### New Features
 


### PR DESCRIPTION
Guided setup now only requires the hostname or FQDN instead
of the full StartURL.

Fixes: #258