### PR TITLE
Fix underlying problem with missing History tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
  * No longer generate errors for empty History tag in cache #305
 
+### New Features
+
+ * Add support for --url-action printurl and exec #303
+
 ## [v1.7.4] - 2022-02-25
 
 ### Bug Fixes


### PR DESCRIPTION
History tags were being lost when we refreshed the cache via
Cache.Refresh()

- Address the empty string value for the tag
- More unit tests

Fixes: #305