### PR TITLE
Allow sorting of roles via an arbitrary field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## [v1.10.0] - 2023-07-29
+## [v1.10.0] - 2023-07-30
 
 ### Bugs
 
@@ -14,12 +14,14 @@
  * Authentication via your SSO provider no longer uses a Firefox container #486
  * Bump to Go v1.19
  * Bump to golangci-lint v1.52.2
+ * AccountId in the `list` command output are now presented with a leading zero
 
 ### New Features
 
  * Profiles in ~/.aws/config now include the `region = XXX` option #481
  * Add `FirstTag` support in the config for placing a tag at the top of the select list #445
  * Support `eval` command in Windows PowerShell via Invoke-Expression #188
+ * Add support for `--sort` and `--reverse` flags for the `list` command #466
 
 ## [v1.9.10] - 2023-02-27
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT_VERSION := 1.9.10
+PROJECT_VERSION := 1.10.0
 DOCKER_REPO     := synfinatic
 PROJECT_NAME    := aws-sso
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -257,9 +257,11 @@ which fields are printed by specifying the field names as arguments.
 Flags:
 
  * `--list-fields`, `-f` -- List the available fields to print
- * `--prefix <Field>=<Prefix>`, `-P` -- Filter results by the given field 
+ * `--prefix <FieldName>=<Prefix>`, `-P` -- Filter results by the given field 
     value & prefix value
  * `--csv` -- Generate results in CSV format
+ * `--sort <FieldName>`, `-s` -- Sort results by the provided field name
+ * `--reverse` -- Reverse the sort order
 
 Arguments: `[<field> ...]`
 
@@ -272,6 +274,8 @@ Default fields:
  * `AccountAlias`
  * `RoleName`
  * `ExpiresStr`
+
+**Note:** Sorting always happens in a case-sensitive and alphabetic manner.
 
 ---
 
@@ -354,14 +358,16 @@ the new settings if you've upgraded from a previous version!
 
 The following environment variables are honored by `aws-sso`:
 
- * `AWS_SSO_FILE_PASSWORD` -- Password to use with the `file` SecureStore
- * `AWS_SSO_CONFIG` -- Specify an alternate path to the `aws-sso` config file
- * `AWS_SSO_BROWSER` -- Override default browser for AWS SSO login
- * `AWS_SSO` -- Override default AWS SSO instance to use
- * `AWS_SSO_ROLE_NAME` -- Used for `--role`/`-R` with some commands
- * `AWS_SSO_ACCOUNT_ID` -- Used for `--account`/`-A` with some commands
- * `AWS_SSO_ROLE_ARN` -- Used for `--arn`/`-a` with some commands and with
-     `eval --refresh`
+ * `AWS_SSO_FILE_PASSWORD` -- Password to use with the `file` SecureStore.
+ * `AWS_SSO_CONFIG` -- Specify an alternate path to the `aws-sso` config file.
+ * `AWS_SSO_BROWSER` -- Override default browser for AWS SSO login.
+ * `AWS_SSO` -- Override default AWS SSO instance to use.
+ * `AWS_SSO_ROLE_NAME` -- Used for `--role`/`-R` with some commands.
+ * `AWS_SSO_ACCOUNT_ID` -- Used for `--account`/`-A` with some commands.
+ * `AWS_SSO_ROLE_ARN` -- Used for `--arn`/`-a` with some commands and with.
+     `eval --refresh`.
+ * `AWS_SSO_FIELD_SORT` -- Used by `list` command to select which field to sort by.
+ * `AWS_SSO_FIELD_SORT_REVERSE` -- Used to reverse the `list` sort order.  Set to `1` to enable.
 
 The `file` SecureStore will use the `AWS_SSO_FILE_PASSWORD` environment
 variable for the password if it is set. (Not recommended.)

--- a/sso/cache_test.go
+++ b/sso/cache_test.go
@@ -384,7 +384,7 @@ func (suite *CacheTestSuite) TestGetAllRoles() {
 	assert.Equal(t, 4, len(aroles))
 	aroles = cache.Roles.GetAccountRoles(502470824893)
 	assert.Equal(t, 4, len(aroles))
-	aroles = cache.Roles.GetAccountRoles(258234615182)
+	aroles = cache.Roles.GetAccountRoles(25823461518)
 	assert.Equal(t, 7, len(aroles))
 }
 

