### PR TITLE
Context sensitive prediction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,20 @@
 # AWS SSO CLI Changelog
 
+## Unreleased
+
+### New Features
+
+ * Auto-completion is now context sensitive to the `--sso`, `--account`, and
+    `--role` flags and filters results accordingly.
+
+### Bugs
+
 ## [v1.9.1] - 2022-05-09
 
 ## Bugs
 
  * Fix `config` command when user has no `UrlExecCommand` defined #385
- * `console` no longer warns when a role is missing the Color or Icon tag 
+ * `console` no longer warns when a role is missing the Color or Icon tag
 
 ## [v1.9.0] - 2022-05-08
 
@@ -353,7 +362,8 @@
 
 Initial release
 
-[Unreleased]: https://github.com/synfinatic/aws-sso-cli/compare/v1.9.0...main
+[Unreleased]: https://github.com/synfinatic/aws-sso-cli/compare/v1.9.1...main
+[v1.9.1]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v1.9.1
 [v1.9.0]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v1.9.0
 [v1.8.1]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v1.8.1
 [v1.8.0]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v1.8.0

--- a/cmd/list_cmd.go
+++ b/cmd/list_cmd.go
@@ -24,28 +24,12 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/synfinatic/aws-sso-cli/internal/predictor"
 	"github.com/synfinatic/aws-sso-cli/internal/utils"
 	"github.com/synfinatic/aws-sso-cli/sso"
 	"github.com/synfinatic/aws-sso-cli/storage"
 	"github.com/synfinatic/gotable"
 )
