### PR TITLE
Add support for using Firefox containers with `console`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+ * Add support for Firefox Containers #336
+
 ### Bug Fixes
 
  * `console` command now works when AWS_PROFILE #332

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ then this won't work for you.
 ## What does AWS SSO CLI do?
 
 AWS SSO CLI makes it easy to manage your shell environment variables allowing
-you to access the AWS API using CLI tools.  Unlike the official AWS tooling,
-the `aws-sso` command does not require defining named profiles in your
+you to access the AWS API & web console using CLI tools.  Unlike the official
+AWS tooling, the `aws-sso` command does not require defining named profiles in your
 `~/.aws/config` (or anywhere else for that matter) for each and every role you
 wish to assume and use.
 
@@ -62,6 +62,11 @@ via an interactive auto-complete experience with automatic and user-defined
 metadata (tags) and exports the necessary [AWS STS Token credentials](
 https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html#using-temp-creds-sdk-cli)
 to your shell environment.
+
+As part of the goal of improving the end-user experience with AWS SSO, it also
+supports using multiple AWS Web Console sessions with Firefox and the [Open URL in
+Container](https://addons.mozilla.org/en-US/firefox/addon/open-url-in-container/)
+plugin and many other quality of life improvements!
 
 ## Demo
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -83,6 +83,7 @@ var DEFAULT_CONFIG map[string]interface{} = map[string]interface{}{
 	"UrlExecCommand":                            "",
 	"LogLevel":                                  "warn",
 	"DefaultSSO":                                "Default",
+	"FirefoxOpenUrlInContainer":                 false,
 }
 
 type CLI struct {

--- a/docs/config.md
+++ b/docs/config.md
@@ -39,6 +39,7 @@ UrlActionExec:
     - <arg 1>
     - <arg N>
     - "%s"
+FirefoxOpenInContainer: [False|True]
 ConsoleDuration: <minutes>
 
 LogLevel: [error|warn|info|debug|trace]
@@ -165,7 +166,7 @@ If you only have a single AWS SSO instance, then it doesn't really matter what y
 but if you have two or more, than `Default` is automatically selected unless you manually
 specify it here, on the CLI (`--sso`), or via the `AWS_SSO` environment variable.
 
-## Browser / UrlAction / UrlActionExec
+## Browser / UrlAction / UrlActionExec / FirefoxOpenUrlInContainer
 
 `UrlAction` gives you control over how AWS SSO and AWS Console URLs are opened in a browser:
 
@@ -178,20 +179,57 @@ specify it here, on the CLI (`--sso`), or via the `AWS_SSO` environment variable
 If `Browser` is not set, then your default browser will be used and that
 your browser needs to support JavaScript for the AWS SSO user interface.
 
-`UrlActionExec` allows you to execute arbitrary commands to handle the URL.  The command and arguments
-should be specified as a list, with the URL to open specified as the format string `%s`.  Only one instance
-of `%s` is allowed.  Note that YAML requires quotes around strings which start with a [reserved indicator](
-https://yaml.org/spec/1.2-old/spec.html#id2774228) like `%`.
+`UrlActionExec` is used with `UrlAction=exec` and allows you to execute arbitrary
+commands to handle the URL.  The command and arguments should be specified as a list,
+with the URL to open specified as the format string `%s`.  Only one instance
+of `%s` is allowed.  Note that YAML requires quotes around strings which start
+with a [reserved indicator]( https://yaml.org/spec/1.2-old/spec.html#id2774228) like `%`.
 
-Example:
+`FirefoxOpenUrlInContainer` is used with `UrlAction=exec` and [Firefox](
+https://getfirefox.com) with the [Firefox Open URL in Container](
+https://addons.mozilla.org/en-US/firefox/addon/open-url-in-container/) plugin.  This causes
+the generated URL to be of the format:
+
+```
+ext+container:name=<ProfileName>&url=<AWS Console URL>
+```
+
+The result is that each account/role has a dedicated Firefox container named after the _ProfileName_
+so that you can be logged in across multiple AWS accounts/roles without getting
+an error from AWS.
+
+**Note:** If your `ProfileFormat` generates a _ProfileName_ with an `&`, then
+`{{ .AccountId }}:{{ .RoleName }}` will be used as the container name instead.
+
+**Note for MacOS users:** This feature does not work with the `open` command, so you should
+specify `/Applications/Firefox.app/Contents/MacOS/firefox` as the command to execute.
+
+
+Examples:
 
 ```yaml
+# Open the AWS Console in your default browser
+UrlAction=open
+```
+
+```yaml
+# Open the AWS Console using Brave on MacOS
+UrlAction=exec
 UrlActionExec:
     - open
     - -a
     - /Applications/Brave Browser.app
     - --args
     - "%s"
+```
+
+```
+# Open the AWS Console in a Firefox container on MacOS
+UrlAction=exec
+FirefoxOpenUrlInContainer: True
+UrlActionExec:
+	- /Applications/Firefox.app/Contents/MacOS/firefox
+	- "%s"
 ```
 
 ## LogLevel / LogLines

--- a/sso/settings.go
+++ b/sso/settings.go
@@ -42,28 +42,29 @@ const (
 )
 
 type Settings struct {
-	configFile        string                 // name of this file
-	cacheFile         string                 // name of cache file; always passed in via CLI args
-	Cache             *Cache                 `yaml:"-"` // our cache data
-	SSO               map[string]*SSOConfig  `koanf:"SSOConfig" yaml:"SSOConfig,omitempty"`
-	DefaultSSO        string                 `koanf:"DefaultSSO" yaml:"DefaultSSO,omitempty"`   // specify default SSO by key
-	SecureStore       string                 `koanf:"SecureStore" yaml:"SecureStore,omitempty"` // json or keyring
-	DefaultRegion     string                 `koanf:"DefaultRegion" yaml:"DefaultRegion,omitempty"`
-	ConsoleDuration   int32                  `koanf:"ConsoleDuration" yaml:"ConsoleDuration,omitempty"`
-	JsonStore         string                 `koanf:"JsonStore" yaml:"JsonStore,omitempty"`
-	UrlAction         string                 `koanf:"UrlAction" yaml:"UrlAction,omitempty"`
-	Browser           string                 `koanf:"Browser" yaml:"Browser,omitempty"`
-	UrlExecCommand    interface{}            `koanf:"UrlExecCommand" yaml:"UrlExecCommand,omitempty"` // string or list
-	ProfileFormat     string                 `koanf:"ProfileFormat" yaml:"ProfileFormat,omitempty"`
-	AccountPrimaryTag []string               `koanf:"AccountPrimaryTag" yaml:"AccountPrimaryTag,omitempty"`
-	PromptColors      PromptColors           `koanf:"PromptColors" yaml:"PromptColors,omitempty"` // go-prompt colors
-	LogLevel          string                 `koanf:"LogLevel" yaml:"LogLevel,omitempty"`
-	LogLines          bool                   `koanf:"LogLines" yaml:"LogLines,omitempty"`
-	HistoryLimit      int64                  `koanf:"HistoryLimit" yaml:"HistoryLimit,omitempty"`
-	HistoryMinutes    int64                  `koanf:"HistoryMinutes" yaml:"HistoryMinutes,omitempty"`
-	ListFields        []string               `koanf:"ListFields" yaml:"ListFields,omitempty"`
-	ConfigVariables   map[string]interface{} `koanf:"ConfigVariables" yaml:"ConfigVariables,omitempty"`
-	EnvVarTags        []string               `koanf:"EnvVarTags" yaml:"EnvVarTags,omitempty"`
+	configFile                string                 // name of this file
+	cacheFile                 string                 // name of cache file; always passed in via CLI args
+	Cache                     *Cache                 `yaml:"-"` // our cache data
+	SSO                       map[string]*SSOConfig  `koanf:"SSOConfig" yaml:"SSOConfig,omitempty"`
+	DefaultSSO                string                 `koanf:"DefaultSSO" yaml:"DefaultSSO,omitempty"`   // specify default SSO by key
+	SecureStore               string                 `koanf:"SecureStore" yaml:"SecureStore,omitempty"` // json or keyring
+	DefaultRegion             string                 `koanf:"DefaultRegion" yaml:"DefaultRegion,omitempty"`
+	ConsoleDuration           int32                  `koanf:"ConsoleDuration" yaml:"ConsoleDuration,omitempty"`
+	JsonStore                 string                 `koanf:"JsonStore" yaml:"JsonStore,omitempty"`
+	UrlAction                 string                 `koanf:"UrlAction" yaml:"UrlAction,omitempty"`
+	Browser                   string                 `koanf:"Browser" yaml:"Browser,omitempty"`
+	UrlExecCommand            interface{}            `koanf:"UrlExecCommand" yaml:"UrlExecCommand,omitempty"` // string or list
+	ProfileFormat             string                 `koanf:"ProfileFormat" yaml:"ProfileFormat,omitempty"`
+	AccountPrimaryTag         []string               `koanf:"AccountPrimaryTag" yaml:"AccountPrimaryTag,omitempty"`
+	PromptColors              PromptColors           `koanf:"PromptColors" yaml:"PromptColors,omitempty"` // go-prompt colors
+	LogLevel                  string                 `koanf:"LogLevel" yaml:"LogLevel,omitempty"`
+	LogLines                  bool                   `koanf:"LogLines" yaml:"LogLines,omitempty"`
+	HistoryLimit              int64                  `koanf:"HistoryLimit" yaml:"HistoryLimit,omitempty"`
+	HistoryMinutes            int64                  `koanf:"HistoryMinutes" yaml:"HistoryMinutes,omitempty"`
+	ListFields                []string               `koanf:"ListFields" yaml:"ListFields,omitempty"`
+	ConfigVariables           map[string]interface{} `koanf:"ConfigVariables" yaml:"ConfigVariables,omitempty"`
+	EnvVarTags                []string               `koanf:"EnvVarTags" yaml:"EnvVarTags,omitempty"`
+	FirefoxOpenUrlInContainer bool                   `koanf:"FirefoxOpenUrlInContainer" yaml:"FirefoxOpenUrlInContainer"`
 }
 
 type SSOConfig struct {


### PR DESCRIPTION
Normally you can be logged into a single role via the AWS console
which is super annoying.  By using a Firefox plugin, we can use
unique containers for each role and avoid any error messages
from AWS. :)

Fixes: #336