### PR TITLE
Support automatically updating ~/.aws/config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 ### New Features
 
  * Add Color and Icon support to Firefox Containers #340
+ * Auto detect new roles and auto-update ~/.aws/config #341
+ * Firefox container support is now handled by guided setup
+
+### Bug Fixes
+
+ * Fix documentation for `UrlExecCommand` config option (was listed as `UrlActionExec`)
 
 ## [v1.8.0] - 2022-04-30
 

--- a/README.md
+++ b/README.md
@@ -167,40 +167,47 @@ Priority is given to:
 
 ### config
 
-Modifies the `~/.aws/config` file to contain a profile for every role accessible
-via AWS SSO CLI.
+Modifies the `~/.aws/config` file to contain a [named profile](
+https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
+for every role accessible via AWS SSO CLI.
 
 Flags:
 
  * `--diff` -- Print a diff of changes to the config file instead of modifying it
- * `--open` -- Override how to open URls: [clip|exec|open] (required)
+ * `--open` -- Specify how to open URls: [clip|exec|open]
  * `--print` -- Print profile entries instead of modifying config file
+ * `--force` -- Write a new config file without prompting
 
-This generates a series of [named profile entries](
-https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
-in the `~/.aws/config` file which allows you to easily use any AWS SSO role
-just by setting the `$AWS_PROFILE` environment variable.  By default, each
-profile is named according to the [ProfileFormat](docs/config.md#profileformat)
-onfig option or overridden by the user defined [Profile](docs/config.md#profile)
-option on a role by role basis.
+
+By default, each profile is named according to the [ProfileFormat](
+docs/config.md#profileformat) config option or overridden by the user defined
+[Profile](docs/config.md#profile) option on a role by role basis.
 
 For each profile generated, it will specify a [list of settings](
 https://docs.aws.amazon.com/sdkref/latest/guide/settings-global.html) as defined
 by the [ConfigVariables](docs/config.md#configvariables) setting in the
 `~/.aws-sso/config.yaml`.
 
+For more information on this feature, [read the Quickstart Guide](
+docs/quickstart.md#integrating-with-the-aws-profile-variable).
+
 Unlike with other ways to use AWS SSO CLI, the AWS IAM STS credentials will
 _automatically refresh_.  This means, if you do not have a valid AWS SSO token,
 you will be prompted to authentiate via your SSO provider and subsequent
 requests to obtain new IAM STS credentials will automatically happen as needed.
 
-**Note:** Due to a limitation in the AWS tooling, `print` and `printurl` arn not
-supported with `--url-action` when using the `$AWS_PROFILE` variable with AWS
-SSO CLI.  Hence, you must use `open` or `exec` to auto-open URLs in your browser
-(recommended) or `clip` to automatically copy URLs to your clipboard.
+**Note:** Due to a limitation in the AWS tooling, `print` and `printurl` are not
+supported values for `--url-action`.  Hence, you must use `open` or `exec` to
+auto-open URLs in your browser (recommended) or `clip` to automatically copy
+URLs to your clipboard.  _No user prompting is possible._
 
 **Note:** You should run this command any time your list of AWS roles changes
-in order to update the `~/.aws/config` file.
+in order to update the `~/.aws/config` file or enable [AutoConfigCheck](
+docs/config.md#AutoConfigCheck) and [ConfigUrlAction](
+docs/config.md#ConfigUrlAction).
+
+**Note:** If `ConfigUrlAction` is set, then `--open` is optional, otherwise it
+is required.
 
 **Note:** It is important that you do _NOT_ remove the `# BEGIN_AWS_SSO_CLI` and
 `# END_AWS_SSO_CLI` lines from your config file!  These markers are used to track

--- a/cmd/cache_cmd.go
+++ b/cmd/cache_cmd.go
@@ -25,8 +25,6 @@ import (
 type CacheCmd struct{}
 
 func (cc *CacheCmd) Run(ctx *RunContext) error {
-	log.Info("Refreshing local cache...")
-
 	awssso := doAuth(ctx)
 	s, err := ctx.Settings.GetSelectedSSO(ctx.Cli.SSO)
 	if err != nil {
@@ -48,6 +46,5 @@ func (cc *CacheCmd) Run(ctx *RunContext) error {
 		return fmt.Errorf("Unable to save role cache: %s", err.Error())
 	}
 
-	log.Info("Cache has been refreshed.")
 	return nil
 }

--- a/cmd/setup_prompt.go
+++ b/cmd/setup_prompt.go
@@ -261,10 +261,6 @@ func promptHistoryLimit(defaultValue int64) (int64, error) {
 	var limit string
 	var err error
 
-	if defaultValue >= 0 {
-		return defaultValue, nil
-	}
-
 	prompt := promptui.Prompt{
 		Label:    "Maximum number of History items to keep (HistoryLimit)",
 		Validate: validateInteger,
@@ -348,6 +344,46 @@ func validateBinary(input string) error {
 		}
 	}
 	return fmt.Errorf("not a valid valid")
+}
+
+func promptAutoConfigCheck(flag bool, action string) (bool, string, error) {
+	var val string
+	var err error
+
+	label := fmt.Sprintf("Auto update %s (AutoConfigCheck)", utils.GetHomePath("~/.aws.config"))
+	sel := promptui.Select{
+		Label:        label,
+		Items:        []string{"Yes", "No"},
+		HideSelected: false,
+		Stdout:       &bellSkipper{},
+		Templates: &promptui.SelectTemplates{
+			Selected: fmt.Sprintf(`%s: {{ . | faint }}`, label),
+		},
+	}
+	if _, val, err = sel.Run(); err != nil {
+		return false, "", err
+	}
+
+	if val == "No" {
+		return false, "", nil
+	}
+
+	label = "How to open URLs via $AWS_PROFILE (ConfigUrlAction)"
+	sel = promptui.Select{
+		Label:        label,
+		Items:        VALID_CONIFG_OPEN,
+		HideSelected: false,
+		Stdout:       &bellSkipper{},
+		Templates: &promptui.SelectTemplates{
+			Selected: fmt.Sprintf(`%s: {{ . | faint }}`, label),
+		},
+	}
+
+	if _, val, err = sel.Run(); err != nil {
+		return false, "", err
+	}
+
+	return true, val, nil
 }
 
 var ssoHostnameRegexp *regexp.Regexp

--- a/docs/config.md
+++ b/docs/config.md
@@ -34,12 +34,15 @@ DefaultSSO: <name of AWS SSO>
 
 Browser: <path to web browser>
 UrlAction: [clip|exec|print|printurl|open]
-UrlActionExec:
+UrlExecCommand:
     - <command>
     - <arg 1>
     - <arg N>
     - "%s"
 FirefoxOpenInContainer: [False|True]
+AutoConfigCheck: [False|True]
+ConfigUrlAction: [clip|exec|open]
+
 ConsoleDuration: <minutes>
 
 LogLevel: [error|warn|info|debug|trace]
@@ -191,13 +194,13 @@ If you only have a single AWS SSO instance, then it doesn't really matter what y
 but if you have two or more, than `Default` is automatically selected unless you manually
 specify it here, on the CLI (`--sso`), or via the `AWS_SSO` environment variable.
 
-## Browser / UrlAction / UrlActionExec
+## Browser / UrlAction / UrlExecCommand
 
 
 `UrlAction` gives you control over how AWS SSO and AWS Console URLs are opened in a browser:
 
  * `clip` -- Copies the URL to your clipboard
- * `exec` -- Execute the command provided in `UrlActionExec`
+ * `exec` -- Execute the command provided in `UrlExecCommand`
  * `open` -- Opens the URL in your default browser or the browser you specified via `--browser` or `Browser`
  * `print` -- Prints the URL with a message in your terminal to stderr
  * `printurl` -- Prints only the URL in your terminal to stderr
@@ -205,7 +208,7 @@ specify it here, on the CLI (`--sso`), or via the `AWS_SSO` environment variable
 If `Browser` is not set, then your default browser will be used and that
 your browser needs to support JavaScript for the AWS SSO user interface.
 
-`UrlActionExec` is used with `UrlAction: exec` and allows you to execute arbitrary
+`UrlExecCommand` is used with `UrlAction: exec` and allows you to execute arbitrary
 commands to handle the URL.  The command and arguments should be specified as a list,
 with the URL to open specified as the format string `%s`.  Only one instance
 of `%s` is allowed.  Note that YAML requires quotes around strings which start
@@ -262,6 +265,20 @@ UrlExecCommand:
     - "%s"
 FirefoxOpenUrlInContainer: True
 ```
+
+## AutoConfigCheck / ConfigUrlAction
+
+These two options when used together enable automatically updating your `~/.aws/config` file
+any time your list of AWS SSO roles change.
+
+When `AutoConfigCheck` must be set to `True` and `ConfigUrlAction` must be set to one of:
+
+ * `clip`
+ * `exec`
+ * `open`
+
+to enable the feature.  You can disable this feature on the command line via the `--no-config-check`
+flag.  `ConfigUrlAction` is also the default action when manually running `aws-sso config`.
 
 ## LogLevel / LogLines
 

--- a/sso/settings.go
+++ b/sso/settings.go
@@ -65,6 +65,8 @@ type Settings struct {
 	ConfigVariables           map[string]interface{} `koanf:"ConfigVariables" yaml:"ConfigVariables,omitempty"`
 	EnvVarTags                []string               `koanf:"EnvVarTags" yaml:"EnvVarTags,omitempty"`
 	FirefoxOpenUrlInContainer bool                   `koanf:"FirefoxOpenUrlInContainer" yaml:"FirefoxOpenUrlInContainer"`
+	AutoConfigCheck           bool                   `koanf:"AutoConfigCheck" yaml:"AutoConfigCheck"`
+	ConfigUrlAction           string                 `koanf:"ConfigUrlAction" yaml:"ConfigUrlAction"`
 }
 
 type SSOConfig struct {


### PR DESCRIPTION
In the past you had to remember to manually run `config`, but now
we can auto-detect changes when the cache is updated.

Fixes: #345