### PR TITLE
Add color/icon support for Firefox containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New Features
+
+ * Add Color and Icon support to Firefox Containers #340
+
 ## [v1.8.0] - 2022-04-30
 
 ### New Features

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -16,6 +16,7 @@
  * [Error: Unable to save... org.freedesktop.DBus.Properties](#error-unable-to-save-orgfreedesktopdbusproperties)
  * [Are macOS Keychain items synced?](#are-macos-keychain-items-synced)
  * [How can I say thanks?](#how-can-I-say-thanks)
+ * [Firefox container color/icon doesn't change](#firefox-container-color-icon-doesnt-change)
 
 ### How do I delete all secrets from the macOS keychain?
 
@@ -287,3 +288,10 @@ Occasionally, someone will ask about giving me a few bucks, but I really don't
 need any money.  If you still would like to throw a few bucks my way, I'd much
 rather you donate to [Second Harvest Food Bank](https://www.shfb.org/) which
 is local to me and could put your money to better work than I would.
+
+### Firefox container color/icon doesn't change
+
+If you have modified your `Color` or `Icon` tag for an Account/Role and the
+label doesn't change in Firefox, you will need to delete the container
+so that it can be re-created or manually change the color/icon in the
+[Firefox settings](about:preferences#containers).

--- a/docs/config.md
+++ b/docs/config.md
@@ -127,6 +127,31 @@ in AWS.
 List of key / value pairs, used by `aws-sso` in prompt mode.  Any tag placed at
 the account level will be applied to all roles in that account.
 
+Some special tags:
+
+ * **Color** -- Used to specify the color of the Firefox container label.  Valid values are:
+	* blue
+	* turquoise
+	* green
+	* yellow
+	* orange
+	* red
+	* pink
+	* purple
+ * **Icon** -- Used to specify the icon of the Firefox container label.  Valid values are:
+	* fingerprint
+	* briefcase
+	* dollar
+	* cart
+	* gift
+	* vacation
+	* food
+	* fruit
+	* pet
+	* tree
+	* chill
+	* circle
+
 #### Roles
 
 The `Roles` block is optional, except for roles you which to assume via role chaining.

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -321,3 +321,13 @@ func AccountIdToInt64(a string) (int64, error) {
 	}
 	return x, nil
 }
+
+// StrListContains returns if `str` is in the `list`
+func StrListContains(str string, list []string) bool {
+	for _, v := range list {
+		if v == str {
+			return true
+		}
+	}
+	return false
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -340,3 +340,9 @@ func (suite *UtilsTestSuite) TestTimeRemain() {
 	assert.NoError(t, e)
 	assert.Equal(t, "5h5m", x)
 }
+
+func TestStrListContains(t *testing.T) {
+	x := []string{"yes", "no"}
+	assert.True(t, StrListContains("yes", x))
+	assert.False(t, StrListContains("nope", x))
+}


### PR DESCRIPTION
- The `Color` and `Icon` tags are now used to define the
    label for the Firefox container
- Refactor code a bit to make it easier to maintain

Fixes: #340