### PR TITLE
Use Firefox Containers for awssso login workflow

### DIFF
--- a/cmd/console_cmd.go
+++ b/cmd/console_cmd.go
@@ -42,35 +42,6 @@ import (
 
 const AWS_FEDERATED_URL = "https://signin.aws.amazon.com/federation"
 
-// taken from https://github.com/honsiorovskyi/open-url-in-container/blob/1.0.3/launcher.sh
-var FIREFOX_PLUGIN_COLORS []string = []string{
-	"blue",
-	"turquoise",
-	"green",
-	"yellow",
-	"orange",
-	"red",
-	"pink",
-	"purple",
-	// "toolbar",  not a valid input, even if it is user selectable
-}
-
-var FIREFOX_PLUGIN_ICONS []string = []string{
-	"fingerprint",
-	"briefcase",
-	"dollar",
-	"cart",
-	"gift",
-	"vacation",
-	"food",
-	"fruit",
-	"pet",
-	"tree",
-	"chill",
-	"circle",
-	// "fence",  not a valid input, even if it is user selectable
-}
-
 type ConsoleCmd struct {
 	// Console actually should honor the --region flag
 	Region   string `kong:"help='AWS Region',env='AWS_DEFAULT_REGION',predictor='region'"`
@@ -364,27 +335,11 @@ func firefoxContainerUrl(ctx *RunContext, accountId int64, role, awsUrl string) 
 	if err != nil && strings.Contains(profile, "&") {
 		profile = fmt.Sprintf("%d:%s", accountId, role)
 	}
-	prefix := fmt.Sprintf("ext+container:name=%s", profile)
 
-	// Firefox Open URL in Container plugin supports color & icon
-	if v, ok := rFlat.Tags["Color"]; ok {
-		if utils.StrListContains(v, FIREFOX_PLUGIN_COLORS) {
-			prefix = fmt.Sprintf("%s&color=%s", prefix, v)
-		} else {
-			log.Errorf("Invalid tag value: Color: %s", v)
-		}
-	}
+	color := rFlat.Tags["Color"]
+	icon := rFlat.Tags["Icon"]
 
-	if v, ok := rFlat.Tags["Icon"]; ok {
-		if utils.StrListContains(v, FIREFOX_PLUGIN_ICONS) {
-			prefix = fmt.Sprintf("%s&icon=%s", prefix, v)
-		} else {
-			log.Errorf("Invalid tag value: Icon: %s", v)
-		}
-	}
-
-	// docs don't say it, but you have to URL escape the url value
-	return fmt.Sprintf("%s&url=%s", prefix, url.QueryEscape(awsUrl))
+	return utils.FirefoxContainerUrl(awsUrl, profile, color, icon)
 }
 
 type LoginResponse struct {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -320,8 +320,8 @@ func doAuth(ctx *RunContext) *sso.AWSSSO {
 		log.WithError(err).Fatalf("Unable to authenticate")
 	}
 	if err = ctx.Settings.Cache.Expired(s); err != nil {
-		log.Infof("Refreshing AWS SSO role cache, please wait...")
 		ssoName, err := ctx.Settings.GetSelectedSSOName(ctx.Cli.SSO)
+		log.Infof("Refreshing AWS SSO role cache for %s, please wait...", ssoName)
 		if err != nil {
 			log.Fatalf(err.Error())
 		}

--- a/internal/utils/url.go
+++ b/internal/utils/url.go
@@ -1,0 +1,210 @@
+package utils
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2022 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/atotto/clipboard"
+	"github.com/skratchdot/open-golang/open" // default opener
+)
+
+// taken from https://github.com/honsiorovskyi/open-url-in-container/blob/1.0.3/launcher.sh
+var FIREFOX_PLUGIN_COLORS []string = []string{
+	"blue",
+	"turquoise",
+	"green",
+	"yellow",
+	"orange",
+	"red",
+	"pink",
+	"purple",
+	// "toolbar",  not a valid input, even if it is user selectable
+}
+
+var FIREFOX_PLUGIN_ICONS []string = []string{
+	"fingerprint",
+	"briefcase",
+	"dollar",
+	"cart",
+	"gift",
+	"vacation",
+	"food",
+	"fruit",
+	"pet",
+	"tree",
+	"chill",
+	"circle",
+	// "fence",  not a valid input, even if it is user selectable
+}
+
+const FIREFOX_CONTAINER_FORMAT = "ext+container:name=%s&url=%s&color=%s&icon=%s"
+
+// FirefoxContainerUrl generates a URL for Firefox Containers
+func FirefoxContainerUrl(target, name, color, icon string) string {
+	if !StrListContains(color, FIREFOX_PLUGIN_COLORS) {
+		log.Warnf("Invalid Firefox Container color: %s", color)
+		color = FIREFOX_PLUGIN_COLORS[0]
+	}
+
+	if !StrListContains(icon, FIREFOX_PLUGIN_ICONS) {
+		log.Warnf("Invalid Firefox Container icon: %s", icon)
+		icon = FIREFOX_PLUGIN_ICONS[0]
+	}
+
+	return fmt.Sprintf(FIREFOX_CONTAINER_FORMAT, name, url.QueryEscape(target), color, icon)
+}
+
+var printWriter io.Writer = os.Stderr
+
+func execWithUrl(command interface{}, url string) error {
+	var cmd *exec.Cmd
+	var cmdStr string
+
+	switch command.(type) {
+	case []interface{}:
+		program := ""
+		x := []string{}
+		for _, iface := range command.([]interface{}) {
+			v := iface.(string)
+			if strings.Contains(v, "%s") {
+				if program == "" {
+					program = fmt.Sprintf(v, url)
+				} else {
+					x = append(x, fmt.Sprintf(v, url))
+				}
+			} else {
+				if program == "" {
+					program = v
+				} else {
+					x = append(x, v)
+				}
+			}
+		}
+		cmdStr = fmt.Sprintf("%s %s", program, strings.Join(x, " "))
+		log.Debugf("exec command as array: %s", cmdStr)
+		cmd = exec.Command(program, x...)
+	default:
+		return fmt.Errorf("Invalid UrlExecCommand type: %v", command)
+	}
+
+	//	var stderr bytes.Buffer
+	//	cmd.Stderr = &stderr
+	err := cmd.Start()
+	if err != nil {
+		err = fmt.Errorf("Unable to exec `%s`: %s", cmdStr, err)
+	}
+	log.Debugf("Opened our URL with %s", command.([]interface{})[0])
+	return err
+}
+
+// these types & variables make our code easier to unit test
+type urlOpenerFunc func(string) error
+type urlOpenerWithFunc func(string, string) error
+type clipboardWriterFunc func(string) error
+
+var urlOpener urlOpenerFunc = open.Run
+var urlOpenerWith urlOpenerWithFunc = open.RunWith
+var clipboardWriter clipboardWriterFunc = clipboard.WriteAll
+
+type UrlAction int
+
+const (
+	UrlActionClip     UrlAction = iota // copy to clipboard
+	UrlActionPrint                     // print message & url to stderr
+	UrlActionPrintUrl                  // print only the  url to stderr
+	UrlActionExec                      // Exec comand
+	UrlActionOpen                      // auto-open in default or specified browser
+)
+
+type HandleUrl struct {
+	Action  UrlAction
+	ExecCmd interface{}
+	Browser string
+	Url     string
+	PreMsg  string
+	PostMsg string
+}
+
+func NewHandleUrl(action, browser string, command interface{}) *HandleUrl {
+	var a UrlAction
+
+	switch action {
+	case "clip":
+		a = UrlActionClip
+	case "print":
+		a = UrlActionPrint
+	case "printurl":
+		a = UrlActionPrintUrl
+	case "exec":
+		a = UrlActionExec
+	case "open":
+		a = UrlActionOpen
+	default:
+		log.Panicf("invalid --url-action: %s", action)
+	}
+
+	h := &HandleUrl{
+		Action:  a,
+		Browser: browser,
+		ExecCmd: command,
+	}
+	return h
+}
+
+// Prints, opens or copies to clipboard the given URL
+func (h *HandleUrl) Open(url, pre, post string) error {
+	var err error
+	switch h.Action {
+	case UrlActionClip:
+		err = clipboardWriter(url)
+		if err == nil {
+			log.Infof("Please open URL copied to clipboard.\n")
+		} else {
+			err = fmt.Errorf("Unable to copy URL to clipboard: %s", err.Error())
+		}
+	case UrlActionExec:
+		err = execWithUrl(h.ExecCmd, url)
+	case UrlActionPrint:
+		fmt.Fprintf(printWriter, "%s%s%s", pre, url, post)
+	case UrlActionPrintUrl:
+		fmt.Fprintf(printWriter, "%s\n", url)
+	case UrlActionOpen:
+		var browser string
+		switch h.Browser {
+		case "":
+			err = urlOpener(url)
+			browser = "default browser"
+		default:
+			err = urlOpenerWith(url, h.Browser)
+		}
+		if err != nil {
+			err = fmt.Errorf("Unable to open URL with %s: %s", browser, err.Error())
+		} else {
+			log.Infof("Opening URL in %s.\n", browser)
+		}
+	}
+
+	return err
+}

--- a/internal/utils/url_test.go
+++ b/internal/utils/url_test.go
@@ -1,0 +1,143 @@
+package utils
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2022 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var checkValue string
+var checkBrowser string
+
+func testUrlOpener(url string) error {
+	checkBrowser = "default browser"
+	checkValue = url
+	return nil
+}
+
+func testUrlOpenerWith(url, browser string) error {
+	checkBrowser = browser
+	checkValue = url
+	return nil
+}
+
+func testClipboardWriter(url string) error {
+	checkValue = url
+	return nil
+}
+
+func testUrlOpenerError(url string) error {
+	return fmt.Errorf("there was an error")
+}
+
+func testUrlOpenerWithError(url, browser string) error {
+	return fmt.Errorf("there was an error")
+}
+
+func (suite *UtilsTestSuite) TestHandleUrl() {
+	t := suite.T()
+
+	assert.Panics(t, func() { NewHandleUrl("foo", "browser", "") })
+
+	// override the print method
+	printWriter = new(bytes.Buffer)
+	h := NewHandleUrl("print", "browser", "")
+	assert.NotNil(t, h)
+	assert.NoError(t, h.Open("bar", "pre", "post"))
+	assert.Equal(t, "prebarpost", printWriter.(*bytes.Buffer).String())
+
+	// new print method for printurl
+	printWriter = new(bytes.Buffer)
+	h = NewHandleUrl("printurl", "browser", "")
+	assert.NotNil(t, h)
+	assert.NoError(t, h.Open("bar", "pre", "post"))
+	assert.Equal(t, "bar\n", printWriter.(*bytes.Buffer).String())
+
+	// Clipboard tests
+	urlOpener = testUrlOpener
+	urlOpenerWith = testUrlOpenerWith
+	clipboardWriter = testClipboardWriter
+
+	h = NewHandleUrl("clip", "browser", "")
+	assert.NotNil(t, h)
+	assert.NoError(t, h.Open("url", "pre", "post"))
+	assert.Equal(t, "url", checkValue)
+
+	h = NewHandleUrl("open", "other-browser", "")
+	assert.NotNil(t, h)
+	assert.NoError(t, h.Open("other-url", "pre", "post"))
+	assert.Equal(t, "other-browser", checkBrowser)
+	assert.Equal(t, "other-url", checkValue)
+
+	h = NewHandleUrl("open", "", "")
+	assert.NotNil(t, h)
+	assert.NoError(t, h.Open("some-url", "pre", "post"))
+	assert.Equal(t, "default browser", checkBrowser)
+	assert.Equal(t, "some-url", checkValue)
+
+	urlOpener = testUrlOpenerError
+	assert.Error(t, h.Open("url", "pre", "post"))
+
+	urlOpenerWith = testUrlOpenerWithError
+	h = NewHandleUrl("open", "foo", "")
+	assert.NotNil(t, h)
+	assert.Error(t, h.Open("url", "pre", "post"))
+
+	clipboardWriter = testUrlOpenerError
+	h = NewHandleUrl("clip", "", "")
+	assert.NotNil(t, h)
+	assert.Error(t, h.Open("url", "pre", "post"))
+
+	// Exec tests
+	h = NewHandleUrl("exec", "", []interface{}{"echo", "foo", "%s"})
+	assert.NotNil(t, h)
+	assert.NoError(t, h.Open("url", "pre", "post"))
+
+	h = NewHandleUrl("exec", "", []interface{}{"%s"})
+	assert.NotNil(t, h)
+	assert.NoError(t, h.Open("sh", "pre", "post"))
+
+	h = NewHandleUrl("exec", "", []interface{}{"/dev/null", "%s"})
+	assert.NotNil(t, h)
+	assert.Error(t, h.Open("url", "pre", "post"))
+
+	h = NewHandleUrl("exec", "", []interface{}{"/dev/null"})
+	assert.NotNil(t, h)
+	assert.Error(t, h.Open("url", "pre", "post"))
+
+	h = NewHandleUrl("exec", "", []interface{}{"%s"})
+	assert.NotNil(t, h)
+	assert.Error(t, h.Open("url", "pre", "post"))
+
+	h = NewHandleUrl("exec", "", "")
+	assert.NotNil(t, h)
+	assert.Error(t, h.Open("url", "pre", "post"))
+}
+
+func TestFirefoxContainersUrl(t *testing.T) {
+	assert.Equal(t, "ext+container:name=Test&url=https%3A%2F%2Fsynfin.net&color=blue&icon=fingerprint",
+		FirefoxContainerUrl("https://synfin.net", "Test", "blue", "fingerprint"))
+
+	assert.Equal(t, "ext+container:name=Test&url=https%3A%2F%2Fsynfin.net&color=blue&icon=fingerprint",
+		FirefoxContainerUrl("https://synfin.net", "Test", "Bad", "Value"))
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -19,7 +19,6 @@ package utils
  */
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -192,114 +191,6 @@ func (suite *UtilsTestSuite) TestAccountToInt64() {
 
 	_, err = AccountIdToInt64("-1")
 	assert.Error(t, err)
-}
-
-var checkValue string
-var checkBrowser string
-
-func testUrlOpener(url string) error {
-	checkBrowser = "default browser"
-	checkValue = url
-	return nil
-}
-
-func testUrlOpenerWith(url, browser string) error {
-	checkBrowser = browser
-	checkValue = url
-	return nil
-}
-
-func testClipboardWriter(url string) error {
-	checkValue = url
-	return nil
-}
-
-func testUrlOpenerError(url string) error {
-	return fmt.Errorf("there was an error")
-}
-
-func testUrlOpenerWithError(url, browser string) error {
-	return fmt.Errorf("there was an error")
-}
-
-func (suite *UtilsTestSuite) TestHandleUrl() {
-	t := suite.T()
-
-	assert.Panics(t, func() { NewHandleUrl("foo", "browser", "") })
-
-	// override the print method
-	printWriter = new(bytes.Buffer)
-	h := NewHandleUrl("print", "browser", "")
-	assert.NotNil(t, h)
-	assert.NoError(t, h.Open("bar", "pre", "post"))
-	assert.Equal(t, "prebarpost", printWriter.(*bytes.Buffer).String())
-
-	// new print method for printurl
-	printWriter = new(bytes.Buffer)
-	h = NewHandleUrl("printurl", "browser", "")
-	assert.NotNil(t, h)
-	assert.NoError(t, h.Open("bar", "pre", "post"))
-	assert.Equal(t, "bar\n", printWriter.(*bytes.Buffer).String())
-
-	// Clipboard tests
-	urlOpener = testUrlOpener
-	urlOpenerWith = testUrlOpenerWith
-	clipboardWriter = testClipboardWriter
-
-	h = NewHandleUrl("clip", "browser", "")
-	assert.NotNil(t, h)
-	assert.NoError(t, h.Open("url", "pre", "post"))
-	assert.Equal(t, "url", checkValue)
-
-	h = NewHandleUrl("open", "other-browser", "")
-	assert.NotNil(t, h)
-	assert.NoError(t, h.Open("other-url", "pre", "post"))
-	assert.Equal(t, "other-browser", checkBrowser)
-	assert.Equal(t, "other-url", checkValue)
-
-	h = NewHandleUrl("open", "", "")
-	assert.NotNil(t, h)
-	assert.NoError(t, h.Open("some-url", "pre", "post"))
-	assert.Equal(t, "default browser", checkBrowser)
-	assert.Equal(t, "some-url", checkValue)
-
-	urlOpener = testUrlOpenerError
-	assert.Error(t, h.Open("url", "pre", "post"))
-
-	urlOpenerWith = testUrlOpenerWithError
-	h = NewHandleUrl("open", "foo", "")
-	assert.NotNil(t, h)
-	assert.Error(t, h.Open("url", "pre", "post"))
-
-	clipboardWriter = testUrlOpenerError
-	h = NewHandleUrl("clip", "", "")
-	assert.NotNil(t, h)
-	assert.Error(t, h.Open("url", "pre", "post"))
-
-	// Exec tests
-	h = NewHandleUrl("exec", "", []interface{}{"echo", "foo", "%s"})
-	assert.NotNil(t, h)
-	assert.NoError(t, h.Open("url", "pre", "post"))
-
-	h = NewHandleUrl("exec", "", []interface{}{"%s"})
-	assert.NotNil(t, h)
-	assert.NoError(t, h.Open("sh", "pre", "post"))
-
-	h = NewHandleUrl("exec", "", []interface{}{"/dev/null", "%s"})
-	assert.NotNil(t, h)
-	assert.Error(t, h.Open("url", "pre", "post"))
-
-	h = NewHandleUrl("exec", "", []interface{}{"/dev/null"})
-	assert.NotNil(t, h)
-	assert.Error(t, h.Open("url", "pre", "post"))
-
-	h = NewHandleUrl("exec", "", []interface{}{"%s"})
-	assert.NotNil(t, h)
-	assert.Error(t, h.Open("url", "pre", "post"))
-
-	h = NewHandleUrl("exec", "", "")
-	assert.NotNil(t, h)
-	assert.Error(t, h.Open("url", "pre", "post"))
 }
 
 func (suite *UtilsTestSuite) TestParseTimeString() {

--- a/sso/awssso.go
+++ b/sso/awssso.go
@@ -88,7 +88,7 @@ func NewAWSSSO(s *SSOConfig, store *storage.SecureStorage) *AWSSSO {
 		ClientType:     awsSSOClientType,
 		SsoRegion:      s.SSORegion,
 		StartUrl:       s.StartUrl,
-		Roles:          map[string][]RoleInfo{},
+		Roles:          map[string][]RoleInfo{}, // key is AccountId
 		SSOConfig:      s,
 		urlAction:      s.settings.UrlAction,
 		browser:        s.settings.Browser,

--- a/sso/awssso_auth_test.go
+++ b/sso/awssso_auth_test.go
@@ -95,6 +95,9 @@ func TestStoreKey(t *testing.T) {
 		key:       "atest",
 		SsoRegion: "us-west-1",
 		StartUrl:  "https://testing.awsapps.com/start",
+		SSOConfig: &SSOConfig{
+			settings: &Settings{},
+		},
 	}
 
 	assert.Equal(t, "atest", as.StoreKey())
@@ -113,6 +116,9 @@ func TestAuthenticateSteps(t *testing.T) {
 		SsoRegion: "us-west-1",
 		StartUrl:  "https://testing.awsapps.com/start",
 		store:     jstore,
+		SSOConfig: &SSOConfig{
+			settings: &Settings{},
+		},
 	}
 
 	as.ssooidc = &mockSsoOidcAPI{
@@ -190,6 +196,9 @@ func TestAuthenticate(t *testing.T) {
 		SsoRegion: "us-west-1",
 		StartUrl:  "https://testing.awsapps.com/start",
 		store:     jstore,
+		SSOConfig: &SSOConfig{
+			settings: &Settings{},
+		},
 	}
 
 	secs, _ := time.ParseDuration("5s")
@@ -262,6 +271,9 @@ func TestAuthenticateFailure(t *testing.T) {
 		SsoRegion: "us-west-1",
 		StartUrl:  "https://testing.awsapps.com/start",
 		store:     jstore,
+		SSOConfig: &SSOConfig{
+			settings: &Settings{},
+		},
 	}
 
 	secs, _ := time.ParseDuration("5s")
@@ -361,6 +373,9 @@ func TestReauthenticate(t *testing.T) {
 		urlAction:      "invalid",
 		browser:        "no-such-browser",
 		urlExecCommand: []interface{}{"/dev/null"},
+		SSOConfig: &SSOConfig{
+			settings: &Settings{},
+		},
 	}
 
 	secs, _ := time.ParseDuration("5s")

--- a/sso/awssso_test.go
+++ b/sso/awssso_test.go
@@ -141,6 +141,7 @@ func TestGetRoles(t *testing.T) {
 		Roles:     map[string][]RoleInfo{},
 		SSOConfig: &SSOConfig{
 			Accounts: map[string]*SSOAccount{},
+			settings: &Settings{},
 		},
 		urlAction: "print",
 		Token: storage.CreateTokenResponse{
@@ -336,6 +337,7 @@ func TestGetRoles(t *testing.T) {
 	as.Roles = map[string][]RoleInfo{} // flush cache
 	as.SSOConfig = &SSOConfig{
 		Accounts: map[string]*SSOAccount{},
+		settings: &Settings{},
 	}
 	as.ssooidc = &mockSsoOidcAPI{
 		Results: []mockSsoOidcAPIResults{
@@ -410,7 +412,9 @@ func TestGetAccounts(t *testing.T) {
 		StartUrl:  "https://testing.awsapps.com/start",
 		store:     jstore,
 		Roles:     map[string][]RoleInfo{},
-		SSOConfig: &SSOConfig{},
+		SSOConfig: &SSOConfig{
+			settings: &Settings{},
+		},
 		Token: storage.CreateTokenResponse{
 			AccessToken:  "access-token",
 			ExpiresIn:    42,
@@ -584,7 +588,9 @@ func TestGetRoleCredentials(t *testing.T) {
 				},
 			},
 		},
-		SSOConfig: &SSOConfig{},
+		SSOConfig: &SSOConfig{
+			settings: &Settings{},
+		},
 		Token: storage.CreateTokenResponse{
 			AccessToken:  "access-token",
 			ExpiresIn:    42,


### PR DESCRIPTION
Need to use containers when using multiple AWS SSO Instances
so that the browser doesn't re-use its existing SSO session.
Otherwise, switching SSO Instance (--sso) ends up being broken
because you'll use the current session all the time.

Refs: #374