### PR TITLE
Flush oudated roles/SSO instances from cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs
 
  * Fix fish auto-complete helper #472
+ * Fix issue where we were not appropriately flushing the roles cache #479
 
 ### Changes
 

--- a/cmd/aws-sso/cache_cmd.go
+++ b/cmd/aws-sso/cache_cmd.go
@@ -40,6 +40,7 @@ func (cc *CacheCmd) Run(ctx *RunContext) error {
 	if err != nil {
 		return fmt.Errorf("Unable to refresh role cache: %s", err.Error())
 	}
+	ctx.Settings.Cache.PruneSSO(ctx.Settings)
 
 	err = ctx.Settings.Cache.Save(true)
 	if err != nil {

--- a/sso/cache_test.go
+++ b/sso/cache_test.go
@@ -539,3 +539,24 @@ func (suite *CacheTestSuite) TestProcessSSORoles() {
 	assert.Equal(t, "testing@domain.com", r.Accounts[123456789012].Roles["testing"].Tags["Email"])
 	assert.Equal(t, "testing", r.Accounts[123456789012].Roles["testing"].Tags["Role"])
 }
+
+func (suite *CacheTestSuite) TestPruneSSO() {
+	t := suite.T()
+
+	s := &Settings{
+		SSO: map[string]*SSOConfig{
+			"Primary": {},
+		},
+	}
+
+	c := &Cache{
+		SSO: map[string]*SSOCache{
+			"Primary": {},
+			"Invalid": {},
+		},
+	}
+
+	c.PruneSSO(s)
+	assert.Contains(t, c.SSO, "Primary")
+	assert.NotContains(t, c.SSO, "Invalid")
+}


### PR DESCRIPTION
Deleting or renaming an SSO instance in the config.yaml would result in those roles being left in the cache.json which would likely lead to conflicts when generating ~/.aws/config

We now prune any oudated SSO instances from the cache when they are removed from the config.yaml

Fixes: #479