### PR TITLE
Fix eval refresh not finding role arn

### DIFF
--- a/cmd/aws-sso/eval_cmd.go
+++ b/cmd/aws-sso/eval_cmd.go
@@ -57,7 +57,7 @@ func (cc *EvalCmd) Run(ctx *RunContext) error {
 
 	// refreshing?
 	if ctx.Cli.Eval.Refresh {
-		if ctx.Cli.Eval.EnvArn != "" {
+		if ctx.Cli.Eval.EnvArn == "" {
 			return fmt.Errorf("Unable to determine current IAM role")
 		}
 		accountid, role, err = utils.ParseRoleARN(ctx.Cli.Eval.EnvArn)


### PR DESCRIPTION
Fixes eval --refresh not finding the AWS_SSO_ROLE_ARN env var