### PR TITLE
Add Firefox container config to guided setup

### DIFF
--- a/cmd/setup_cmd.go
+++ b/cmd/setup_cmd.go
@@ -19,51 +19,21 @@ package main
  */
 import (
 	"fmt"
-	"net"
-	"regexp"
-	"strconv"
-	"strings"
 
-	"github.com/manifoldco/promptui"
 	"github.com/synfinatic/aws-sso-cli/sso"
-	"github.com/synfinatic/aws-sso-cli/utils"
-)
-
-// https://docs.aws.amazon.com/general/latest/gr/sso.html
-var AvailableAwsSSORegions []string = []string{
-	"us-east-1",
-	"us-east-2",
-	"us-west-2",
-	"ap-south-1",
-	"ap-northeast-2",
-	"ap-southeast-1",
-	"ap-southeast-2",
-	"ap-northeast-1",
-	"ca-central-1",
-	"eu-central-1",
-	"eu-west-1",
-	"eu-west-2",
-	"eu-west-3",
-	"eu-north-1",
-	"sa-east-1",
-	"us-gov-west-1",
-}
-
-const (
-	START_URL_FORMAT  = "https://%s.awsapps.com/start"
-	START_FQDN_FORMAT = "%s.awsapps.com"
 )
 
 // SetupCmd defines the Kong args for the setup command (which currently doesn't exist)
 type SetupCmd struct {
 	DefaultRegion    string `kong:"help='Default AWS region for running commands (or \"None\")'"`
-	UrlAction        string `kong:"name='default-url-action',help='How to handle URLs [open|print|clip]'"`
 	SSOStartHostname string `kong:"help='AWS SSO User Portal Hostname'"`
 	SSORegion        string `kong:"help='AWS SSO Instance Region'"`
 	HistoryLimit     int64  `kong:"help='Number of items to keep in History',default=-1"`
 	HistoryMinutes   int64  `kong:"help='Number of minutes to keep items in History',default=-1"`
 	DefaultLevel     string `kong:"help='Logging level [error|warn|info|debug|trace]'"`
 	Force            bool   `kong:"help='Force override of existing config file'"`
+	FirefoxPath      string `kong:"help='Path to the Firefox web browser'"`
+	RanSetup         bool   `kong:"hidden"` // track if setup has already run
 }
 
 // Run executes the setup command
