### PR TITLE
Add FullTextSearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # AWS SSO CLI Changelog
 
+## Unreleased
+
+### Changes
+
+ * [FullTextSearch](docs/config.md) is enabled by default for interactive `list` mode.
+
+### New Features
+
+ * Add full-text search for interactive `list` mode #504
+
 ## [v1.11.0] - 2023-08-02
 
 ### Bugs

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT_VERSION := 1.11.0
+PROJECT_VERSION := 1.12.0
 DOCKER_REPO     := synfinatic
 PROJECT_NAME    := aws-sso
 

--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -90,6 +90,7 @@ var DEFAULT_CONFIG map[string]interface{} = map[string]interface{}{
 	"DefaultSSO":                                "Default",
 	"FirefoxOpenUrlInContainer":                 false,
 	"AutoConfigCheck":                           false,
+	"FullTextSearch":                            true,
 	"ProfileFormat":                             sso.DEFAULT_PROFILE_TEMPLATE,
 	"CacheRefresh":                              24, // in hours
 	"Threads":                                   5,

--- a/cmd/aws-sso/setup_cmd.go
+++ b/cmd/aws-sso/setup_cmd.go
@@ -100,6 +100,7 @@ func setupWizard(ctx *RunContext, reconfig, addSSO bool) error {
 			ConsoleDuration: 60,
 			CacheRefresh:    168,
 			AutoConfigCheck: false,
+			FullTextSearch:  true,
 			HistoryLimit:    10,
 			HistoryMinutes:  1440,
 			UrlExecCommand:  []string{},
@@ -118,6 +119,9 @@ func setupWizard(ctx *RunContext, reconfig, addSSO bool) error {
 	if s.CacheRefresh > 0 {
 		s.AutoConfigCheck = promptAutoConfigCheck(s.AutoConfigCheck)
 	}
+
+	// full text search?
+	s.FullTextSearch = promptFullTextSearch(s.FullTextSearch)
 
 	// next how we open URLs
 	s.UrlAction = promptUrlAction(s.UrlAction)

--- a/cmd/aws-sso/setup_prompt.go
+++ b/cmd/aws-sso/setup_prompt.go
@@ -549,6 +549,28 @@ func promptAutoConfigCheck(flag bool) bool {
 	return yesNoItems[i].Value == "Yes"
 }
 
+func promptFullTextSearch(flag bool) bool {
+	var i int
+	var err error
+
+	fmt.Printf("\n")
+
+	label := "Enable full-text search? (FullTextSearch)"
+	sel := promptui.Select{
+		Label:        label,
+		Items:        yesNoItems,
+		CursorPos:    yesNoPos(flag),
+		HideSelected: false,
+		Stdout:       &utils.BellSkipper{},
+		Templates:    makeSelectTemplate(label),
+	}
+	if i, _, err = sel.Run(); err != nil {
+		log.WithError(err).Fatalf("Unable to select FullTextSearch")
+	}
+
+	return yesNoItems[i].Value == "Yes"
+}
+
 func promptCacheRefresh(defaultValue int64) int64 {
 	var val string
 	var err error

--- a/docs/config.md
+++ b/docs/config.md
@@ -65,6 +65,7 @@ ConfigVariables:
     <VarN>: <ValueN>
 
 FirstTag: <Tag Name>
+FullTextSearch: [true|false]
 AccountPrimaryTag:
     - <tag 1>
     - <tag 2>
@@ -423,6 +424,11 @@ Some examples to consider:
 When selecting a role, the tag key name at the top of the list will be this value regardless
 of sort order.  Useful if you want `History` or some other tag easily accessible via arrow keys.
 
+## FullTextSearch
+
+When set to `true`, searching via interactive exec mode (`aws-sso exec` without role selector args)
+will cause searching to be done via substrings rather than the default prefix based search.
+
 ## AccountPrimaryTag
 
 When selecting a role, if you first select by role name (via the `Role` tag) you
@@ -507,6 +513,7 @@ Specify which fields to display via the `list` command.  Valid options are:
  * `Id` -- Unique row identifier
  * `AccountAlias` -- Account Name from AWS SSO
  * `AccountId` -- AWS Account Id
+ * `AccountIdPad` -- AWS Account Id with leading zeros if necessary
  * `AccountName` -- Account Name from config.yaml
  * `Arn` -- Role ARN
  * `DefaultRegion` -- Configured default region

--- a/sso/settings.go
+++ b/sso/settings.go
@@ -74,6 +74,7 @@ type Settings struct {
 	ListFields                []string                 `koanf:"ListFields" yaml:"ListFields,omitempty"`
 	ConfigVariables           map[string]interface{}   `koanf:"ConfigVariables" yaml:"ConfigVariables,omitempty"`
 	EnvVarTags                []string                 `koanf:"EnvVarTags" yaml:"EnvVarTags,omitempty"`
+	FullTextSearch            bool                     `koanf:"FullTextSearch" yaml:"FullTextSearch"`
 }
 
 // GetDefaultRegion scans the config settings file to pick the most local DefaultRegion from the tree


### PR DESCRIPTION
Enable full text search in interactive list mode.  Users can disable via `FullTextSearch: false` in the config file

Fixes: #504