--- a/sso/roles_test.go
+++ b/sso/roles_test.go
@@ -108,7 +108,7 @@ func (suite *CacheRolesTestSuite) TestAccountIds() {
 	roles := suite.cache.SSO[suite.cache.ssoName].Roles
 
 	assert.NotEmpty(t, roles.AccountIds())
-	assert.Contains(t, roles.AccountIds(), int64(258234615182))
+	assert.Contains(t, roles.AccountIds(), int64(25823461518))
 	assert.NotContains(t, roles.AccountIds(), int64(2582346))
 }
 
@@ -124,7 +124,7 @@ func (suite *CacheRolesTestSuite) TestGetAccountRoles() {
 	t := suite.T()
 	roles := suite.cache.SSO[suite.cache.ssoName].Roles
 
-	flat := roles.GetAccountRoles(258234615182)
+	flat := roles.GetAccountRoles(25823461518)
 	assert.NotEmpty(t, flat)
 
 	flat = roles.GetAccountRoles(258234615)
@@ -147,7 +147,7 @@ func (suite *CacheRolesTestSuite) TestGetRoleTags() {
 
 	tags := *(roles.GetRoleTags())
 	assert.NotEmpty(t, tags)
-	arn := "arn:aws:iam::258234615182:role/AWSAdministratorAccess"
+	arn := "arn:aws:iam::025823461518:role/AWSAdministratorAccess"
 	assert.Contains(t, tags, arn)
 	assert.NotContains(t, tags, "foobar")
 	assert.Contains(t, tags[arn]["Email"], "control-tower-dev-aws@ourcompany.com")
@@ -161,9 +161,9 @@ func (suite *CacheRolesTestSuite) TestGetRole() {
 	_, err := roles.GetRole(58234615182, "AWSAdministratorAccess")
 	assert.Error(t, err)
 
-	r, err := roles.GetRole(258234615182, "AWSAdministratorAccess")
+	r, err := roles.GetRole(25823461518, "AWSAdministratorAccess")
 	assert.NoError(t, err)
-	assert.Equal(t, int64(258234615182), r.AccountId)
+	assert.Equal(t, int64(25823461518), r.AccountId)
 	assert.Equal(t, "AWSAdministratorAccess", r.RoleName)
 	assert.Equal(t, "", r.Profile)
 	assert.Equal(t, "us-east-1", r.DefaultRegion)
@@ -176,7 +176,7 @@ func (suite *CacheRolesTestSuite) TestGetRole() {
 func (suite *CacheRolesTestSuite) TestProfileName() {
 	t := suite.T()
 	roles := suite.cache.SSO[suite.cache.ssoName].Roles
-	r, err := roles.GetRole(258234615182, "AWSAdministratorAccess")
+	r, err := roles.GetRole(25823461518, "AWSAdministratorAccess")
 	assert.NoError(t, err)
 
 	p, err := r.ProfileName(suite.settings)
@@ -231,6 +231,35 @@ func (suite *CacheRolesTestSuite) TestGetEnvVarTags() {
 		"AWS_SSO_TAG_ACCOUNTNAME": "Audit",
 	}
 	assert.Equal(t, x, flat.GetEnvVarTags(&settings))
+}
+
+func TestAWSRoleFlatGetField(t *testing.T) {
+	flat := AWSRoleFlat{
+		RoleName:  "foobar",
+		AccountId: 12344553243,
+		Expires:   0,
+	}
+
+	f, err := flat.GetField("RoleName")
+	assert.NoError(t, err)
+	assert.Equal(t, Sval, f.Type)
+	assert.Equal(t, "foobar", f.Sval)
+
+	f, err = flat.GetField("AccountId")
+	assert.NoError(t, err)
+	assert.Equal(t, Sval, f.Type)
+	assert.Equal(t, "012344553243", f.Sval)
+
+	f, err = flat.GetField("Expires")
+	assert.NoError(t, err)
+	assert.Equal(t, Ival, f.Type)
+	assert.Equal(t, int64(0), f.Ival)
+
+	f, err = flat.GetField("Tags")
+	assert.Error(t, err)
+
+	f, err = flat.GetField("Role")
+	assert.Error(t, err)
 }
 
 func TestAWSRoleFlatGetHeader(t *testing.T) {

--- a/sso/testdata/cache.json
+++ b/sso/testdata/cache.json
@@ -6,7 +6,7 @@
       "LastUpdate": 1635913188,
       "Roles": {
         "Accounts": {
-          "258234615182": {
+          "025823461518": {
             "Alias": "OurCompany Control Tower Playground",
             "Name": "OurCompany Control Tower Playground",
             "EmailAddress": "control-tower-dev-aws@ourcompany.com",
@@ -15,11 +15,11 @@
             },
             "Roles": {
               "AWSAdministratorAccess": {
-                "Arn": "arn:aws:iam::258234615182:role/AWSAdministratorAccess",
+                "Arn": "arn:aws:iam::025823461518:role/AWSAdministratorAccess",
 				"DefaultRegion": "us-east-1",
                 "Tags": {
                   "AccountAlias": "OurCompany Control Tower Playground",
-                  "AccountID": "258234615182",
+                  "AccountID": "025823461518",
                   "AccountName": "OurCompany Control Tower Playground",
                   "Email": "control-tower-dev-aws@ourcompany.com",
                   "Foo": "Bar",
@@ -29,60 +29,60 @@
                 }
               },
               "AWSOrganizationsFullAccess": {
-                "Arn": "arn:aws:iam::258234615182:role/AWSOrganizationsFullAccess",
+                "Arn": "arn:aws:iam::025823461518:role/AWSOrganizationsFullAccess",
                 "Tags": {
                   "AccountAlias": "OurCompany Control Tower Playground",
-                  "AccountID": "258234615182",
+                  "AccountID": "025823461518",
                   "AccountName": "OurCompany Control Tower Playground",
                   "Email": "control-tower-dev-aws@ourcompany.com",
                   "Role": "AWSOrganizationsFullAccess"
                 }
               },
               "AWSPowerUserAccess": {
-                "Arn": "arn:aws:iam::258234615182:role/AWSPowerUserAccess",
+                "Arn": "arn:aws:iam::025823461518:role/AWSPowerUserAccess",
                 "Tags": {
                   "AccountAlias": "OurCompany Control Tower Playground",
-                  "AccountID": "258234615182",
+                  "AccountID": "025823461518",
                   "AccountName": "OurCompany Control Tower Playground",
                   "Email": "control-tower-dev-aws@ourcompany.com",
                   "Role": "AWSPowerUserAccess"
                 }
               },
               "AWSReadOnlyAccess": {
-                "Arn": "arn:aws:iam::258234615182:role/AWSReadOnlyAccess",
+                "Arn": "arn:aws:iam::025823461518:role/AWSReadOnlyAccess",
                 "Tags": {
                   "AccountAlias": "OurCompany Control Tower Playground",
-                  "AccountID": "258234615182",
+                  "AccountID": "025823461518",
                   "AccountName": "OurCompany Control Tower Playground",
                   "Email": "control-tower-dev-aws@ourcompany.com",
                   "Role": "AWSReadOnlyAccess"
                 }
               },
               "AWSServiceCatalogEndUserAccess": {
-                "Arn": "arn:aws:iam::258234615182:role/AWSServiceCatalogEndUserAccess",
+                "Arn": "arn:aws:iam::025823461518:role/AWSServiceCatalogEndUserAccess",
                 "Tags": {
                   "AccountAlias": "OurCompany Control Tower Playground",
-                  "AccountID": "258234615182",
+                  "AccountID": "025823461518",
                   "AccountName": "OurCompany Control Tower Playground",
                   "Email": "control-tower-dev-aws@ourcompany.com",
                   "Role": "AWSServiceCatalogEndUserAccess"
                 }
               },
               "DoNothingRole": {
-                "Arn": "arn:aws:iam::258234615182:role/DoNothingRole",
+                "Arn": "arn:aws:iam::025823461518:role/DoNothingRole",
                 "Tags": {
                   "AccountAlias": "OurCompany Control Tower Playground",
-                  "AccountID": "258234615182",
+                  "AccountID": "025823461518",
                   "AccountName": "OurCompany Control Tower Playground",
                   "Email": "control-tower-dev-aws@ourcompany.com",
                   "Role": "DoNothingRole"
                 }
               },
               "SSO-ProductionDevelopersRO": {
-                "Arn": "arn:aws:iam::258234615182:role/SSO-ProductionDevelopersRO",
+                "Arn": "arn:aws:iam::025823461518:role/SSO-ProductionDevelopersRO",
                 "Tags": {
                   "AccountAlias": "OurCompany Control Tower Playground",
-                  "AccountID": "258234615182",
+                  "AccountID": "025823461518",
                   "AccountName": "OurCompany Control Tower Playground",
                   "Email": "control-tower-dev-aws@ourcompany.com",
                   "Role": "SSO-ProductionDevelopersRO"


### PR DESCRIPTION
Add `--sort` and `--reverse` to the `list` command to enable sorting by any available field and reverse sorting.  Sorting always happens alphabetically and is case-sensitive.

AccountIds are also now always presented with leading zeros as appropriate now.

Fixes #466