### PR TITLE
Profiles in .aws/config now include the `region` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changes
 
  * Authentication via your SSO provider no longer uses a Firefox container #486
+ * Profiles in ~/.aws/config now include the `region = XXX` option #481
 
 ## [v1.9.10] - 2023-02-27
 

--- a/cmd/aws-sso/config_profiles_cmd.go
+++ b/cmd/aws-sso/config_profiles_cmd.go
@@ -31,6 +31,7 @@ const (
 	CONFIG_TEMPLATE = `{{range $sso, $struct := . }}{{ range $arn, $profile := $struct }}
 [profile {{ $profile.Profile }}]
 credential_process = {{ $profile.BinaryPath }} -u {{ $profile.Open }} -S "{{ $profile.Sso }}" process --arn {{ $profile.Arn }}
+{{ if len $profile.DefaultRegion }}region = {{ printf "%s\n" $profile.DefaultRegion }}{{ end -}}
 {{ range $key, $value := $profile.ConfigVariables }}{{ $key }} = {{ $value }}
 {{end}}{{end}}{{end}}`
 )

--- a/sso/settings.go
+++ b/sso/settings.go
@@ -384,6 +384,7 @@ type ProfileConfig struct {
 	Arn             string
 	BinaryPath      string
 	ConfigVariables map[string]interface{}
+	DefaultRegion   string
 	Open            string
 	Profile         string
 	Sso             string
@@ -431,6 +432,7 @@ func (s *Settings) GetAllProfiles(open url.Action) (*ProfileMap, error) {
 				Arn:             role.Arn,
 				BinaryPath:      binaryPath,
 				ConfigVariables: s.ConfigVariables,
+				DefaultRegion:   role.DefaultRegion,
 				Open:            string(open),
 				Profile:         profile,
 				Sso:             ssoName,


### PR DESCRIPTION
If the user has set `DefaultRegion` in the `~/.aws-sso/config.yaml` file, then that will be set in the `~/.aws/config` file as the `region` option for the profile.

Fixes: #481