### PR TITLE
update to gotable v0.0.3 for fixed CSV support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/stretchr/testify v1.7.1
-	github.com/synfinatic/gotable v0.0.2
+	github.com/synfinatic/gotable v0.0.3
 	github.com/willabides/kongplete v0.2.0
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
 )

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/synfinatic/gotable v0.0.2 h1:hKS83dW8IcdAMkwK08/Z3iMoZ468pv/zI6mJQ9uYRvs=
-github.com/synfinatic/gotable v0.0.2/go.mod h1:kWXD1bxZY6tyu6tWK3CIbGAOrtF7teg0ZQotUMDvoMw=
+github.com/synfinatic/gotable v0.0.3 h1:KI01OLECmOv7laXVNtw6T4kEHue09z9OuQwtNB8D5Mw=
+github.com/synfinatic/gotable v0.0.3/go.mod h1:kWXD1bxZY6tyu6tWK3CIbGAOrtF7teg0ZQotUMDvoMw=
 github.com/willabides/kongplete v0.2.0 h1:C6wYVn+IPyA8rAGRGLLkuxhhSQTEECX4t8u3gi+fuD0=
 github.com/willabides/kongplete v0.2.0/go.mod h1:kFVw+PkQsqkV7O4tfIBo6iJ9qY94PJC8sPfMgFG5AdM=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
old version of gotable didn't escape commas

Fixes: #371