### PR TITLE
Redirect users to AWS signin url instead of AWS SSO CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
  * `console` command now works when AWS_PROFILE #332
+ * Fix `console` URL redirect #328
 
 ## [1.7.5] - 2022-03-29
 

--- a/cmd/console_cmd.go
+++ b/cmd/console_cmd.go
@@ -298,8 +298,14 @@ func openConsoleAccessKey(ctx *RunContext, creds *storage.RoleCredentials, durat
 		return fmt.Errorf("Error parsing Login response: %s", err.Error())
 	}
 
+	sso, err := ctx.Settings.GetSelectedSSO(ctx.Cli.SSO)
+	if err != nil {
+		return err
+	}
+	issuer := sso.StartUrl
+
 	login := LoginUrlParams{
-		Issuer:      "https://github.com/synfinatic/aws-sso-cli",
+		Issuer:      issuer,
 		Destination: fmt.Sprintf("https://console.aws.amazon.com/console/home?region=%s", region),
 		SigninToken: loginResponse.SigninToken,
 	}


### PR DESCRIPTION
Console access was directing users sometimes to the AWS SSO page
instead of the AWS SSO login page because I didn't understand
the purpose of the Issuer field.

Fixes: #328