### PR TITLE
Fixing bug with data length in keyring code 

### DIFF
--- a/internal/storage/keyring.go
+++ b/internal/storage/keyring.go
@@ -228,7 +228,7 @@ func (kr *KeyringStore) joinAndGetKeyringData(key string) ([]byte, error) {
 	}
 
 	totalBytes, data := binary.BigEndian.Uint64(chunk[:8]), chunk[8:]
-	readBytes := uint64(len(chunk))
+	readBytes := uint64(len(data))
 
 	for i := 1; readBytes < totalBytes; i++ {
 		k := fmt.Sprintf("%s_%d", key, i)


### PR DESCRIPTION
Fixing bug where the number of bytes read (`readBytes`) was including the leading 8 bytes of size, which would cause it to always have a mismatch with the `totalBytes` value (by exactly 8 bytes) and therefore fail to read data from the keyring in Windows.