### PR TITLE
Really fix setup -> list/etc & default log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
     or the role History
  * Auto-guided setup now loads the config so the user defined command is
     successful #260
+ * default `list` command will now refresh the cache if necessary
 
 ### Changes
 

--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -19,7 +19,6 @@ package main
  */
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -81,13 +80,11 @@ func NewPredictor(cacheFile, configFile string) *Predictor {
 
 	settings, err := sso.LoadSettings(configFile, cacheFile, defaults, override)
 	if err != nil {
-		fmt.Printf("Unable to open config.  Auto-complete is disabled: %s", err.Error())
 		return &p
 	}
 
 	c, err := sso.OpenCache(cacheFile, settings)
 	if err != nil {
-		fmt.Printf("Unable to open cache. Auto-complete is disabled: %s", err.Error())
 		return &p
 	}
 

--- a/cmd/list_cmd.go
+++ b/cmd/list_cmd.go
@@ -86,6 +86,19 @@ func (cc *ListCmd) Run(ctx *RunContext) error {
 type DefaultCmd struct{}
 
 func (cc *DefaultCmd) Run(ctx *RunContext) error {
+	s, err := ctx.Settings.GetSelectedSSO("")
+	if err != nil {
+		return err
+	}
+
+	// update cache?
+	if err = ctx.Settings.Cache.Expired(s); err != nil {
+		c := &CacheCmd{}
+		if err = c.Run(ctx); err != nil {
+			log.WithError(err).Errorf("Unable to refresh local cache")
+		}
+	}
+
 	printRoles(ctx, ctx.Settings.ListFields)
 	return nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,7 +79,7 @@ var DEFAULT_CONFIG map[string]interface{} = map[string]interface{}{
 	"ListFields":                                []string{"AccountId", "AccountAlias", "RoleName", "ExpiresStr"},
 	"ConsoleDuration":                           60,
 	"UrlAction":                                 "open",
-	"LogLevel":                                  "info",
+	"LogLevel":                                  "warn",
 	"DefaultSSO":                                "Default",
 }
 
@@ -88,7 +88,7 @@ type CLI struct {
 	Browser    string `kong:"short='b',help='Path to browser to open URLs with',env='AWS_SSO_BROWSER'"`
 	ConfigFile string `kong:"name='config',default='${CONFIG_FILE}',help='Config file',env='AWS_SSO_CONFIG'"`
 	Lines      bool   `kong:"help='Print line number in logs'"`
-	LogLevel   string `kong:"short='L',name='level',help='Logging level [error|warn|info|debug|trace] (default: info)'"`
+	LogLevel   string `kong:"short='L',name='level',help='Logging level [error|warn|info|debug|trace] (default: warn)'"`
 	UrlAction  string `kong:"short='u',help='How to handle URLs [open|print|clip] (default: open)'"`
 	SSO        string `kong:"short='S',help='Override default AWS SSO Instance',env='AWS_SSO',predictor='sso'"`
 	STSRefresh bool   `kong:"help='Force refresh of STS Token Credentials'"`
@@ -136,7 +136,6 @@ func main() {
 		if err = setupWizard(&run_ctx); err != nil {
 			log.Fatalf("%s", err.Error())
 		}
-		cli.ConfigFile = utils.GetHomePath(cli.ConfigFile)
 	} else if err != nil {
 		log.WithError(err).Fatalf("Unable to open config file: %s", cli.ConfigFile)
 	}

--- a/sso/cache.go
+++ b/sso/cache.go
@@ -236,7 +236,8 @@ func (c *Cache) deleteOldHistory() {
 func (c *Cache) Refresh(sso *AWSSSO, config *SSOConfig, ssoName string) error {
 	// save role creds expires time
 	expires := map[string]int64{}
-	for _, account := range c.SSO[ssoName].Roles.Accounts {
+	cache := c.GetSSO()
+	for _, account := range cache.Roles.Accounts {
 		for _, role := range account.Roles {
 			if role.Expires > 0 {
 				expires[role.Arn] = role.Expires

--- a/sso/cache_test.go
+++ b/sso/cache_test.go
@@ -266,7 +266,7 @@ func (suite *CacheTestSuite) TestMarkRolesExpired() {
 	}
 }
 
-func (suite CacheTestSuite) TestSetRoleExpires() {
+func (suite *CacheTestSuite) TestSetRoleExpires() {
 	t := suite.T()
 	err := suite.cache.SetRoleExpires(TEST_ROLE_ARN, 12344553243)
 	assert.NoError(t, err)
@@ -279,7 +279,7 @@ func (suite CacheTestSuite) TestSetRoleExpires() {
 	assert.Error(t, err)
 }
 
-func (suite CacheTestSuite) TestCheckProfiles() {
+func (suite *CacheTestSuite) TestCheckProfiles() {
 	t := suite.T()
 	tests := ProfileTests{}
 


### PR DESCRIPTION
- update --level flag to default to warn per the docs
- Fix crash when there is no cache file introduced in
    b46ab25064c823aebea8306c2a7898e15e0980c5
- default command (list) will now refresh the cache
    if necessary

Fixes: #260