### PR TITLE
Replace list --profile-prefix with --prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
  * `config` wizard now intelligently selects a default value for
     `ConfigProfilesUrlAction` #387
 
+### Changes
+
+ * Replace `list --profile-prefix` with a more flexible `list --prefix` option #395
+
 ### Bugs
 
  * Fix broken `completions` for zsh and fish

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -388,7 +388,7 @@ this by first exporting `AWS_SSO` to the value you want to use.
 
 If you want to pass specific args to `aws-sso-profile` you can use the
 `$AWS_SSO_HELPER_ARGS` environment variable.  If nothing is set, then
-`--level error` is used.
+`--level error --no-config-check` is used.
 
 Currently the following shells are fully supported:
 

--- a/internal/helper/bash_profile.sh
+++ b/internal/helper/bash_profile.sh
@@ -1,16 +1,16 @@
 __aws_sso_profile_complete() {
     COMPREPLY=()
-    local _args=${AWS_SSO_HELPER_ARGS:- -L error}
+    local _args=${AWS_SSO_HELPER_ARGS:- -L error --no-config-check}
     local cur
     _get_comp_words_by_ref -n : cur
 
-    COMPREPLY=($(compgen -W '$({{ .Executable }} $_args list --csv -P "$cur" Profile)' -- ""))
+    COMPREPLY=($(compgen -W '$({{ .Executable }} $_args list --csv -P "Profile=$cur" Profile)' -- ""))
 
     __ltrim_colon_completions "$cur"
 }
 
 aws-sso-profile() {
-    local _args=${AWS_SSO_HELPER_ARGS:- -L error}
+    local _args=${AWS_SSO_HELPER_ARGS:- -L error --no-config-check}
     if [ -n "$AWS_PROFILE" ]; then
         echo "Unable to assume a role while AWS_PROFILE is set"
         return 1
@@ -22,7 +22,7 @@ aws-sso-profile() {
 }
 
 aws-sso-clear() {
-    local _args=${AWS_SSO_HELPER_ARGS:- -L error}
+    local _args=${AWS_SSO_HELPER_ARGS:- -L error --no-config-check}
     if [ -z "$AWS_SSO_PROFILE" ]; then
         echo "AWS_SSO_PROFILE is not set"
         return 1


### PR DESCRIPTION
Support more advanced prefix filter on any field, not just Profile
with --prefix <FieldName>=<Prefix> instead of just
--profile-prefix <Prefix> to enable more advanced auto-complete
shell integrations that don't rely on bash completion.

helpers now include `--no-config-check` by default

Fixes: #395