### PR TITLE
fix double block markers in config file

### DIFF
--- a/cmd/config_cmd.go
+++ b/cmd/config_cmd.go
@@ -27,14 +27,11 @@ import (
 
 const (
 	AWS_CONFIG_FILE = "~/.aws/config"
-	CONFIG_TEMPLATE = `# BEGIN_AWS_SSO_CLI
-{{ range $sso, $struct := . }}{{ range $arn, $profile := $struct }}
+	CONFIG_TEMPLATE = `{{range $sso, $struct := . }}{{ range $arn, $profile := $struct }}
 [profile {{ $profile.Profile }}]
 credential_process = {{ $profile.BinaryPath }} -u {{ $profile.Open }} -S "{{ $profile.Sso }}" process --arn {{ $profile.Arn }}
 {{ range $key, $value := $profile.ConfigVariables }}{{ $key }} = {{ $value }}
-{{end}}{{end}}{{end}}
-# END_AWS_SSO_CLI
-`
+{{end}}{{end}}{{end}}`
 )
 
 var VALID_CONFIG_OPEN []string = []string{

--- a/internal/utils/fileedit.go
+++ b/internal/utils/fileedit.go
@@ -35,7 +35,7 @@ import (
 const (
 	CONFIG_PREFIX = "# BEGIN_AWS_SSO_CLI"
 	CONFIG_SUFFIX = "# END_AWS_SSO_CLI"
-	FILE_TEMPLATE = "%s\n\n%s\n\n%s\n"
+	FILE_TEMPLATE = "%s\n%s\n%s\n"
 )
 
 type FileEdit struct {


### PR DESCRIPTION
The template for .aws/config shouldn't also include the
markers.  Also to reduce extra blank lines, remove \n's from
the format string in file edit