### PR TITLE
Fix condition

### DIFF
--- a/cmd/process_cmd.go
+++ b/cmd/process_cmd.go
@@ -62,7 +62,7 @@ func (cc *ProcessCmd) Run(ctx *RunContext) error {
 		}
 	}
 
-	if role != "" || account == 0 {
+	if role == "" || account == 0 {
 		return fmt.Errorf("Please specify --arn or --account and --role")
 	}
 


### PR DESCRIPTION
Error introduced by 41e96526:
```diff
- if len(role) == 0 || account == 0 {
+ if role != "" || account == 0 {
```