### PR TITLE
SSO authentication no longer uses Firefox containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
  * Fix fish auto-complete helper #472
 
+### Changes
+
+ * Authentication via your SSO provider no longer uses a Firefox container #486
+
 ## [v1.9.10] - 2023-02-27
 
  * Switch to `https` for homebrew submodule

--- a/internal/url/url.go
+++ b/internal/url/url.go
@@ -317,3 +317,13 @@ func commandBuilder(command []string, url string) (string, []string, error) {
 
 	return program, cmdList, nil
 }
+
+// SSOAuthAction returns the action except in the case where it might use a
+// container, in that case it returns a straight Open.  This is so that URLs
+// used to do AWS SSO auth use the primary browser session to avoid re-auth
+func SSOAuthAction(action Action) Action {
+	if action.IsContainer() {
+		return Open
+	}
+	return action
+}

--- a/internal/url/url_test.go
+++ b/internal/url/url_test.go
@@ -240,3 +240,24 @@ func TestNewConfigProfilesAction(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, a, ConfigProfilesAction("open"), a)
 }
+
+func TestSSOAuthAction(t *testing.T) {
+	// no change
+	a, _ := NewAction("clip")
+	assert.Equal(t, a, SSOAuthAction(Clip))
+	a, _ = NewAction("open")
+	assert.Equal(t, a, SSOAuthAction(Open))
+	a, _ = NewAction("")
+	assert.Equal(t, a, SSOAuthAction(Undef))
+	a, _ = NewAction("print")
+	assert.Equal(t, a, SSOAuthAction(Print))
+	a, _ = NewAction("printurl")
+	assert.Equal(t, a, SSOAuthAction(PrintUrl))
+	a, _ = NewAction("exec")
+	assert.Equal(t, a, SSOAuthAction(Exec))
+
+	// change to open
+	a, _ = NewAction("open")
+	assert.Equal(t, a, SSOAuthAction(GrantedContainer))
+	assert.Equal(t, a, SSOAuthAction(OpenUrlContainer))
+}

--- a/sso/awssso_auth.go
+++ b/sso/awssso_auth.go
@@ -109,7 +109,7 @@ func (as *AWSSSO) reauthenticate() error {
 		return fmt.Errorf("Unable to get device auth info from AWS SSO: %s", err.Error())
 	}
 
-	urlOpener := url.NewHandleUrl(as.urlAction, auth.VerificationUriComplete,
+	urlOpener := url.NewHandleUrl(url.SSOAuthAction(as.urlAction), auth.VerificationUriComplete,
 		as.browser, as.urlExecCommand)
 	urlOpener.ContainerSettings(as.StoreKey(), DEFAULT_AUTH_COLOR, DEFAULT_AUTH_ICON)
 


### PR DESCRIPTION
Should hopefully prevent users from having to re-authenticate their SSO session needlessly.

Fixes: #486