### PR TITLE
list command now prints AWS SSO session expire time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### New Features
 
  * Add support for --url-action printurl and exec #303
+ * `list` command now prints how long until the AWS SSO session expires #313
 
 ## [v1.7.4] - 2022-02-25
 


### PR DESCRIPTION
Now we print both the AWS STS session time for each IAM Role
and now the time until the AWS SSO session expires.

Fixes: #313