### PR TITLE
Fix windows powershell eval support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [v1.10.0] - 2023-07-29
+
 ### Bugs
 
  * Fix fish auto-complete helper #472
@@ -17,6 +19,7 @@
 
  * Profiles in ~/.aws/config now include the `region = XXX` option #481
  * Add `FirstTag` support in the config for placing a tag at the top of the select list #445
+ * Support `eval` command in Windows PowerShell via Invoke-Expression #188
 
 ## [v1.9.10] - 2023-02-27
 
@@ -486,7 +489,8 @@
 
 Initial release
 
-[Unreleased]: https://github.com/synfinatic/aws-sso-cli/compare/v1.9.10...main
+[Unreleased]: https://github.com/synfinatic/aws-sso-cli/compare/v1.10.0...main
+[v1.10.0]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v1.9.10
 [v1.9.10]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v1.9.9
 [v1.9.9]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v1.9.9
 [v1.9.8]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v1.9.8

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -166,6 +166,15 @@ of _STDERR_ to see the URL to open.
 See [Environment Variables](#environment-variables) for more information about
 what varibles are set.
 
+#### Windows PowerShell
+
+Getting Windows PowerShell to work requires a slightly different invocation than
+bash/zsh/etc:
+
+`aws-sso eval <args> | Out-String | Invoke-Expression`
+
+But other than that, it works the same way.
+
 ---
 
 ### exec


### PR DESCRIPTION
PowerShell requires a slightly different output of environment variables than bash/zsh/etc.

Updated docs to refelect how to use `eval` with PowerShell.

Bump to v1.10.0

Fixes: #188