### PR TITLE
Fix lint errors & go v1.18

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.45.2
+          version: v1.46.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.17
+    - name: Set up Go 1.18
       uses: actions/setup-go@v1
       with:
-        go-version: 1.17
+        go-version: 1.18
       id: go
 
     - name: Check out code into the Go module directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changes
+
+ * Update to Golang v1.18
+
 ### Bugs
 
  * `aws-sso config` no longer prompts to backup a config file if it 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/synfinatic/aws-sso-cli
 
-go 1.17
+go 1.18
 
 require (
 	github.com/99designs/keyring v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -205,7 +205,6 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.3.0 h1:NGXK3lHquSN08v5vWalVI/L8XU9hdzE/G6xsrze47As=
-github.com/stretchr/objx v0.3.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -256,7 +255,6 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200909081042-eff7692f9009/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200918174421-af09f7315aff/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a h1:ppl5mZgokTT8uPkmYOyEUmPTr3ypaKkg5eFOGrAmxxE=
 golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/predictor/predictor.go
+++ b/internal/predictor/predictor.go
@@ -19,7 +19,6 @@ package predictor
  */
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -153,7 +152,7 @@ func (p *Predictor) SsoComplete() complete.Predictor {
 	ssos := []string{}
 	s := sso.Settings{}
 
-	if config, err := ioutil.ReadFile(p.configFile); err == nil {
+	if config, err := os.ReadFile(p.configFile); err == nil {
 		if err = yaml.Unmarshal(config, &s); err == nil {
 			for sso := range s.SSO {
 				ssos = append(ssos, sso)

--- a/internal/storage/json_store.go
+++ b/internal/storage/json_store.go
@@ -21,7 +21,7 @@ package storage
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	// "github.com/davecgh/go-spew/spew"
 	"github.com/synfinatic/aws-sso-cli/internal/utils"
@@ -48,7 +48,7 @@ func OpenJsonStore(fileName string) (*JsonStore, error) {
 		StaticCredentials:   map[string]StaticCredentials{},
 	}
 
-	cacheBytes, err := ioutil.ReadFile(fileName)
+	cacheBytes, err := os.ReadFile(fileName)
 	if err != nil {
 		log.Infof("Creating new cache file: %s", fileName)
 	} else if len(cacheBytes) > 0 {
@@ -71,7 +71,7 @@ func (jc *JsonStore) save() error {
 		return err
 	}
 
-	return ioutil.WriteFile(jc.filename, jbytes, 0600)
+	return os.WriteFile(jc.filename, jbytes, 0600)
 }
 
 // SaveRegisterClientData saves the RegisterClientData in our JSON store

--- a/internal/storage/json_store_test.go
+++ b/internal/storage/json_store_test.go
@@ -19,7 +19,6 @@ package storage
  */
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -50,10 +49,10 @@ func (s *JsonStoreTestSuite) SetupTest() {
 	s.jsonFile = f.Name()
 	f.Close()
 
-	input, err := ioutil.ReadFile(TEST_JSON_STORE_FILE)
+	input, err := os.ReadFile(TEST_JSON_STORE_FILE)
 	assert.Nil(t, err)
 
-	err = ioutil.WriteFile(s.jsonFile, input, 0600)
+	err = os.WriteFile(s.jsonFile, input, 0600)
 	assert.Nil(t, err)
 
 	s.json, err = OpenJsonStore(s.jsonFile)

--- a/internal/storage/keyring_test.go
+++ b/internal/storage/keyring_test.go
@@ -21,7 +21,6 @@ package storage
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -331,7 +330,7 @@ func TestNewKeyringConfig(t *testing.T) {
 	d, err := os.MkdirTemp("", "test-keyring")
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(path.Join(d, "aws-sso-cli-records"), []byte("INVALID DATA"), 0600)
+	err = os.WriteFile(path.Join(d, "aws-sso-cli-records"), []byte("INVALID DATA"), 0600)
 	assert.NoError(t, err)
 
 	defer func() {
@@ -385,10 +384,10 @@ func TestKeyringSuiteFails(t *testing.T) {
 		return fmt.Errorf("unmarshal failure")
 	}
 
-	in, err := ioutil.ReadFile("./testdata/aws-sso-cli-records")
+	in, err := os.ReadFile("./testdata/aws-sso-cli-records")
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(path.Join(d, "secure", "aws-sso-cli-records"), in, 0600)
+	err = os.WriteFile(path.Join(d, "secure", "aws-sso-cli-records"), in, 0600)
 	assert.NoError(t, err)
 
 	err = kr.getStorageData(&kr.cache)

--- a/sso/awssso_auth_test.go
+++ b/sso/awssso_auth_test.go
@@ -21,7 +21,6 @@ package sso
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -104,7 +103,7 @@ func TestStoreKey(t *testing.T) {
 }
 
 func TestAuthenticateSteps(t *testing.T) {
-	tfile, err := ioutil.TempFile("", "*storage.json")
+	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
 	jstore, err := storage.OpenJsonStore(tfile.Name())
@@ -184,7 +183,7 @@ func TestAuthenticateSteps(t *testing.T) {
 }
 
 func TestAuthenticate(t *testing.T) {
-	tfile, err := ioutil.TempFile("", "*storage.json")
+	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
 	jstore, err := storage.OpenJsonStore(tfile.Name())
@@ -259,7 +258,7 @@ func TestAuthenticate(t *testing.T) {
 }
 
 func TestAuthenticateFailure(t *testing.T) {
-	tfile, err := ioutil.TempFile("", "*storage.json")
+	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
 	jstore, err := storage.OpenJsonStore(tfile.Name())
@@ -358,7 +357,7 @@ func TestAuthenticateFailure(t *testing.T) {
 }
 
 func TestReauthenticate(t *testing.T) {
-	tfile, err := ioutil.TempFile("", "*storage.json")
+	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
 	jstore, err := storage.OpenJsonStore(tfile.Name())

--- a/sso/awssso_test.go
+++ b/sso/awssso_test.go
@@ -21,7 +21,6 @@ package sso
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -75,7 +74,7 @@ func (m *mockSsoAPI) GetRoleCredentials(ctx context.Context, params *sso.GetRole
 
 func TestNewAWSSSO(t *testing.T) {
 	var jstore storage.SecureStorage
-	tfile, err := ioutil.TempFile("", "*storage.json")
+	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
 	jstore, err = storage.OpenJsonStore(tfile.Name())
@@ -124,7 +123,7 @@ func TestGetFieldNameRoleInfo(t *testing.T) {
 }
 
 func TestGetRoles(t *testing.T) {
-	tfile, err := ioutil.TempFile("", "*storage.json")
+	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
 	jstore, err := storage.OpenJsonStore(tfile.Name())
@@ -398,7 +397,7 @@ func TestGetRoles(t *testing.T) {
 }
 
 func TestGetAccounts(t *testing.T) {
-	tfile, err := ioutil.TempFile("", "*storage.json")
+	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
 	jstore, err := storage.OpenJsonStore(tfile.Name())
@@ -551,7 +550,7 @@ func TestGetAccounts(t *testing.T) {
 }
 
 func TestGetRoleCredentials(t *testing.T) {
-	tfile, err := ioutil.TempFile("", "*storage.json")
+	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
 	jstore, err := storage.OpenJsonStore(tfile.Name())

--- a/sso/cache.go
+++ b/sso/cache.go
@@ -21,7 +21,7 @@ package sso
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -60,7 +60,7 @@ func OpenCache(f string, s *Settings) (*Cache, error) {
 	var err error
 	var cacheBytes []byte
 	if f != "" {
-		cacheBytes, err = ioutil.ReadFile(f)
+		cacheBytes, err = os.ReadFile(f)
 		if err != nil {
 			return &cache, err // return empty struct
 		}
@@ -138,7 +138,7 @@ func (c *Cache) Save(updateTime bool) error {
 	if err != nil {
 		return fmt.Errorf("Unable to create directory for %s: %s", c.CacheFile(), err.Error())
 	}
-	err = ioutil.WriteFile(c.CacheFile(), jbytes, 0600)
+	err = os.WriteFile(c.CacheFile(), jbytes, 0600)
 	if err != nil {
 		return fmt.Errorf("Unable to write %s: %s", c.CacheFile(), err.Error())
 	}

--- a/sso/cache_test.go
+++ b/sso/cache_test.go
@@ -20,7 +20,6 @@ package sso
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -60,10 +59,10 @@ func TestCacheTestSuite(t *testing.T) {
 		cacheFile:      f.Name(),
 	}
 
-	input, err := ioutil.ReadFile(TEST_CACHE_FILE)
+	input, err := os.ReadFile(TEST_CACHE_FILE)
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(f.Name(), input, 0600)
+	err = os.WriteFile(f.Name(), input, 0600)
 	assert.NoError(t, err)
 
 	c, err := OpenCache(f.Name(), settings)

--- a/sso/roles_test.go
+++ b/sso/roles_test.go
@@ -19,7 +19,6 @@ package sso
  */
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -59,10 +58,10 @@ func TestCacheRolesTestSuite(t *testing.T) {
 	}
 
 	// cache
-	input, err := ioutil.ReadFile(TEST_CACHE_FILE)
+	input, err := os.ReadFile(TEST_CACHE_FILE)
 	assert.NoError(t, err)
 
-	err = ioutil.WriteFile(f.Name(), input, 0600)
+	err = os.WriteFile(f.Name(), input, 0600)
 	assert.NoError(t, err)
 
 	c, err := OpenCache(f.Name(), settings)
@@ -75,10 +74,10 @@ func TestCacheRolesTestSuite(t *testing.T) {
 	jsonFile := f2.Name()
 	f2.Close()
 
-	input, err = ioutil.ReadFile(TEST_JSON_STORE_FILE)
+	input, err = os.ReadFile(TEST_JSON_STORE_FILE)
 	assert.Nil(t, err)
 
-	err = ioutil.WriteFile(jsonFile, input, 0600)
+	err = os.WriteFile(jsonFile, input, 0600)
 	assert.Nil(t, err)
 
 	sstore, err := storage.OpenJsonStore(jsonFile)
@@ -378,7 +377,7 @@ func (suite *CacheRolesTestSuite) TestCheckProfiles() {
 	t := suite.T()
 	tests := ProfileTests{}
 
-	data, err := ioutil.ReadFile(TEST_ROLES_TEST_FILE)
+	data, err := os.ReadFile(TEST_ROLES_TEST_FILE)
 	assert.NoError(t, err)
 
 	err = goyaml.Unmarshal(data, &tests)

--- a/sso/settings.go
+++ b/sso/settings.go
@@ -23,7 +23,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -298,7 +297,7 @@ func (s *Settings) Save(configFile string, overwrite bool) error {
 	}
 
 	// need to make directory if not exist
-	return ioutil.WriteFile(configFile, fileBytes, 0600)
+	return os.WriteFile(configFile, fileBytes, 0600)
 }
 
 // configure our settings using the overrides

--- a/sso/settings_test.go
+++ b/sso/settings_test.go
@@ -20,7 +20,6 @@ package sso
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -168,7 +167,7 @@ func (suite *SettingsTestSuite) TestGetAllTags() {
 func (suite *SettingsTestSuite) TestSave() {
 	t := suite.T()
 
-	dir, err := ioutil.TempDir("", "settings_test")
+	dir, err := os.MkdirTemp("", "settings_test")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 


### PR DESCRIPTION
- Update golangci-lint to v1.46.2
- Update to Go v1.8
- io/ioutil is deprecated