### PR TITLE
Update cache faster via goroutines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
 # AWS SSO CLI Changelog
 
-## [Unreleased] 
+## [v1.9.6] - 2022-12-04
 
-### Bugs 
+### New Features
+ * Add `Threads` option to config file
+ * Updating the account and role cache now honors the `Threads` option
+ * If updating role cache takes > 2 seconds, let users know we're working on it #448
+
+### Bugs
  * `config-profiles` now pads the AccountID in the profile name as described. #446
+ * `cache` command no longer queries AWS twice if the cache was expired/invalidated
+ * Fix `make fmt` target to use gofmt
+
+### Changes
+ * Unexpected AccessToken failure is now considered an error
 
 ## [v1.9.5] - 2022-11-13
 
@@ -419,7 +429,8 @@
 
 Initial release
 
-[Unreleased]: https://github.com/synfinatic/aws-sso-cli/compare/v1.9.5...main
+[Unreleased]: https://github.com/synfinatic/aws-sso-cli/compare/v1.9.6...main
+[v1.9.6]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v1.9.6
 [v1.9.5]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v1.9.5
 [v1.9.4]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v1.9.4
 [v1.9.3]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v1.9.3

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT_VERSION := 1.9.4
+PROJECT_VERSION := 1.9.6
 DOCKER_REPO     := synfinatic
 PROJECT_NAME    := aws-sso
 
@@ -171,7 +171,7 @@ $(DIST_DIR):
 
 .PHONY: fmt
 fmt: ## Format Go code
