### PR TITLE
pesudo-randomize color/icon if not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### New Features
 
  * Auto-completion is now context sensitive to the `--sso`, `--account`, and
-    `--role` flags and filters results accordingly.
+    `--role` flags and filters results accordingly. #382
  * Add zsh support for shell helpers #360
+ * Firefox container name color & icon will be pseudo-randomized if you don't
+    specify a Color/Icon tag #392
 
 ### Bugs
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT_VERSION := 1.9.1
+PROJECT_VERSION := 1.9.2
 DOCKER_REPO     := synfinatic
 PROJECT_NAME    := aws-sso
 

--- a/internal/utils/bellskipper_test.go
+++ b/internal/utils/bellskipper_test.go
@@ -27,7 +27,7 @@ import (
 func TestBellSkipper(t *testing.T) {
 	b := BellSkipper{}
 
-	bytes := []byte("this is my buffer")
+	bytes := []byte("this is my bellskipper buffer\n")
 	i, err := b.Write(bytes)
 	assert.NoError(t, err)
 	assert.Equal(t, len(bytes), i)

--- a/internal/utils/url.go
+++ b/internal/utils/url.go
@@ -61,20 +61,33 @@ var FIREFOX_PLUGIN_ICONS []string = []string{
 
 const FIREFOX_CONTAINER_FORMAT = "ext+container:name=%s&url=%s&color=%s&icon=%s"
 
+// selectElement selects a deterministic pseudo-random option given a string
+// as the seed
+func selectElement(seed string, options []string) string {
+	var v = byte(0)
+	var bytes = []byte(seed)
+
+	for i := 0; i < len(seed); i++ {
+		v += bytes[i] // overflows
+	}
+	v %= byte(len(options))
+	return options[int(v)]
+}
+
 // FirefoxContainerUrl generates a URL for Firefox Containers
 func FirefoxContainerUrl(target, name, color, icon string) string {
 	if !StrListContains(color, FIREFOX_PLUGIN_COLORS) {
 		if color != "" {
 			log.Warnf("Invalid Firefox Container color: %s", color)
 		}
-		color = FIREFOX_PLUGIN_COLORS[0]
+		color = selectElement(name, FIREFOX_PLUGIN_COLORS)
 	}
 
 	if !StrListContains(icon, FIREFOX_PLUGIN_ICONS) {
 		if icon != "" {
 			log.Warnf("Invalid Firefox Container icon: %s", icon)
 		}
-		icon = FIREFOX_PLUGIN_ICONS[0]
+		icon = selectElement(name, FIREFOX_PLUGIN_ICONS)
 	}
 
 	return fmt.Sprintf(FIREFOX_CONTAINER_FORMAT, name, url.QueryEscape(target), color, icon)

--- a/internal/utils/url_test.go
+++ b/internal/utils/url_test.go
@@ -143,8 +143,11 @@ func TestFirefoxContainersUrl(t *testing.T) {
 	assert.Equal(t, "ext+container:name=Test&url=https%3A%2F%2Fsynfin.net&color=blue&icon=fingerprint",
 		FirefoxContainerUrl("https://synfin.net", "Test", "blue", "fingerprint"))
 
-	assert.Equal(t, "ext+container:name=Test&url=https%3A%2F%2Fsynfin.net&color=blue&icon=fingerprint",
-		FirefoxContainerUrl("https://synfin.net", "Test", "Bad", "Value"))
+	assert.Equal(t, "ext+container:name=Testy&url=https%3A%2F%2Fsynfin.net&color=turquoise&icon=briefcase",
+		FirefoxContainerUrl("https://synfin.net", "Testy", "Bad", "Value"))
+
+	assert.Equal(t, "ext+container:name=Testy&url=https%3A%2F%2Fsynfin.net&color=turquoise&icon=briefcase",
+		FirefoxContainerUrl("https://synfin.net", "Testy", "", ""))
 }
 
 func TestCommandBuilder(t *testing.T) {
@@ -169,4 +172,15 @@ func TestCommandBuilder(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "foo", cmd)
 	assert.Equal(t, []string{"bar", "url"}, l)
+}
+
+func TestSelectElement(t *testing.T) {
+	check := map[string]string{
+		"a":  "turquoise", // 97 % 8 => 1
+		"aa": "green",     // 194 % 8 => 2
+		"2d": "pink",      // 150 % 8 => 6
+	}
+	for k, v := range check {
+		assert.Equal(t, v, selectElement(k, FIREFOX_PLUGIN_COLORS))
+	}
 }

--- a/sso/cache_test.go
+++ b/sso/cache_test.go
@@ -127,22 +127,24 @@ func (suite *CacheTestSuite) TestAddHistory() {
 	cache := c.GetSSO()
 	assert.Equal(t, []string{}, cache.History)
 
+	now := time.Now().Unix()
+
 	// Basic add
 	c.AddHistory("arn:aws:iam::123456789012:role/Foo")
 	assert.Equal(t, []string{"arn:aws:iam::123456789012:role/Foo"}, cache.History)
-	tag := fmt.Sprintf("MyAccount:Foo,%d", time.Now().Unix())
+	tag := fmt.Sprintf("MyAccount:Foo,%d", now)
 	assert.Equal(t, tag, c.GetSSO().Roles.Accounts[123456789012].Roles["Foo"].Tags["History"])
 
 	// Add again which should be a no-op
 	c.AddHistory("arn:aws:iam::123456789012:role/Foo")
 	assert.Equal(t, []string{"arn:aws:iam::123456789012:role/Foo"}, cache.History)
-	tag = fmt.Sprintf("MyAccount:Foo,%d", time.Now().Unix())
+	tag = fmt.Sprintf("MyAccount:Foo,%d", now)
 	assert.Equal(t, tag, c.GetSSO().Roles.Accounts[123456789012].Roles["Foo"].Tags["History"])
 
 	// Add a new item which expires the previous item
 	c.AddHistory("arn:aws:iam::123456789012:role/Bar")
 	assert.Equal(t, []string{"arn:aws:iam::123456789012:role/Bar"}, cache.History)
-	tag = fmt.Sprintf("MyAccount:Bar,%d", time.Now().Unix())
+	tag = fmt.Sprintf("MyAccount:Bar,%d", now)
 	assert.NotContains(t, "History", c.GetSSO().Roles.Accounts[123456789012].Roles["Foo"].Tags)
 	assert.Equal(t, tag, c.GetSSO().Roles.Accounts[123456789012].Roles["Bar"].Tags["History"])
 


### PR DESCRIPTION
- Firefox container icon/color will be auto-selected based on the
    provided container name.
- Fix an inconsistent sso/cache unit test
- Bellskipper test was generating output which could be confusing
    during debugging

Fixes: #392