@@ -74,13 +44,16 @@ func (cc *SetupCmd) Run(ctx *RunContext) error {
 func setupWizard(ctx *RunContext) error {
 	var err error
 	var instanceName, startHostname, ssoRegion, awsRegion, urlAction string
-	var historyLimit, historyMinutes, logLevel string
+	var logLevel, firefoxBrowserPath, browser string
 	var hLimit, hMinutes int64
+	urlExecCommand := []string{}
+	firefoxOpenUrlInContainer := false
 
-	if ctx.Cli.Setup.UrlAction != "" {
-		utils.NewHandleUrl(ctx.Cli.Setup.UrlAction, "", "")
-		urlAction = ctx.Cli.Setup.UrlAction
+	// Don't run setup twice
+	if ctx.Cli.Setup.RanSetup {
+		return nil
 	}
+	ctx.Cli.Setup.RanSetup = true
 
 	if ctx.Cli.Setup.DefaultLevel != "" {
 		if err := logLevelValidate(ctx.Cli.Setup.DefaultLevel); err != nil {
@@ -88,171 +61,68 @@ func setupWizard(ctx *RunContext) error {
 		}
 	}
 
-	// Name our SSO instance
-	prompt := promptui.Prompt{
-		Label:    "SSO Instance Name (DefaultSSO)",
-		Validate: validateSSOName,
-		Default:  ctx.Cli.SSO,
-		Pointer:  promptui.PipeCursor,
-	}
-	if instanceName, err = prompt.Run(); err != nil {
+	if instanceName, err = promptSsoInstance(ctx.Cli.SSO); err != nil {
 		return err
 	}
 
-	validFQDN := false
-	for !validFQDN {
-		// Get the hostname of the AWS SSO start URL
-		prompt = promptui.Prompt{
-			Label:    "SSO Start URL Hostname (XXXXXXX.awsapps.com)",
-			Validate: validateSSOHostname,
-			Default:  ctx.Cli.Setup.SSOStartHostname,
-			Pointer:  promptui.PipeCursor,
-		}
-		if startHostname, err = prompt.Run(); err != nil {
-			return err
-		}
-		if strings.HasSuffix(startHostname, ".awsapps.com") {
-			fqdn := strings.Split(startHostname, ".")
-			startHostname = fqdn[0]
-		}
-		if _, err := net.LookupHost(fmt.Sprintf(START_FQDN_FORMAT, startHostname)); err == nil {
-			validFQDN = true
-		} else if err != nil {
-			log.Errorf("Unable to resolve %s", fmt.Sprintf(START_FQDN_FORMAT, startHostname))
-		}
-	}
-
-	// Pick our AWS SSO region
-	label := "AWS SSO Region (SSORegion)"
-	sel := promptui.Select{
-		Label:        label,
-		Items:        AvailableAwsSSORegions,
-		HideSelected: false,
-		Stdout:       &bellSkipper{},
-		Templates: &promptui.SelectTemplates{
-			Selected: fmt.Sprintf(`%s: {{ . | faint }}`, label),
-		},
-	}
-	if _, ssoRegion, err = sel.Run(); err != nil {
+	if startHostname, err = promptStartUrl(ctx.Cli.Setup.SSOStartHostname); err != nil {
 		return err
 	}
 
-	// Pick the default AWS region to use
-	defaultRegions := []string{"None"}
-	defaultRegions = append(defaultRegions, AvailableAwsRegions...)
-
-	for _, v := range defaultRegions {
-		if v == ctx.Cli.Setup.DefaultRegion {
-			awsRegion = v
-			break
-		}
+	if ssoRegion, err = promptAwsSsoRegion(ctx.Cli.Setup.SSORegion); err != nil {
+		return err
 	}
 
-	if len(awsRegion) == 0 {
-		label = "Default region for connecting to AWS (DefaultRegion)"
-		sel = promptui.Select{
-			Label:        label,
-			Items:        defaultRegions,
-			HideSelected: false,
-			Stdout:       &bellSkipper{},
-			Templates: &promptui.SelectTemplates{
-				Selected: fmt.Sprintf(`%s: {{ . | faint }}`, label),
-			},
-		}
-		if _, awsRegion, err = sel.Run(); err != nil {
-			return err
-		}
+	if awsRegion, err = promptDefaultRegion(ctx.Cli.Setup.DefaultRegion); err != nil {
+		return err
 	}
 
-	if awsRegion == "None" {
-		awsRegion = ""
+	if firefoxBrowserPath, err = promptUseFirefox(ctx.Cli.Setup.FirefoxPath); err != nil {
+		return err
 	}
 
-	// UrlAction
-	if len(urlAction) == 0 {
-		// How should we deal with URLs?  Note we don't support `exec`
-		// here since that is an "advanced" feature
-		label = "Default action to take with URLs (UrlAction)"
-		sel = promptui.Select{
-			Label:  label,
-			Items:  []string{"open", "print", "printurl", "clip"},
-			Stdout: &bellSkipper{},
-			Templates: &promptui.SelectTemplates{
-				Selected: fmt.Sprintf(`%s: {{ . | faint }}`, label),
-			},
-		}
-		if _, urlAction, err = sel.Run(); err != nil {
-			return err
-		}
-	}
-
-	// HistoryLimit
-	if ctx.Cli.Setup.HistoryLimit < 0 {
-		prompt = promptui.Prompt{
-			Label:    "Maximum number of History items to keep (HistoryLimit)",
-			Validate: validateInteger,
-			Default:  "10",
-			Pointer:  promptui.PipeCursor,
-		}
-		if historyLimit, err = prompt.Run(); err != nil {
-			return err
-		}
-		hLimit, _ = strconv.ParseInt(historyLimit, 10, 64)
-	} else {
-		hLimit = ctx.Cli.Setup.HistoryLimit
-	}
-
-	// HistoryMinutes
-	if ctx.Cli.Setup.HistoryMinutes < 0 {
-		prompt = promptui.Prompt{
-			Label:    "Number of minutes to keep items in History (HistoryMinutes)",
-			Validate: validateInteger,
-			Default:  "1440",
-			Pointer:  promptui.PipeCursor,
-		}
-		if historyMinutes, err = prompt.Run(); err != nil {
-			return err
-		}
-		hMinutes, _ = strconv.ParseInt(historyMinutes, 10, 64)
-	} else {
-		hMinutes = ctx.Cli.Setup.HistoryMinutes
-	}
-
-	// LogLevel
-	if ctx.Cli.Setup.DefaultLevel == "" {
-		logLevels := []string{
-			"error",
-			"warn",
-			"info",
-			"debug",
-			"trace",
-		}
-		label = "Log Level (LogLevel)"
-		sel = promptui.Select{
-			Label:        label,
-			Items:        logLevels,
-			HideSelected: false,
-			CursorPos:    1, // warn
-			Stdout:       &bellSkipper{},
-			Templates: &promptui.SelectTemplates{
-				Selected: fmt.Sprintf(`%s: {{ . | faint }}`, label),
-			},
-		}
-		if _, logLevel, err = sel.Run(); err != nil {
-			return err
+	if firefoxBrowserPath != "" {
+		firefoxOpenUrlInContainer = true
+		urlAction = "exec"
+		urlExecCommand = []string{
+			firefoxBrowserPath,
+			`%s`,
 		}
 	} else {
-		logLevel = ctx.Cli.Setup.DefaultLevel
+		if urlAction, err = promptUrlAction(); err != nil {
+			return err
+		}
+
+		if urlAction == "open" {
+			if browser, err = promptDefaultBrowser(ctx.Cli.Browser); err != nil {
+				return err
+			}
+		}
+	}
+
+	if hLimit, err = promptHistoryLimit(ctx.Cli.Setup.HistoryLimit); err != nil {
+		return err
+	}
+
+	if hMinutes, err = promptHistoryMinutes(ctx.Cli.Setup.HistoryMinutes); err != nil {
+		return err
+	}
+
+	if logLevel, err = promptLogLevel(ctx.Cli.Setup.DefaultLevel); err != nil {
+		return err
 	}
 
 	// write config file
 	s := sso.Settings{
-		DefaultSSO:     instanceName,
-		SSO:            map[string]*sso.SSOConfig{},
-		UrlAction:      urlAction,
-		HistoryLimit:   hLimit,
-		HistoryMinutes: hMinutes,
-		LogLevel:       logLevel,
+		DefaultSSO:                instanceName,
+		SSO:                       map[string]*sso.SSOConfig{},
+		UrlAction:                 urlAction,
+		UrlExecCommand:            urlExecCommand,
+		FirefoxOpenUrlInContainer: firefoxOpenUrlInContainer,
+		Browser:                   browser,
+		HistoryLimit:              hLimit,
+		HistoryMinutes:            hMinutes,
+		LogLevel:                  logLevel,
 	}
 	s.SSO[instanceName] = &sso.SSOConfig{
 		SSORegion:     ssoRegion,
@@ -260,39 +130,4 @@ func setupWizard(ctx *RunContext) error {
 		DefaultRegion: awsRegion,
 	}
 	return s.Save(ctx.Cli.ConfigFile, false)
-}
-
-var ssoHostnameRegexp *regexp.Regexp
-
-// validateSSOHostname verifies our SSO Start url is in the format of http://xxxxx.awsapps.com/start
-// and the FQDN is valid
-func validateSSOHostname(input string) error {
-	if ssoHostnameRegexp == nil {
-		ssoHostnameRegexp, _ = regexp.Compile(`^([a-zA-Z0-9-]+)(\.awsapps\.com)?$`)
-	}
-	if len(input) > 0 && len(input) < 64 && ssoHostnameRegexp.Match([]byte(input)) {
-		return nil
-	}
-	return fmt.Errorf("Invalid DNS hostname: %s", input)
-}
-
-var ssoNameRegexp *regexp.Regexp
-
-// validateSSOName just makes sure we have some text
-func validateSSOName(input string) error {
-	if ssoNameRegexp == nil {
-		ssoNameRegexp, _ = regexp.Compile(`^[a-zA-Z0-9]+$`)
-	}
-	if len(input) > 0 && ssoNameRegexp.Match([]byte(input)) {
-		return nil
-	}
-	return fmt.Errorf("SSO Name must be a valid string")
-}
-
-func validateInteger(input string) error {
-	_, err := strconv.ParseInt(input, 10, 64)
-	if err != nil {
-		return fmt.Errorf("Value must be a valid integer")
-	}
-	return nil
 }

--- a/cmd/setup_prompt.go
+++ b/cmd/setup_prompt.go
@@ -1,0 +1,404 @@
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2022 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"regexp"
+	"runtime"
+	"strconv"
+
+	"github.com/manifoldco/promptui"
+	"github.com/synfinatic/aws-sso-cli/utils"
+)
+
+const (
+	START_URL_FORMAT  = "https://%s.awsapps.com/start"
+	START_FQDN_FORMAT = "%s.awsapps.com"
+)
+
+// https://docs.aws.amazon.com/general/latest/gr/sso.html
+var AvailableAwsSSORegions []string = []string{
+	"us-east-1",
+	"us-east-2",
+	"us-west-2",
+	"ap-south-1",
+	"ap-northeast-2",
+	"ap-southeast-1",
+	"ap-southeast-2",
+	"ap-northeast-1",
+	"ca-central-1",
+	"eu-central-1",
+	"eu-west-1",
+	"eu-west-2",
+	"eu-west-3",
+	"eu-north-1",
+	"sa-east-1",
+	"us-gov-west-1",
+}
+
+func promptSsoInstance(defaultValue string) (string, error) {
+	var val string
+	var err error
+
+	// Name our SSO instance
+	prompt := promptui.Prompt{
+		Label:    "SSO Instance Name (DefaultSSO)",
+		Validate: validateSSOName,
+		Default:  defaultValue,
+		Pointer:  promptui.PipeCursor,
+	}
+	if val, err = prompt.Run(); err != nil {
+		return "", err
+	}
+	return val, nil
+}
+
+func promptStartUrl(defaultValue string) (string, error) {
+	var val string
+	var err error
+	validFQDN := false
+
+	for !validFQDN {
+		// Get the hostname of the AWS SSO start URL
+		prompt := promptui.Prompt{
+			Label:    "SSO Start URL Hostname (XXXXXXX.awsapps.com)",
+			Validate: validateSSOHostname,
+			Default:  defaultValue,
+			Pointer:  promptui.PipeCursor,
+		}
+		if val, err = prompt.Run(); err != nil {
+			return "", err
+		}
+
+		if _, err := net.LookupHost(fmt.Sprintf(START_FQDN_FORMAT, val)); err == nil {
+			validFQDN = true
+		} else if err != nil {
+			log.Errorf("Unable to resolve %s", fmt.Sprintf(START_FQDN_FORMAT, val))
+		}
+	}
+
+	return val, nil
+}
+
+func promptAwsSsoRegion(defaultValue string) (string, error) {
+	var val string
+	var err error
+
+	pos := 0
+	for i, v := range AvailableAwsSSORegions {
+		if v == defaultValue {
+			pos = i
+		}
+	}
+
+	// Pick our AWS SSO region
+	label := "AWS SSO Region (SSORegion)"
+	sel := promptui.Select{
+		Label:        label,
+		Items:        AvailableAwsSSORegions,
+		HideSelected: false,
+		CursorPos:    pos,
+		Stdout:       &bellSkipper{},
+		Templates: &promptui.SelectTemplates{
+			Selected: fmt.Sprintf(`%s: {{ . | faint }}`, label),
+		},
+	}
+	if _, val, err = sel.Run(); err != nil {
+		return "", err
+	}
+
+	return val, nil
+}
+
+func promptDefaultRegion(defaultValue string) (string, error) {
+	var val string
+	var err error
+
+	// Pick the default AWS region to use
+	defaultRegions := []string{"None"}
+	defaultRegions = append(defaultRegions, AvailableAwsRegions...)
+
+	for _, v := range defaultRegions {
+		if v == defaultValue {
+			return v, nil
+		}
+	}
+
+	label := "Default region for connecting to AWS (DefaultRegion)"
+	sel := promptui.Select{
+		Label:        label,
+		Items:        defaultRegions,
+		HideSelected: false,
+		Stdout:       &bellSkipper{},
+		Templates: &promptui.SelectTemplates{
+			Selected: fmt.Sprintf(`%s: {{ . | faint }}`, label),
+		},
+	}
+	if _, val, err = sel.Run(); err != nil {
+		return "", err
+	}
+
+	if val == "None" {
+		val = ""
+	}
+
+	return val, nil
+}
+
+func promptUseFirefox(defaultValue string) (string, error) {
+	var val, useFirefox string
+	var err error
+
+	label := "Use Firefox containers to open URLs?"
+	sel := promptui.Select{
+		Label:        label,
+		HideSelected: false,
+		Items:        []string{"Yes", "No"},
+		Stdout:       &bellSkipper{},
+		Templates: &promptui.SelectTemplates{
+			Selected: fmt.Sprintf(`%s: {{ . | faint }}`, label),
+		},
+	}
+	if _, useFirefox, err = sel.Run(); err != nil {
+		return "", err
+	}
+
+	if useFirefox == "Yes" {
+		fmt.Printf("Ensure that you have the 'Open external links in a container' plugin for Firefox.")
+		prompt := promptui.Prompt{
+			Label:    "Path to Firefox binary",
+			Stdout:   &bellSkipper{},
+			Default:  firefoxDefaultBrowserPath(defaultValue),
+			Pointer:  promptui.PipeCursor,
+			Validate: validateBinary,
+		}
+		if val, err = prompt.Run(); err != nil {
+			return "", err
+		}
+	}
+
+	return val, nil
+}
+
+func promptUrlAction() (string, error) {
+	var val string
+	var err error
+
+	// How should we deal with URLs?  Note we don't support `exec`
+	// here since that is an "advanced" feature
+	label := "Default action to take with URLs (UrlAction)"
+	sel := promptui.Select{
+		Label:  label,
+		Items:  []string{"open", "print", "printurl", "clip"},
+		Stdout: &bellSkipper{},
+		Templates: &promptui.SelectTemplates{
+			Selected: fmt.Sprintf(`%s: {{ . | faint }}`, label),
+		},
+	}
+	if _, val, err = sel.Run(); err != nil {
+		return "", err
+	}
+
+	return val, nil
+}
+
+func promptDefaultBrowser(defaultValue string) (string, error) {
+	var val string
+	var err error
+	override := ""
+
+	label := "Override default browser?"
+	sel := promptui.Select{
+		Label:  label,
+		Items:  []string{"No", "Yes"},
+		Stdout: &bellSkipper{},
+		Templates: &promptui.SelectTemplates{
+			Selected: fmt.Sprintf(`%s: {{ . | faint }}`, label),
+		},
+	}
+	if _, override, err = sel.Run(); err != nil {
+		return "", err
+	}
+
+	if override == "No" {
+		return "", nil
+	}
+
+	prompt := promptui.Prompt{
+		Label:    "Specify path to browser to use",
+		Default:  defaultValue,
+		Stdout:   &bellSkipper{},
+		Pointer:  promptui.PipeCursor,
+		Validate: validateBinary,
+	}
+	if val, err = prompt.Run(); err != nil {
+		return "", err
+	}
+
+	return val, nil
+}
+
+func promptHistoryLimit(defaultValue int64) (int64, error) {
+	var limit string
+	var err error
+
+	if defaultValue >= 0 {
+		return defaultValue, nil
+	}
+
+	prompt := promptui.Prompt{
+		Label:    "Maximum number of History items to keep (HistoryLimit)",
+		Validate: validateInteger,
+		Default:  fmt.Sprintf("%d", defaultValue),
+		Pointer:  promptui.PipeCursor,
+	}
+	if limit, err = prompt.Run(); err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(limit, 10, 64)
+}
+
+func promptHistoryMinutes(defaultValue int64) (int64, error) {
+	var err error
+	var minutes string
+
+	if defaultValue >= 0 {
+		return defaultValue, nil
+	}
+
+	prompt := promptui.Prompt{
+		Label:    "Number of minutes to keep items in History (HistoryMinutes)",
+		Validate: validateInteger,
+		Default:  "1440",
+		Pointer:  promptui.PipeCursor,
+	}
+	if minutes, err = prompt.Run(); err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(minutes, 10, 64)
+}
+
+func promptLogLevel(defaultValue string) (string, error) {
+	var val string
+	var err error
+
+	logLevels := []string{
+		"error",
+		"warn",
+		"info",
+		"debug",
+		"trace",
+	}
+
+	if defaultValue != "" && utils.StrListContains(defaultValue, logLevels) {
+		return defaultValue, nil
+	}
+
+	label := "Log Level (LogLevel)"
+	sel := promptui.Select{
+		Label:        label,
+		Items:        logLevels,
+		HideSelected: false,
+		CursorPos:    1, // warn
+		Stdout:       &bellSkipper{},
+		Templates: &promptui.SelectTemplates{
+			Selected: fmt.Sprintf(`%s: {{ . | faint }}`, label),
+		},
+	}
+	if _, val, err = sel.Run(); err != nil {
+		return "", err
+	}
+	return val, nil
+}
+
+func validateBinary(input string) error {
+	s, err := os.Stat(input)
+	if err != nil {
+		return err
+	}
+	switch runtime.GOOS {
+	case "windows":
+		// Windows doesn't have file permissions
+		if s.Mode().IsRegular() {
+			return nil
+		}
+	default:
+		// must be a file and user execute bit set
+		if s.Mode().IsRegular() && s.Mode().Perm()&0100 > 0 {
+			return nil
+		}
+	}
+	return fmt.Errorf("not a valid valid")
+}
+
+var ssoHostnameRegexp *regexp.Regexp
+
+// validateSSOHostname verifies our SSO Start url is in the format of http://xxxxx.awsapps.com/start
+// and the FQDN is valid
+func validateSSOHostname(input string) error {
+	if ssoHostnameRegexp == nil {
+		ssoHostnameRegexp, _ = regexp.Compile(`^([a-zA-Z0-9-]+)(\.awsapps\.com)?$`)
+	}
+	if len(input) > 0 && len(input) < 64 && ssoHostnameRegexp.Match([]byte(input)) {
+		return nil
+	}
+	return fmt.Errorf("Invalid DNS hostname: %s", input)
+}
+
+var ssoNameRegexp *regexp.Regexp
+
+// validateSSOName just makes sure we have some text
+func validateSSOName(input string) error {
+	if ssoNameRegexp == nil {
+		ssoNameRegexp, _ = regexp.Compile(`^[a-zA-Z0-9]+$`)
+	}
+	if len(input) > 0 && ssoNameRegexp.Match([]byte(input)) {
+		return nil
+	}
+	return fmt.Errorf("SSO Name must be a valid string")
+}
+
+func validateInteger(input string) error {
+	_, err := strconv.ParseInt(input, 10, 64)
+	if err != nil {
+		return fmt.Errorf("Value must be a valid integer")
+	}
+	return nil
+}
+
+// returns the default path to the firefox browser
+func firefoxDefaultBrowserPath(path string) string {
+	if len(path) != 0 {
+		return path
+	}
+
+	switch runtime.GOOS {
+	case "darwin":
+		path = "/Applications/Firefox.app/Contents/MacOS/firefox"
+	case "linux":
+		path = "/usr/bin/firefox"
+	case "windows":
+		path = "\\Program Files\\Mozilla Firefox\\firefox.exe"
+	default:
+	}
+	return path
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -221,7 +221,7 @@ UrlAction: open
 ```yaml
 # Open the AWS Console using Brave on MacOS
 UrlAction: exec
-UrlActionExec:
+UrlExecCommand:
     - open
     - -a
     - /Applications/Brave Browser.app
@@ -257,7 +257,7 @@ Example:
 ```yaml
 # Open the AWS Console in a Firefox container on MacOS
 UrlAction: exec
-UrlActionExec:
+UrlExecCommand:
     - /Applications/Firefox.app/Contents/MacOS/firefox
     - "%s"
 FirefoxOpenUrlInContainer: True


### PR DESCRIPTION
Guided setup now prompts if you want to use Firefox
containers.  If you say no, then you'll get the older
workflow for UrlAction.

Non-Firefox container workflow now prompts if you want
to use a non-default browser.

Fixes: #345