-
-// keys match AWSRoleFlat header and value is the description
-var allListFields = map[string]string{
-	"Id":            "Column Index",
-	"Arn":           "AWS Role Resource Name",
-	"AccountId":     "AWS AccountID",
-	"AccountName":   "Configured Account Name",
-	"AccountAlias":  "AWS Account Alias",
-	"DefaultRegion": "Default AWS Region",
-	"EmailAddress":  "Root Email for AWS account",
-	"ExpiresStr":    "Time until STS creds expire",
-	"Expires":       "Unix Epoch when STS creds expire",
-	"RoleName":      "AWS Role Name",
-	"SSO":           "AWS SSO Instance Name",
-	"Via":           "Role Chain Via",
-	"Profile":       "AWS_SSO_PROFILE / AWS_PROFILE",
-}
 
 type ListCmd struct {
 	ListFields    bool     `kong:"short='f',help='List available fields',xor='fields'"`
@@ -196,7 +180,7 @@ func (cfn ConfigFieldNames) GetHeader(fieldName string) (string, error) {
 // listAllFields generates a table with all the AWSRoleFlat fields we can print
 func listAllFields() {
 	names := []string{}
-	for k := range allListFields {
+	for k := range predictor.AllListFields {
 		names = append(names, k)
 	}
 	sort.Strings(names)
@@ -204,7 +188,7 @@ func listAllFields() {
 	for _, k := range names {
 		ts = append(ts, ConfigFieldNames{
 			Field:       k,
-			Description: allListFields[k],
+			Description: predictor.AllListFields[k],
 		})
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/synfinatic/aws-sso-cli/awsconfig"
 	"github.com/synfinatic/aws-sso-cli/internal/helper"
+	"github.com/synfinatic/aws-sso-cli/internal/predictor"
 	"github.com/synfinatic/aws-sso-cli/internal/utils"
 	"github.com/synfinatic/aws-sso-cli/sso"
 	"github.com/synfinatic/aws-sso-cli/storage"
@@ -82,13 +83,11 @@ var DEFAULT_CONFIG map[string]interface{} = map[string]interface{}{
 	"ListFields":                                []string{"AccountId", "AccountAlias", "RoleName", "Profile", "ExpiresStr"},
 	"ConsoleDuration":                           60,
 	"UrlAction":                                 "open",
-	"UrlExecCommand":                            "",
+	"ConfigProfilesUrlAction":                   "open",
 	"LogLevel":                                  "warn",
 	"DefaultSSO":                                "Default",
 	"FirefoxOpenUrlInContainer":                 false,
 	"AutoConfigCheck":                           false,
-	"ConfigProfilesUrlAction":                   "",
-	"ConfigUrlAction":                           "", // deprecated
 	"ProfileFormat":                             `{{ .AccountId }}:{{ .RoleName }}`,
 	"CacheRefresh":                              24, // in hours
 }
@@ -134,6 +133,7 @@ func main() {
 	utils.SetLogger(log)
 	awsconfig.SetLogger(log)
 	helper.SetLogger(log)
+	predictor.SetLogger(log)
 
 	if err := logLevelValidate(cli.LogLevel); err != nil {
 		log.Fatalf("%s", err.Error())
@@ -209,7 +209,7 @@ func parseArgs(cli *CLI) (*kong.Context, sso.OverrideSettings) {
 		vars,
 	)
 
-	p := NewPredictor(utils.GetHomePath(INSECURE_CACHE_FILE), utils.GetHomePath(CONFIG_FILE))
+	p := predictor.NewPredictor(utils.GetHomePath(INSECURE_CACHE_FILE), utils.GetHomePath(CONFIG_FILE))
 
 	kongplete.Complete(parser,
 		kongplete.WithPredictors(

--- a/cmd/setup_prompt.go
+++ b/cmd/setup_prompt.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 
 	"github.com/manifoldco/promptui"
+	"github.com/synfinatic/aws-sso-cli/internal/predictor"
 	"github.com/synfinatic/aws-sso-cli/internal/utils"
 )
 
@@ -34,26 +35,6 @@ const (
 	START_URL_FORMAT  = "https://%s.awsapps.com/start"
 	START_FQDN_FORMAT = "%s.awsapps.com"
 )
-
-// https://docs.aws.amazon.com/general/latest/gr/sso.html
-var AvailableAwsSSORegions []string = []string{
-	"us-east-1",
-	"us-east-2",
-	"us-west-2",
-	"ap-south-1",
-	"ap-northeast-2",
-	"ap-southeast-1",
-	"ap-southeast-2",
-	"ap-northeast-1",
-	"ca-central-1",
-	"eu-central-1",
-	"eu-west-1",
-	"eu-west-2",
-	"eu-west-3",
-	"eu-north-1",
-	"sa-east-1",
-	"us-gov-west-1",
-}
 
 type selectOptions struct {
 	Name  string
@@ -184,7 +165,7 @@ func promptAwsSsoRegion(defaultValue string) string {
 	fmt.Printf("\n")
 
 	items := []selectOptions{}
-	for _, x := range AvailableAwsSSORegions {
+	for _, x := range predictor.AvailableAwsSSORegions {
 		items = append(items, selectOptions{
 			Value: x,
 			Name:  x,
@@ -220,7 +201,7 @@ func promptDefaultRegion(defaultValue string) string {
 			Value: "",
 		},
 	}
-	for _, x := range AvailableAwsRegions {
+	for _, x := range predictor.AvailableAwsRegions {
 		items = append(items, selectOptions{
 			Value: x,
 			Name:  x,

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -301,8 +301,8 @@ in your shell via [eval](#eval) or [exec](#exec).
 ### completions
 
 Configures your appropriate shell configuration file to add auto-complete
-functionality for commands, flags and options.  Must restart your shell
-for this to take effect.
+and [shell helper](#shell-helper) functionality for commands, flags and
+options.  Must restart your shell for this to take effect.
 
 For more information about this feature, please read [the quickstart](
 quickstart.md#enabling-auto-completion-in-your-shell).
@@ -390,7 +390,7 @@ If you want to pass specific args to `aws-sso-profile` you can use the
 `$AWS_SSO_HELPER_ARGS` environment variable.  If nothing is set, then 
 `--level error` is used.
 
-Currently the following shells are supported:
+Currently the following shells are fully supported:
 
  * `bash`
  * [zsh - TBD](https://github.com/synfinatic/aws-sso-cli/issues/360)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -183,7 +183,7 @@ and the `$AWS_PROFILE` environment variable, AWS SSO CLI can support that as wel
 
 #### Configuration
 
-Run: `aws-sso config --open [open|clip|exec]`
+Run: `aws-sso config`
 
 This will add the following lines (example) to your `~/.aws/config` file:
 

--- a/internal/predictor/comp_vars.go
+++ b/internal/predictor/comp_vars.go
@@ -1,0 +1,103 @@
+package predictor
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2022 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// getSSOFlag returns the value of -S/--sso from $COMP_LINE or empty string
+func getSSOFlag() string {
+	compLine, ok := os.LookupEnv("COMP_LINE")
+	if !ok {
+		return ""
+	}
+
+	return flagValue(compLine, []string{"-S", "--sso"})
+}
+
+// getAccountIdFlag returns the value of -A/--account from $COMP_LINE or
+// -1 for none
+func getAccountIdFlag() int64 {
+	compLine, ok := os.LookupEnv("COMP_LINE")
+	if !ok {
+		return -1
+	}
+
+	aStr := flagValue(compLine, []string{"-A", "--account"})
+	if aStr == "" {
+		return -1
+	}
+	aid, _ := strconv.ParseInt(aStr, 10, 64)
+	return aid
+}
+
+// getRoleFlag returns the value of -R/--role from $COMP_LINE or empty string
+func getRoleFlag() string {
+	compLine, ok := os.LookupEnv("COMP_LINE")
+	if !ok {
+		return ""
+	}
+
+	return flagValue(compLine, []string{"-R", "--role"})
+}
+
+func flagValue(line string, flags []string) string {
+	var flag string
+	i := 0
+
+	// remove double spaces
+	line = strings.ReplaceAll(line, "  ", "")
+
+	// skip past our executable
+	i = strings.Index(line, " ")
+	if i < 0 {
+		return ""
+	}
+
+	line = line[i:]
+
+	for _, flag = range flags {
+		i = strings.Index(line, flag)
+		if i > 0 {
+			i += len(flag)
+			line = line[i:] // jump past our flag
+			break
+		}
+	}
+
+	// missing completely or need a space + at least 1 char
+	if i < 0 || len(line) < 2 {
+		return ""
+	}
+
+	line = line[1:] // eat the space
+
+	// find the next space
+	i = strings.Index(line, " ")
+	if i < 0 {
+		// let kongplete do the work
+		return ""
+	}
+
+	// return a result
+	return line[:i]
+}

--- a/internal/predictor/comp_vars_test.go
+++ b/internal/predictor/comp_vars_test.go
@@ -1,0 +1,78 @@
+package predictor
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2022 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSSOFlag(t *testing.T) {
+	defer func() { os.Unsetenv("COMP_LINE") }()
+
+	os.Setenv("COMP_LINE", "aws-sso eval -S Default -R")
+	assert.Equal(t, "Default", getSSOFlag())
+
+	os.Setenv("COMP_LINE", "aws-sso eval --sso Default -R")
+	assert.Equal(t, "Default", getSSOFlag())
+
+	os.Setenv("COMP_LINE", "aws-sso eval --so Default -R")
+	assert.Equal(t, "", getSSOFlag())
+}
+
+func TestGetAccountIdFlag(t *testing.T) {
+	defer func() { os.Unsetenv("COMP_LINE") }()
+
+	os.Setenv("COMP_LINE", "aws-sso eval -A 5555 -R")
+	assert.Equal(t, int64(5555), getAccountIdFlag())
+
+	os.Setenv("COMP_LINE", "aws-sso eval --account 5555 -R")
+	assert.Equal(t, int64(5555), getAccountIdFlag())
+
+	os.Setenv("COMP_LINE", "aws-sso eval --account -5555 -R")
+	assert.Equal(t, int64(-5555), getAccountIdFlag())
+
+	os.Setenv("COMP_LINE", "aws-sso eval --accoun 5555 -R")
+	assert.Equal(t, int64(-1), getAccountIdFlag())
+}
+
+func TestGetRoleFlag(t *testing.T) {
+	defer func() { os.Unsetenv("COMP_LINE") }()
+
+	os.Setenv("COMP_LINE", "aws-sso eval -R Default -A")
+	assert.Equal(t, "Default", getRoleFlag())
+
+	os.Setenv("COMP_LINE", "aws-sso eval --role Default -A")
+	assert.Equal(t, "Default", getRoleFlag())
+
+	os.Setenv("COMP_LINE", "aws-sso eval --rol Default -A")
+	assert.Equal(t, "", getRoleFlag())
+}
+
+func TestFlagValue(t *testing.T) {
+	flags := []string{"-S", "--sso"}
+
+	assert.Equal(t, "", flagValue("", flags))
+	assert.Equal(t, "", flagValue("aws-sso eval -S", flags))
+	assert.Equal(t, "", flagValue("aws-sso eval -S D", flags))
+	assert.Equal(t, "", flagValue("aws-sso eval -S Default", flags))
+	assert.Equal(t, "Default", flagValue("aws-sso eval -S Default ", flags))
+}

--- a/internal/predictor/constants.go
+++ b/internal/predictor/constants.go
@@ -1,0 +1,85 @@
+package predictor
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2022 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// keys match AWSRoleFlat header and value is the description
+var AllListFields = map[string]string{
+	"Id":            "Column Index",
+	"Arn":           "AWS Role Resource Name",
+	"AccountId":     "AWS AccountID",
+	"AccountName":   "Configured Account Name",
+	"AccountAlias":  "AWS Account Alias",
+	"DefaultRegion": "Default AWS Region",
+	"EmailAddress":  "Root Email for AWS account",
+	"ExpiresStr":    "Time until STS creds expire",
+	"Expires":       "Unix Epoch when STS creds expire",
+	"RoleName":      "AWS Role Name",
+	"SSO":           "AWS SSO Instance Name",
+	"Via":           "Role Chain Via",
+	"Profile":       "AWS_SSO_PROFILE / AWS_PROFILE",
+}
+
+// AvailableAwsRegions lists all the AWS regions that AWS provides
+// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
+var AvailableAwsRegions []string = []string{
+	"us-gov-west-1",
+	"us-gov-east-1",
+	"us-east-1",
+	"us-east-2",
+	"us-west-1",
+	"us-west-2",
+	"af-south-1",
+	"ap-east-1",
+	"ap-south-1",
+	"ap-northeast-1",
+	"ap-northeast-2",
+	"ap-northeast-3",
+	"ap-southeast-1",
+	"ap-southeast-2",
+	"ap-northeast-1",
+	"ca-central-1",
+	"eu-central-1",
+	"eu-west-1",
+	"eu-west-2",
+	"eu-south-1",
+	"eu-west-3",
+	"eu-north-1",
+	"me-south-1",
+	"sa-east-1",
+}
+
+// https://docs.aws.amazon.com/general/latest/gr/sso.html
+var AvailableAwsSSORegions []string = []string{
+	"us-east-1",
+	"us-east-2",
+	"us-west-2",
+	"ap-south-1",
+	"ap-northeast-2",
+	"ap-southeast-1",
+	"ap-southeast-2",
+	"ap-northeast-1",
+	"ca-central-1",
+	"eu-central-1",
+	"eu-west-1",
+	"eu-west-2",
+	"eu-west-3",
+	"eu-north-1",
+	"sa-east-1",
+	"us-gov-west-1",
+}

--- a/internal/predictor/logger.go
+++ b/internal/predictor/logger.go
@@ -1,0 +1,40 @@
+package predictor
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2022 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+var log *logrus.Logger
+
+func SetLogger(l *logrus.Logger) {
+	log = l
+}
+
+/*
+func GetLogger() *logrus.Logger {
+	return log
+}
+*/
+
+// this is configured by cmd/main.go, but we have this here for unit tests
+func init() {
+	log = logrus.New()
+}

--- a/internal/predictor/predictor_test.go
+++ b/internal/predictor/predictor_test.go
@@ -1,0 +1,73 @@
+package predictor
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2022 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	// "os"
+	// "fmt"
+	"testing"
+
+	// "github.com/davecgh/go-spew/spew"
+	"github.com/posener/complete"
+	"github.com/stretchr/testify/assert"
+	// "github.com/stretchr/testify/suite"
+)
+
+func TestNewPredictor(t *testing.T) {
+	p := NewPredictor("./testdata/cache.json", "./testdata/settings.yaml")
+	assert.NotNil(t, p)
+	assert.NotEmpty(t, p.accountids)
+	assert.NotEmpty(t, p.arns)
+	assert.NotEmpty(t, p.profiles)
+	assert.NotEmpty(t, p.roles)
+}
+
+func TestCompletions(t *testing.T) {
+	p := NewPredictor("./testdata/cache.json", "./testdata/settings.yaml")
+
+	args := complete.Args{}
+
+	c := p.AccountComplete()
+	assert.NotNil(t, c)
+	assert.Equal(t, 4, len(c.Predict(args)))
+
+	c = p.FieldListComplete()
+	assert.NotNil(t, c)
+	assert.Equal(t, len(AllListFields), len(c.Predict(args)))
+
+	c = p.RoleComplete()
+	assert.NotNil(t, c)
+	assert.Equal(t, 7, len(c.Predict(args)))
+
+	c = p.ArnComplete()
+	assert.NotNil(t, c)
+	assert.Equal(t, 19, len(c.Predict(args)))
+
+	c = p.ProfileComplete()
+	assert.NotNil(t, c)
+	assert.Equal(t, 19, len(c.Predict(args)))
+
+	c = p.RegionComplete()
+	assert.NotNil(t, c)
+	assert.Equal(t, len(AvailableAwsRegions), len(c.Predict(args)))
+
+	c = p.SsoComplete()
+	assert.NotNil(t, c)
+	assert.Equal(t, 3, len(c.Predict(args)))
+}

--- a/internal/predictor/testdata/cache.json
+++ b/internal/predictor/testdata/cache.json
@@ -1,0 +1,252 @@
+{
+  "ConfigCreatedAt": 1635710861,
+  "Version": 3,
+  "SSO": {
+    "Default": {
+      "LastUpdate": 1635913188,
+      "Roles": {
+        "Accounts": {
+          "258234615182": {
+            "Alias": "OurCompany Control Tower Playground",
+            "Name": "OurCompany Control Tower Playground",
+            "EmailAddress": "control-tower-dev-aws@ourcompany.com",
+            "Tags": {
+              "Type": "Main Account"
+            },
+            "Roles": {
+              "AWSAdministratorAccess": {
+                "Arn": "arn:aws:iam::258234615182:role/AWSAdministratorAccess",
+				"DefaultRegion": "us-east-1",
+                "Tags": {
+                  "AccountAlias": "OurCompany Control Tower Playground",
+                  "AccountID": "258234615182",
+                  "AccountName": "OurCompany Control Tower Playground",
+                  "Email": "control-tower-dev-aws@ourcompany.com",
+                  "Foo": "Bar",
+                  "Role": "AWSAdministratorAccess",
+                  "Test": "value",
+                  "Type": "Main Account"
+                }
+              },
+              "AWSOrganizationsFullAccess": {
+                "Arn": "arn:aws:iam::258234615182:role/AWSOrganizationsFullAccess",
+                "Tags": {
+                  "AccountAlias": "OurCompany Control Tower Playground",
+                  "AccountID": "258234615182",
+                  "AccountName": "OurCompany Control Tower Playground",
+                  "Email": "control-tower-dev-aws@ourcompany.com",
+                  "Role": "AWSOrganizationsFullAccess"
+                }
+              },
+              "AWSPowerUserAccess": {
+                "Arn": "arn:aws:iam::258234615182:role/AWSPowerUserAccess",
+                "Tags": {
+                  "AccountAlias": "OurCompany Control Tower Playground",
+                  "AccountID": "258234615182",
+                  "AccountName": "OurCompany Control Tower Playground",
+                  "Email": "control-tower-dev-aws@ourcompany.com",
+                  "Role": "AWSPowerUserAccess"
+                }
+              },
+              "AWSReadOnlyAccess": {
+                "Arn": "arn:aws:iam::258234615182:role/AWSReadOnlyAccess",
+                "Tags": {
+                  "AccountAlias": "OurCompany Control Tower Playground",
+                  "AccountID": "258234615182",
+                  "AccountName": "OurCompany Control Tower Playground",
+                  "Email": "control-tower-dev-aws@ourcompany.com",
+                  "Role": "AWSReadOnlyAccess"
+                }
+              },
+              "AWSServiceCatalogEndUserAccess": {
+                "Arn": "arn:aws:iam::258234615182:role/AWSServiceCatalogEndUserAccess",
+                "Tags": {
+                  "AccountAlias": "OurCompany Control Tower Playground",
+                  "AccountID": "258234615182",
+                  "AccountName": "OurCompany Control Tower Playground",
+                  "Email": "control-tower-dev-aws@ourcompany.com",
+                  "Role": "AWSServiceCatalogEndUserAccess"
+                }
+              },
+              "DoNothingRole": {
+                "Arn": "arn:aws:iam::258234615182:role/DoNothingRole",
+                "Tags": {
+                  "AccountAlias": "OurCompany Control Tower Playground",
+                  "AccountID": "258234615182",
+                  "AccountName": "OurCompany Control Tower Playground",
+                  "Email": "control-tower-dev-aws@ourcompany.com",
+                  "Role": "DoNothingRole"
+                }
+              },
+              "SSO-ProductionDevelopersRO": {
+                "Arn": "arn:aws:iam::258234615182:role/SSO-ProductionDevelopersRO",
+                "Tags": {
+                  "AccountAlias": "OurCompany Control Tower Playground",
+                  "AccountID": "258234615182",
+                  "AccountName": "OurCompany Control Tower Playground",
+                  "Email": "control-tower-dev-aws@ourcompany.com",
+                  "Role": "SSO-ProductionDevelopersRO"
+                }
+              }
+            }
+          },
+          "833365043586": {
+            "Alias": "Log archive",
+            "Name": "Log archive",
+            "EmailAddress": "control-tower-dev-aws+log@ourcompany.com",
+            "Tags": {
+              "Type": "Sub Account"
+            },
+            "Roles": {
+              "AWSAdministratorAccess": {
+                "Arn": "arn:aws:iam::833365043586:role/AWSAdministratorAccess",
+                "Tags": {
+                  "AccountAlias": "Log archive",
+                  "AccountID": "833365043586",
+                  "AccountName": "Log archive",
+                  "Email": "control-tower-dev-aws+log@ourcompany.com",
+                  "Role": "AWSAdministratorAccess"
+                }
+              },
+              "AWSPowerUserAccess": {
+                "Arn": "arn:aws:iam::833365043586:role/AWSPowerUserAccess",
+                "Tags": {
+                  "AccountAlias": "Log archive",
+                  "AccountID": "833365043586",
+                  "AccountName": "Log archive",
+                  "Email": "control-tower-dev-aws+log@ourcompany.com",
+                  "Role": "AWSPowerUserAccess"
+                }
+              },
+              "AWSReadOnlyAccess": {
+                "Arn": "arn:aws:iam::833365043586:role/AWSReadOnlyAccess",
+                "Tags": {
+                  "AccountAlias": "Log archive",
+                  "AccountID": "833365043586",
+                  "AccountName": "Log archive",
+                  "Email": "control-tower-dev-aws+log@ourcompany.com",
+                  "Role": "AWSReadOnlyAccess"
+                }
+              },
+              "SSO-ProductionDevelopersRO": {
+                "Arn": "arn:aws:iam::833365043586:role/SSO-ProductionDevelopersRO",
+                "Tags": {
+                  "AccountAlias": "Log archive",
+                  "AccountID": "833365043586",
+                  "AccountName": "Log archive",
+                  "Email": "control-tower-dev-aws+log@ourcompany.com",
+                  "Role": "SSO-ProductionDevelopersRO"
+                }
+              }
+            },
+            "DefaultRegion": "eu-north-1"
+          },
+          "502470824893": {
+            "Alias": "Audit",
+            "Name": "Audit",
+            "EmailAddress": "control-tower-dev-aws+audit@ourcompany.com",
+            "Tags": {
+              "Type": "Sub Account"
+            },
+            "Roles": {
+              "AWSAdministratorAccess": {
+                "Arn": "arn:aws:iam::502470824893:role/AWSAdministratorAccess",
+                "Profile": "audit-admin",
+                "Tags": {
+                  "AccountAlias": "Audit",
+                  "AccountID": "502470824893",
+                  "AccountName": "Audit",
+                  "Email": "control-tower-dev-aws+audit@ourcompany.com",
+                  "Role": "AWSAdministratorAccess"
+                }
+              },
+              "AWSPowerUserAccess": {
+                "Arn": "arn:aws:iam::502470824893:role/AWSPowerUserAccess",
+                "Tags": {
+                  "AccountAlias": "Audit",
+                  "AccountID": "502470824893",
+                  "AccountName": "Audit",
+                  "Email": "control-tower-dev-aws+audit@ourcompany.com",
+                  "Role": "AWSPowerUserAccess"
+                }
+              },
+              "AWSReadOnlyAccess": {
+                "Arn": "arn:aws:iam::502470824893:role/AWSReadOnlyAccess",
+                "Tags": {
+                  "AccountAlias": "Audit",
+                  "AccountID": "502470824893",
+                  "AccountName": "Audit",
+                  "Email": "control-tower-dev-aws+audit@ourcompany.com",
+                  "Role": "AWSReadOnlyAccess"
+                }
+              },
+              "SSO-ProductionDevelopersRO": {
+                "Arn": "arn:aws:iam::502470824893:role/SSO-ProductionDevelopersRO",
+                "Tags": {
+                  "AccountAlias": "Audit",
+                  "AccountID": "502470824893",
+                  "AccountName": "Audit",
+                  "Email": "control-tower-dev-aws+audit@ourcompany.com",
+                  "Role": "SSO-ProductionDevelopersRO"
+                }
+              }
+            }
+          },
+          "707513610766": {
+            "Alias": "control-tower-dev-sub1-aws",
+            "Name": "Dev Account",
+            "EmailAddress": "test+control-tower-sub1@ourcompany.com",
+            "Tags": {
+              "Type": "Sub Account"
+            },
+            "Roles": {
+              "AWSAdministratorAccess": {
+                "Arn": "arn:aws:iam::707513610766:role/AWSAdministratorAccess",
+                "Tags": {
+                  "AccountAlias": "control-tower-dev-sub1-aws",
+                  "AccountID": "707513610766",
+                  "AccountName": "Dev Account",
+                  "Email": "test+control-tower-sub1@ourcompany.com",
+                  "Role": "AWSAdministratorAccess"
+                }
+              },
+              "AWSPowerUserAccess": {
+                "Arn": "arn:aws:iam::707513610766:role/AWSPowerUserAccess",
+                "Tags": {
+                  "AccountAlias": "control-tower-dev-sub1-aws",
+                  "AccountID": "707513610766",
+                  "AccountName": "Dev Account",
+                  "Email": "test+control-tower-sub1@ourcompany.com",
+                  "Role": "AWSPowerUserAccess"
+                }
+              },
+              "AWSReadOnlyAccess": {
+                "Arn": "arn:aws:iam::707513610766:role/AWSReadOnlyAccess",
+                "Tags": {
+                  "AccountAlias": "control-tower-dev-sub1-aws",
+                  "AccountID": "707513610766",
+                  "AccountName": "Dev Account",
+                  "Email": "test+control-tower-sub1@ourcompany.com",
+                  "Role": "AWSReadOnlyAccess"
+                }
+              },
+              "SSO-ProductionDevelopersRO": {
+                "Arn": "arn:aws:iam::707513610766:role/SSO-ProductionDevelopersRO",
+                "Tags": {
+                  "AccountAlias": "control-tower-dev-sub1-aws",
+                  "AccountID": "707513610766",
+                  "AccountName": "Dev Account",
+                  "Email": "test+control-tower-sub1@ourcompany.com",
+                  "Role": "SSO-ProductionDevelopersRO"
+                }
+              }
+            }
+          }
+        },
+        "SSORegion": "us-east-1",
+        "StartUrl": "https://d-754545454.awsapps.com/start",
+        "DefaultRegion": ""
+      }
+    }
+  }
+}

--- a/internal/predictor/testdata/settings.yaml
+++ b/internal/predictor/testdata/settings.yaml
@@ -1,0 +1,72 @@
+SSOConfig:
+    Default:
+        SSORegion: us-east-1
+        StartUrl: https://d-754545454.awsapps.com/start
+        DefaultRegion: us-east-1
+        Accounts:
+            258234615182:
+                Name: OurCompany Control Tower Playground
+                DefaultRegion: eu-west-1
+                Tags:
+                  Type: Main Account
+                Roles:
+                  AWSAdministratorAccess:
+                    DefaultRegion: ca-central-1
+                    Tags:
+                      Test: value
+                      Foo: Bar
+                  LimitedAccess:
+                    Tags:
+                      Test: value
+                      Foo: Moo
+            833365043586:
+                Name: Log archive
+                Tags:
+                  Type: Sub Account
+                Roles:
+                  AWSAdministratorAccess:
+                    Tags:
+                      Test: logs
+                      Foo: Bar
+                      Can: Man
+            502470824893:
+                Name: Audit
+                Tags:
+                  Type: Sub Account
+            707513610766:
+                Name: Dev Account
+                Tags:
+                  Type: Sub Account
+    Another:
+        SSORegion: us-east-1
+        StartUrl: https://d-755555555.awsapps.com/start
+        Accounts:
+            182347455:
+                Name: Whatever
+                Roles:
+                  AWSAdministratorAccess:
+                    Tags:
+                      Test: moocow
+                      Bar: baz
+    Bug292:
+      SSORegion: us-east-1
+      StartUrl: https://d-88888888888.awsapps.com/start
+      Accounts:
+        0012345678912:
+          Name: MyTestName
+
+DefaultSSO: Default                       
+Browser: /Applications/Firefox.app
+UrlAction: print
+SecureStore: json
+JsonStore: ./testdata/store.json
+ProfileFormat: "{{.AccountName}}/{{.RoleName}}"
+AccountPrimaryTag:
+  - AccountAlias
+ConfigUrlAction: open
+LogLevel: warn
+DefaultRegion: us-west-2
+EnvVarTags:
+  - Role 
+  - Arn
+  - Foo


### PR DESCRIPTION
This change now looks at all the flags on the command line and uses
previous flags to filter results for the current flag.  We now
honor:

 * -S/--sso
 * -R/--role
 * -A/--account

Which impacts the --role, --account, --profile and --arn flags.

Refactor our code and move all predction code into internal/predictor

Fixes: #382