### PR TITLE
Add support for FirstTag config option

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -18,13 +18,13 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.51.2
+          version: v1.52.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.18
+    - name: Set up Go 1.19
       uses: actions/setup-go@v1
       with:
-        go-version: 1.18
+        go-version: 1.19
       id: go
 
     - name: Check out code into the Go module directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@
 ### Changes
 
  * Authentication via your SSO provider no longer uses a Firefox container #486
+ * Bump to Go v1.19
+ * Bump to golangci-lint v1.52.2
+
+### New Features
+
  * Profiles in ~/.aws/config now include the `region = XXX` option #481
+ * Add `FirstTag` support in the config for placing a tag at the top of the select list #445
 
 ## [v1.9.10] - 2023-02-27
 

--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/synfinatic/aws-sso-cli/internal/helper"
 	"github.com/synfinatic/aws-sso-cli/internal/predictor"
 	"github.com/synfinatic/aws-sso-cli/internal/storage"
+	"github.com/synfinatic/aws-sso-cli/internal/tags"
 	"github.com/synfinatic/aws-sso-cli/internal/url"
 	"github.com/synfinatic/aws-sso-cli/internal/utils"
 	"github.com/synfinatic/aws-sso-cli/sso"
@@ -136,6 +137,7 @@ func main() {
 	predictor.SetLogger(log)
 	sso.SetLogger(log)
 	storage.SetLogger(log)
+	tags.SetLogger(log)
 	url.SetLogger(log)
 	utils.SetLogger(log)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -64,6 +64,7 @@ ConfigVariables:
     <Var2>: <Value2>
     <VarN>: <ValueN>
 
+FirstTag: <Tag Name>
 AccountPrimaryTag:
     - <tag 1>
     - <tag 2>
@@ -414,6 +415,11 @@ Some examples to consider:
 
  * `sts_regional_endpoints: regional`
  * `output: json`
+
+## FirstTag
+
+When selecting a role, the tag key name at the top of the list will be this value regardless
+of sort order.  Useful if you want `History` or some other tag easily accessible via arrow keys.
 
 ## AccountPrimaryTag
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/synfinatic/aws-sso-cli
 
-go 1.18
+go 1.19
 
 require (
 	github.com/99designs/keyring v1.2.2

--- a/internal/tags/logger.go
+++ b/internal/tags/logger.go
@@ -1,0 +1,38 @@
+package tags
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2022 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"github.com/sirupsen/logrus"
+)
+
+var log *logrus.Logger
+
+func SetLogger(l *logrus.Logger) {
+	log = l
+}
+
+func GetLogger() *logrus.Logger {
+	return log
+}
+
+// this is configured by cmd/main.go, but we have this here for unit tests
+func init() {
+	log = logrus.New()
+}

--- a/internal/tags/tags_list.go
+++ b/internal/tags/tags_list.go
@@ -1,4 +1,4 @@
-package sso
+package tags
 
 /*
  * AWS SSO CLI
@@ -82,7 +82,8 @@ func (t *TagsList) Merge(a *TagsList) {
 }
 
 // Returns a sorted unique list of tag keys, removing any keys which have already been picked
-func (t *TagsList) UniqueKeys(picked []string) []string {
+// if first is set, ensure that is the first element
+func (t *TagsList) UniqueKeys(picked []string, first string) []string {
 	keys := []string{}
 	for key := range *t {
 		seen := false
@@ -97,12 +98,29 @@ func (t *TagsList) UniqueKeys(picked []string) []string {
 		}
 	}
 	sort.Strings(keys)
+
+	// move the first element to the top
+	if first != "" {
+		found := false
+		// remove the element from the list
+		for i, v := range keys {
+			if v == first {
+				keys = append(keys[:i], keys[i+1:]...)
+				found = true
+				break
+			}
+		}
+		// add it to the top
+		if found {
+			keys = append([]string{first}, keys...)
+		}
+	}
 	return keys
 }
 
-// reformatHistory modifies the History tag values to their human format for the selector
+// ReformatHistory modifies the History tag values to their human format for the selector
 // History tag value is: <AccountAlias>:<RoleName>,<epochtime>
-func reformatHistory(value string) string {
+func ReformatHistory(value string) string {
 	x := strings.Split(value, ",")
 
 	// oldformat

--- a/internal/tags/tags_list_test.go
+++ b/internal/tags/tags_list_test.go
@@ -1,4 +1,4 @@
-package sso
+package tags
 
 import (
 	"fmt"
@@ -118,9 +118,12 @@ func (suite *TagsListTestSuite) TestUniqueKeys() {
 
 	tl.Add("tag3", "value3")
 
-	assert.ElementsMatch(t, []string{"tag", "tag2", "tag3"}, tl.UniqueKeys([]string{}), "All")
-	assert.ElementsMatch(t, []string{}, tl.UniqueKeys([]string{"tag", "tag2", "tag3"}), "None")
-	assert.ElementsMatch(t, []string{"tag2"}, tl.UniqueKeys([]string{"tag", "tag3"}), "Some")
+	assert.ElementsMatch(t, []string{"tag", "tag2", "tag3"}, tl.UniqueKeys([]string{}, ""), "All")
+	assert.ElementsMatch(t, []string{}, tl.UniqueKeys([]string{"tag", "tag2", "tag3"}, ""), "None")
+	assert.ElementsMatch(t, []string{"tag2"}, tl.UniqueKeys([]string{"tag", "tag3"}, ""), "Some")
+
+	assert.ElementsMatch(t, []string{"tag3", "tag", "tag2"}, tl.UniqueKeys([]string{}, "tag3"), "tag3")
+	assert.ElementsMatch(t, []string{"tag", "tag2", "tag3"}, tl.UniqueKeys([]string{}, "tag4"), "tag4")
 }
 
 func (suite *TagsListTestSuite) TestUniqueValues() {
@@ -148,7 +151,7 @@ func (suite *TagsListTestSuite) TestReformatHistory() {
 	t := suite.T()
 
 	// special case, has no timestamp
-	assert.Equal(t, "foo", reformatHistory("foo"))
+	assert.Equal(t, "foo", ReformatHistory("foo"))
 
 	invalidTS := []string{
 		"fooo,",
@@ -156,19 +159,19 @@ func (suite *TagsListTestSuite) TestReformatHistory() {
 	}
 
 	for _, x := range invalidTS {
-		assert.Panics(t, func() { reformatHistory(x) })
+		assert.Panics(t, func() { ReformatHistory(x) })
 	}
 
 	// valid case
 	ninetyMinAgo := time.Now().Add(time.Minute * -90)
 	x := fmt.Sprintf("foo,%d", ninetyMinAgo.Unix())
-	assert.Equal(t, "[1h30m0s] foo", reformatHistory(x))
+	assert.Equal(t, "[1h30m0s] foo", ReformatHistory(x))
 
 	thirtyMinAgo := time.Now().Add(time.Minute * -30)
 	x = fmt.Sprintf("foo,%d", thirtyMinAgo.Unix())
-	assert.Equal(t, "[0h30m0s] foo", reformatHistory(x))
+	assert.Equal(t, "[0h30m0s] foo", ReformatHistory(x))
 
 	// case with comma in account alias
 	x = fmt.Sprintf("foo, bar,%d", thirtyMinAgo.Unix())
-	assert.Equal(t, "[0h30m0s] foo, bar", reformatHistory(x))
+	assert.Equal(t, "[0h30m0s] foo, bar", ReformatHistory(x))
 }

--- a/sso/cache.go
+++ b/sso/cache.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	// "github.com/davecgh/go-spew/spew"
+	"github.com/synfinatic/aws-sso-cli/internal/tags"
 	"github.com/synfinatic/aws-sso-cli/internal/utils"
 )
 
@@ -369,15 +370,15 @@ func (c *Cache) MarkRolesExpired() error {
 }
 
 // returns all tags, but with with spaces replaced with underscores
-func (c *Cache) GetAllTagsSelect() *TagsList {
+func (c *Cache) GetAllTagsSelect() *tags.TagsList {
 	cache := c.GetSSO()
-	tags := cache.Roles.GetAllTags()
-	fixedTags := NewTagsList()
-	for k, values := range *tags {
+	t := cache.Roles.GetAllTags()
+	fixedTags := tags.NewTagsList()
+	for k, values := range *t {
 		key := strings.ReplaceAll(k, " ", "_")
 		for _, v := range values {
 			if key == "History" {
-				v = reformatHistory(v)
+				v = tags.ReformatHistory(v)
 			}
 			fixedTags.Add(key, strings.ReplaceAll(v, " ", "_"))
 		}
@@ -396,7 +397,7 @@ func (c *Cache) GetRoleTagsSelect() *RoleTags {
 		for k, v := range role.Tags {
 			key := strings.ReplaceAll(k, " ", "_")
 			if key == "History" {
-				v = reformatHistory(v)
+				v = tags.ReformatHistory(v)
 			}
 			value := strings.ReplaceAll(v, " ", "_")
 			ret[role.Arn][key] = value

--- a/sso/config.go
+++ b/sso/config.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/synfinatic/aws-sso-cli/internal/tags"
 	"github.com/synfinatic/aws-sso-cli/internal/utils"
 )
 
@@ -83,8 +84,8 @@ func (s *SSOConfig) GetRoles() []*SSORole {
 }
 
 // returns all of the available account & role tags for our SSO Provider
-func (s *SSOConfig) GetAllTags() *TagsList {
-	tags := NewTagsList()
+func (s *SSOConfig) GetAllTags() *tags.TagsList {
+	tags := tags.NewTagsList()
 
 	for _, accountInfo := range s.Accounts {
 		/*

--- a/sso/roles.go
+++ b/sso/roles.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/Masterminds/sprig/v3"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/synfinatic/aws-sso-cli/internal/tags"
 	"github.com/synfinatic/aws-sso-cli/internal/utils"
 	"github.com/synfinatic/gotable"
 )
@@ -99,8 +100,8 @@ func (r *Roles) GetAccountRoles(accountId int64) map[string]*AWSRoleFlat {
 }
 
 // GetAllTags returns all the unique key/tag pairs for every role
-func (r *Roles) GetAllTags() *TagsList {
-	ret := TagsList{}
+func (r *Roles) GetAllTags() *tags.TagsList {
+	ret := tags.TagsList{}
 	fList := r.GetAllRoles()
 	for _, role := range fList {
 		for k, v := range role.Tags {

--- a/sso/settings.go
+++ b/sso/settings.go
@@ -69,6 +69,7 @@ type Settings struct {
 	HistoryMinutes            int64                    `koanf:"HistoryMinutes" yaml:"HistoryMinutes,omitempty"`
 	ProfileFormat             string                   `koanf:"ProfileFormat" yaml:"ProfileFormat,omitempty"`
 	AccountPrimaryTag         []string                 `koanf:"AccountPrimaryTag" yaml:"AccountPrimaryTag,omitempty"`
+	FirstTag                  string                   `koanf:"FirstTag" yaml:"FirstTag,omitempty"`
 	PromptColors              PromptColors             `koanf:"PromptColors" yaml:"PromptColors,omitempty"` // go-prompt colors
 	ListFields                []string                 `koanf:"ListFields" yaml:"ListFields,omitempty"`
 	ConfigVariables           map[string]interface{}   `koanf:"ConfigVariables" yaml:"ConfigVariables,omitempty"`


### PR DESCRIPTION
Allows overriding the default sort order and place a specific tag at the top of the list.

Fixes: #445