### PR TITLE
Support leading zeros for AccountID in profile names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # AWS SSO CLI Changelog
 
+## [Unreleased] 
+
+### Bugs 
+ * `config-profiles` now pads the AccountID in the profile name as described. #446
+
 ## [v1.9.5] - 2022-11-13
 
 ### New Features

--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -89,7 +89,7 @@ var DEFAULT_CONFIG map[string]interface{} = map[string]interface{}{
 	"DefaultSSO":                                "Default",
 	"FirefoxOpenUrlInContainer":                 false,
 	"AutoConfigCheck":                           false,
-	"ProfileFormat":                             `{{ .AccountId }}:{{ .RoleName }}`,
+	"ProfileFormat":                             `{{ AccountIdStr .AccountId }}:{{ .RoleName }}`,
 	"CacheRefresh":                              24, // in hours
 }
 


### PR DESCRIPTION
The FAQ/docs says one thing regarding the default, and the code did something different. :(

Fixes: #446