-	@go fmt ./...
+	@gofmt -s -w */*.go */*/*.go
 
 .PHONY: test-fmt
 test-fmt: fmt ## Test to make sure code if formatted correctly

--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -91,6 +91,7 @@ var DEFAULT_CONFIG map[string]interface{} = map[string]interface{}{
 	"AutoConfigCheck":                           false,
 	"ProfileFormat":                             `{{ AccountIdStr .AccountId }}:{{ .RoleName }}`,
 	"CacheRefresh":                              24, // in hours
+	"Threads":                                   5,
 }
 
 type CLI struct {
@@ -103,6 +104,7 @@ type CLI struct {
 	SSO           string `kong:"short='S',help='Override default AWS SSO Instance',env='AWS_SSO',predictor='sso'"`
 	STSRefresh    bool   `kong:"help='Force refresh of STS Token Credentials'"`
 	NoConfigCheck bool   `kong:"help='Disable automatic ~/.aws/config updates'"`
+	Threads       int    `kong:"help='Override number of threads for talking to AWS'"`
 
 	// Commands
 	Cache          CacheCmd          `kong:"cmd,help='Force reload of cached AWS SSO role info and config.yaml'"`
@@ -236,11 +238,12 @@ func parseArgs(cli *CLI) (*kong.Context, sso.OverrideSettings) {
 	}
 
 	override := sso.OverrideSettings{
-		UrlAction:  action,
 		Browser:    cli.Browser,
 		DefaultSSO: cli.SSO,
 		LogLevel:   cli.LogLevel,
 		LogLines:   cli.Lines,
+		Threads:    cli.Threads,
+		UrlAction:  action,
 	}
 
 	log.SetFormatter(&logrus.TextFormatter{

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -28,6 +28,7 @@
 
  * [Error: Unable to save... org.freedesktop.DBus.Properties](#error-unable-to-save-orgfreedesktopdbusproperties)
  * [Error: Invalid grant provided](#error-invalid-grant-provided)
+ * [Error: Unexpected AccessToken failure; refreshing](#error-unexpected-accesstoken-failure-refreshing)
 
 ##### Misc
 
@@ -303,6 +304,15 @@ Depending on your OS and setup, running:
 
 as your default (non-root) user, but be sure to check the relevant documentation
 with your OS for best practices.
+
+### Error: Unexpected AccessToken failure; refreshing
+
+This can happen when querying AWS for a list of AWS Accounts or Roles and may
+indicate that AWS is throttling requests because the number of
+[Threads](config.md#Threads) is too high.
+
+Note: Unlike most errors, this one is not always fatal, but it can cause `aws-sso`
+to behave very poorly.
 
 ### Are macOS Keychain items synced?
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -37,6 +37,7 @@ DefaultRegion: <AWS_DEFAULT_REGION>
 DefaultSSO: <name of AWS SSO>
 CacheRefresh: <hours>
 AutoConfigCheck: [False|True]
+Threads: <integer>
 
 Browser: <path to web browser>
 UrlAction: [clip|exec|print|printurl|open|granted-containers|open-url-in-container]
@@ -212,6 +213,11 @@ is 24 (1 day).  Disable this feature by setting to any value <= 0.
 
 **Note:** If this feature is disabled, then [AutoConfigCheck](#autoconfigcheck)
 is also disabled.
+
+## Threads
+
+Certain actions when communicating with AWS can be accellerated by running multiple
+parallel threads.  Must be >= 1.  Default is 10 threads.
 
 ## Browser / UrlAction / UrlExecCommand
 

--- a/sso/awssso_test.go
+++ b/sso/awssso_test.go
@@ -656,8 +656,7 @@ func TestGetFieldNameAccountInfo(t *testing.T) {
 
 func TestGetAccountId64(t *testing.T) {
 	ai := AccountInfo{
-		AccountId:   "1111111",
-		AccountName: "FooBar",
+		AccountId: "1111111",
 	}
 
 	assert.Equal(t, int64(1111111), ai.GetAccountId64())
@@ -667,4 +666,16 @@ func TestGetAccountId64(t *testing.T) {
 
 	ai.AccountId = "InvalidAccountId"
 	assert.Panics(t, func() { ai.GetAccountId64() })
+
+	ri := RoleInfo{
+		AccountId: "1111111",
+	}
+
+	assert.Equal(t, int64(1111111), ri.GetAccountId64())
+
+	ri.AccountId = "-1"
+	assert.Panics(t, func() { ri.GetAccountId64() })
+
+	ri.AccountId = "InvalidAccountId"
+	assert.Panics(t, func() { ri.GetAccountId64() })
 }

--- a/sso/settings.go
+++ b/sso/settings.go
@@ -54,6 +54,7 @@ type Settings struct {
 	ConsoleDuration           int32                    `koanf:"ConsoleDuration" yaml:"ConsoleDuration,omitempty"`
 	JsonStore                 string                   `koanf:"JsonStore" yaml:"JsonStore,omitempty"`
 	CacheRefresh              int64                    `koanf:"CacheRefresh" yaml:"CacheRefresh,omitempty"`
+	Threads                   int                      `koanf:"Threads" yaml:"Threads,omitempty"`
 	AutoConfigCheck           bool                     `koanf:"AutoConfigCheck" yaml:"AutoConfigCheck,omitempty"`
 	FirefoxOpenUrlInContainer bool                     `koanf:"FirefoxOpenUrlInContainer" yaml:"FirefoxOpenUrlInContainer,omitempty"` // deprecated
 	UrlAction                 url.Action               `koanf:"UrlAction" yaml:"UrlAction"`
@@ -126,6 +127,7 @@ type OverrideSettings struct {
 	LogLevel   string
 	LogLines   bool
 	UrlAction  url.Action
+	Threads    int
 }
 
 // Loads our settings from config, cache and CLI args
@@ -310,6 +312,10 @@ func (s *Settings) setOverrides(override OverrideSettings) {
 
 	if override.UrlAction != "" {
 		s.UrlAction = override.UrlAction
+	}
+
+	if override.Threads > 0 {
+		s.Threads = override.Threads
 	}
 }
 

--- a/sso/settings_test.go
+++ b/sso/settings_test.go
@@ -308,6 +308,7 @@ func (suite *SettingsTestSuite) TestSetOverrides() {
 		Browser:    "my-browser",
 		DefaultSSO: "hello",
 		UrlAction:  url.PrintUrl,
+		Threads:    10,
 	}
 
 	s.setOverrides(overrides)
@@ -317,6 +318,7 @@ func (suite *SettingsTestSuite) TestSetOverrides() {
 	assert.Equal(t, "my-browser", s.Browser)
 	assert.Equal(t, "hello", s.DefaultSSO)
 	assert.Equal(t, url.PrintUrl, s.UrlAction)
+	assert.Equal(t, 10, s.Threads)
 }
 
 func TestCreatedAt(t *testing.T) {


### PR DESCRIPTION
- Add `Threads` config option (default is 10)
- Use "threads" to fetch role info from AWS
- Let users know when fetching roles is taking a while.

Fixes: #448