### PR TITLE
prompt user when AWS_PROFILE is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # AWS SSO CLI Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+ * `console` command now works when AWS_PROFILE #332
+
 ## [1.7.5] - 2022-03-29
 
 ### Bug Fixes


### PR DESCRIPTION
Instead of generating a confusing error, prompt the user
for which role they would like to assume.

Fixes: #332