### PR TITLE
Do not generate bogus config statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
  * No longer crash during guided setup if user presses `<Del>` #531
  * No longer error out on simple input errors during guided setup
+ * Do not create invalid `maxretry` and `maxbackoff` in SSO Instance during config #536
 
 ### Changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT_VERSION := 1.12.0
+PROJECT_VERSION := 1.13.0
 DOCKER_REPO     := synfinatic
 PROJECT_NAME    := aws-sso
 

--- a/sso/config.go
+++ b/sso/config.go
@@ -34,8 +34,8 @@ type SSOConfig struct {
 	Accounts      map[string]*SSOAccount `koanf:"Accounts" yaml:"Accounts,omitempty"` // key must be a string to avoid parse errors!
 	DefaultRegion string                 `koanf:"DefaultRegion" yaml:"DefaultRegion,omitempty"`
 	// passed to AWSSSO from our Settings
-	MaxBackoff int
-	MaxRetry   int
+	MaxBackoff int `koanf:"-" yaml:"-"`
+	MaxRetry   int `koanf:"-" yaml:"-"`
 }
 
 type SSOAccount struct {


### PR DESCRIPTION
The `maxretry` and `maxbackoff` are not config options exposed a the SSO Instance layer and should not generate entries in the config during `aws-sso config`

Fixes: #536