### PR TITLE
Users can now set CacheRefresh in the config

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -88,6 +88,7 @@ var DEFAULT_CONFIG map[string]interface{} = map[string]interface{}{
 	"AutoConfigCheck":                           false,
 	"ConfigUrlAction":                           "",
 	"ProfileFormat":                             `{{ .AccountId }}_{{ .RoleName }}`,
+	"CacheRefresh":                              24, // in hours
 }
 
 type CLI struct {

--- a/cmd/setup_cmd.go
+++ b/cmd/setup_cmd.go
@@ -28,6 +28,7 @@ type SetupCmd struct {
 	DefaultRegion    string `kong:"help='Default AWS region for running commands (or \"None\")'"`
 	SSOStartHostname string `kong:"help='AWS SSO User Portal Hostname'"`
 	SSORegion        string `kong:"help='AWS SSO Instance Region'"`
+	CacheRefresh     int64  `kong:"help='Number of hours between AWS SSO cache is refreshed'"`
 	HistoryLimit     int64  `kong:"help='Number of items to keep in History',default=-1"`
 	HistoryMinutes   int64  `kong:"help='Number of minutes to keep items in History',default=-1"`
 	DefaultLevel     string `kong:"help='Logging level [error|warn|info|debug|trace]'"`
@@ -47,7 +48,7 @@ func setupWizard(ctx *RunContext) error {
 	var err error
 	var instanceName, startHostname, ssoRegion, awsRegion, urlAction string
 	var logLevel, firefoxBrowserPath, browser, configUrlAction string
-	var hLimit, hMinutes int64
+	var hLimit, hMinutes, cacheRefresh int64
 	var autoConfigCheck bool
 	urlExecCommand := []string{}
 	firefoxOpenUrlInContainer := false
@@ -73,6 +74,10 @@ func setupWizard(ctx *RunContext) error {
 	}
 
 	if ssoRegion, err = promptAwsSsoRegion(ctx.Cli.Setup.SSORegion); err != nil {
+		return err
+	}
+
+	if cacheRefresh, err = promptCacheRefresh(ctx.Cli.Setup.CacheRefresh); err != nil {
 		return err
 	}
 
@@ -124,6 +129,7 @@ func setupWizard(ctx *RunContext) error {
 	s := sso.Settings{
 		DefaultSSO:                instanceName,
 		SSO:                       map[string]*sso.SSOConfig{},
+		CacheRefresh:              cacheRefresh,
 		UrlAction:                 urlAction,
 		UrlExecCommand:            urlExecCommand,
 		FirefoxOpenUrlInContainer: firefoxOpenUrlInContainer,

--- a/cmd/setup_prompt.go
+++ b/cmd/setup_prompt.go
@@ -129,6 +129,22 @@ func promptAwsSsoRegion(defaultValue string) (string, error) {
 	return val, nil
 }
 
+func promptCacheRefresh(defaultValue int64) (int64, error) {
+	var val string
+	var err error
+
+	prompt := promptui.Prompt{
+		Label:    "Number of hours between refreshing AWS SSO cache (0 to disable)",
+		Validate: validateInteger,
+		Default:  fmt.Sprintf("%d", defaultValue),
+		Pointer:  promptui.PipeCursor,
+	}
+	if val, err = prompt.Run(); err != nil {
+		return 0, err
+	}
+	return strconv.ParseInt(val, 10, 64)
+}
+
 func promptDefaultRegion(defaultValue string) (string, error) {
 	var val string
 	var err error

--- a/docs/config.md
+++ b/docs/config.md
@@ -34,6 +34,7 @@ SSOConfig:
 # See description below for these options
 DefaultRegion: <AWS_DEFAULT_REGION>
 DefaultSSO: <name of AWS SSO>
+CacheRefresh: <hours>
 
 Browser: <path to web browser>
 UrlAction: [clip|exec|print|printurl|open]
@@ -198,6 +199,12 @@ in order to assume a role with `Via`.
 If you only have a single AWS SSO instance, then it doesn't really matter what you call it,
 but if you have two or more, than `Default` is automatically selected unless you manually
 specify it here, on the CLI (`--sso`), or via the `AWS_SSO` environment variable.
+
+## CacheRefresh
+
+This is the number of hours between automatically refreshing your AWS SSO cache to detect
+any changes in the roles you have been granted access to.  The default is 24 (1 day).  Disable
+this feature by setting to any value <= 0.
 
 ## Browser / UrlAction / UrlExecCommand
 

--- a/sso/cache.go
+++ b/sso/cache.go
@@ -102,8 +102,14 @@ func (c *Cache) Expired(s *SSOConfig) error {
 		return fmt.Errorf("Local cache is out of date; current cache version %d is less than %d", c.Version, CACHE_VERSION)
 	}
 
+	// negative values disable refresh
+	if s.settings.CacheRefresh <= 0 {
+		return nil
+	}
+
+	ttl := s.settings.CacheRefresh * 60 * 60 // convert hours to seconds
 	cache := c.GetSSO()
-	if cache.LastUpdate+CACHE_TTL < time.Now().Unix() {
+	if cache.LastUpdate+ttl < time.Now().Unix() {
 		return fmt.Errorf("Local cache is out of date; TTL has been exceeded.")
 	}
 

--- a/sso/cache_test.go
+++ b/sso/cache_test.go
@@ -329,7 +329,14 @@ func (suite *CacheTestSuite) TestDeleteOldHistory() {
 
 func (suite *CacheTestSuite) TestExpired() {
 	t := suite.T()
-	assert.Error(t, suite.cache.Expired(nil))
+	s := SSOConfig{
+		settings: &Settings{
+			CacheRefresh: 24,
+		},
+	}
+	assert.Error(t, suite.cache.Expired(&s))
+	s.settings.CacheRefresh = 0
+	assert.NoError(t, suite.cache.Expired(&s))
 }
 
 func (suite *CacheTestSuite) TestGetRole() {

--- a/sso/settings.go
+++ b/sso/settings.go
@@ -38,7 +38,6 @@ import (
 
 const (
 	AWS_SSO_SESSION_EXPIRATION_FORMAT = "2006-01-02 15:04:05 -0700 MST"
-	CACHE_TTL                         = 60 * 60 * 24 // 1 day in seconds
 )
 
 type Settings struct {
@@ -67,6 +66,7 @@ type Settings struct {
 	FirefoxOpenUrlInContainer bool                   `koanf:"FirefoxOpenUrlInContainer" yaml:"FirefoxOpenUrlInContainer"`
 	AutoConfigCheck           bool                   `koanf:"AutoConfigCheck" yaml:"AutoConfigCheck"`
 	ConfigUrlAction           string                 `koanf:"ConfigUrlAction" yaml:"ConfigUrlAction"`
+	CacheRefresh              int64                  `koanf:"CacheRefresh" yaml:"CacheRefresh"`
 }
 
 type SSOConfig struct {


### PR DESCRIPTION
This controls how often we will automatically refresh
the AWS SSO cache with all the roles.  Default is still 24hrs.

Fixes: #355