### PR TITLE
Refresh SSO AccessToken if first attempt errors out

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,8 +40,9 @@ jobs:
 
     # If this run was triggered by a pull request event, then checkout
     # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
+    # Note: no longer recommended!
+    #    - run: git checkout HEAD^2
+    #  if: ${{ github.event_name == 'pull_request' }}
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # AWS SSO CLI Changelog
 
-## [v1.8.0] - Unreleased
+## [v1.7.2] - Unreleased
+
+### Bug Fixes
+
+ * Cached AWS SSO AccessToken is sometimes invalid even though it was not expired
+    and any calls to SSO were failing.  #279
 
 ### Changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT_VERSION := 1.7.1
+PROJECT_VERSION := 1.7.2
 DOCKER_REPO     := synfinatic
 PROJECT_NAME    := aws-sso
 

--- a/sso/cache.go
+++ b/sso/cache.go
@@ -127,7 +127,7 @@ func (c *Cache) Save(updateTime bool) error {
 	}
 	jbytes, err := json.MarshalIndent(c, "", "  ")
 	if err != nil {
-		return fmt.Errorf("Unable to masrhal json: %s", err.Error())
+		return fmt.Errorf("Unable to marshal json: %s", err.Error())
 	}
 	err = utils.EnsureDirExists(c.CacheFile())
 	if err != nil {
@@ -377,6 +377,7 @@ func (c *Cache) NewRoles(as *AWSSSO, config *SSOConfig) (*Roles, error) {
 	return &r, nil
 }
 
+// addSSORoles retrieves all the SSO Roles from AWS SSO and places them in r
 func (c *Cache) addSSORoles(r *Roles, as *AWSSSO) error {
 	cache := c.GetSSO()
 


### PR DESCRIPTION
For some reason our SSO AccessTokens are being marked as invalid
by AWS SSO API and so the sso.GetAccounts() and sso.GetRoles()
calls should try force reauthenticating once to AWS SSO in order to get a
new AccessToken for these calls.

Refs: #279