### PR TITLE
No longer read ~/.aws/credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changes
 
  * Add unit tests for AWS SSO API calls
+ * No longer read ~/.aws/credentials via AWS Go SDK for slightly better security #280
 
 ## [v1.7.3] - 2022-02-10
 

--- a/sso/awssso.go
+++ b/sso/awssso.go
@@ -70,13 +70,13 @@ type AWSSSO struct {
 }
 
 func NewAWSSSO(s *SSOConfig, store *storage.SecureStorage) *AWSSSO {
-	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(s.SSORegion))
-	if err != nil {
-		log.Fatalf("Unable to get accounts: %s", err.Error())
-	}
+	oidcSession := ssooidc.New(ssooidc.Options{
+		Region: s.SSORegion,
+	})
 
-	oidcSession := ssooidc.NewFromConfig(cfg)
-	ssoSession := sso.NewFromConfig(cfg)
+	ssoSession := sso.New(sso.Options{
+		Region: s.SSORegion,
+	})
 
 	as := AWSSSO{
 		sso:        ssoSession,


### PR DESCRIPTION
Use a slightly different API to initalize our sso and ssooidc
handles which doesn't load our config stored in ~/.aws

Fixes: #280