### PR TITLE
Force a cache refresh when doing `config-profiles`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Bugs
+ * `config-profiles` now always uses the latest list of profiles from AWS #420
+
 ## [v1.9.4] - 2022-09-29
 
 ### Bugs

--- a/cmd/aws-sso/config_profiles_cmd.go
+++ b/cmd/aws-sso/config_profiles_cmd.go
@@ -60,6 +60,12 @@ func (cc *ConfigProfilesCmd) Run(ctx *RunContext) error {
 
 	urlAction, _ := url.NewAction(string(action))
 
+	// refresh our cache
+	c := &CacheCmd{}
+	if err = c.Run(ctx); err != nil {
+		return err
+	}
+
 	profiles, err := ctx.Settings.GetAllProfiles(urlAction)
 	if err != nil {
 		return err


### PR DESCRIPTION
We weren't doing any cache expiration detection or anything so new users could end up with an empty list or users might end up with out dated profiles.

Fixes: #420