### PR TITLE
AutoConfigCheck now honors AWS_CONFIG_FILE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
  * Added [logout](docs/commands.md#logout) command which invalidates the browser
     session and all credentials #526
+ * `AutoConfigCheck` now honors the `$AWS_CONFIG_FILE` variable #540
+ * `config-profiles` now supports the `--aws-config` flag
 
 ## [v1.12.0] - 2023-08-12
 

--- a/cmd/aws-sso/auth.go
+++ b/cmd/aws-sso/auth.go
@@ -21,6 +21,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/synfinatic/aws-sso-cli/internal/awsconfig"
 	"github.com/synfinatic/aws-sso-cli/internal/url"
 	"github.com/synfinatic/aws-sso-cli/internal/utils"
 	"github.com/synfinatic/aws-sso-cli/sso"
@@ -101,29 +102,10 @@ func doAuth(ctx *RunContext) *sso.AWSSSO {
 		// should we update our config??
 		if !ctx.Cli.NoConfigCheck && ctx.Settings.AutoConfigCheck {
 			if ctx.Settings.ConfigProfilesUrlAction != url.ConfigProfilesUndef {
-				cfgFile := utils.GetHomePath("~/.aws/config")
-
 				action, _ := url.NewAction(string(ctx.Settings.ConfigProfilesUrlAction))
-				profiles, err := ctx.Settings.GetAllProfiles(action)
+				err := awsconfig.UpdateAwsConfig(ctx.Settings, action, "", true, false)
 				if err != nil {
-					log.Warnf("Unable to update %s: %s", cfgFile, err.Error())
-					return AwsSSO
-				}
-
-				if err = profiles.UniqueCheck(ctx.Settings); err != nil {
-					log.Errorf("Unable to update %s: %s", cfgFile, err.Error())
-					return AwsSSO
-				}
-
-				f, err := utils.NewFileEdit(CONFIG_TEMPLATE, profiles)
-				if err != nil {
-					log.Errorf("%s", err)
-					return AwsSSO
-				}
-
-				if err = f.UpdateConfig(true, false, cfgFile); err != nil {
-					log.Errorf("Unable to update %s: %s", cfgFile, err.Error())
-					return AwsSSO
+					log.Errorf("Unable to auto-update aws config file: %s", err.Error())
 				}
 			}
 		}

--- a/cmd/aws-sso/config_profiles_cmd.go
+++ b/cmd/aws-sso/config_profiles_cmd.go
@@ -20,14 +20,12 @@ package main
 
 import (
 	"fmt"
-	"os"
 
+	"github.com/synfinatic/aws-sso-cli/internal/awsconfig"
 	"github.com/synfinatic/aws-sso-cli/internal/url"
-	"github.com/synfinatic/aws-sso-cli/internal/utils"
 )
 
 const (
-	AWS_CONFIG_FILE = "~/.aws/config"
 	CONFIG_TEMPLATE = `{{range $sso, $struct := . }}{{ range $arn, $profile := $struct }}
 [profile {{ $profile.Profile }}]
 credential_process = {{ $profile.BinaryPath }} -u {{ $profile.Open }} -S "{{ $profile.Sso }}" process --arn {{ $profile.Arn }}
@@ -37,10 +35,11 @@ credential_process = {{ $profile.BinaryPath }} -u {{ $profile.Open }} -S "{{ $pr
 )
 
 type ConfigProfilesCmd struct {
-	Diff  bool   `kong:"help='Print a diff of changes to the config file instead of modifying it',xor='action'"`
-	Force bool   `kong:"help='Write a new config file without prompting'"`
-	Open  string `kong:"help='Specify how to open URLs: [clip|exec|open|granted-containers|open-url-in-container]'"`
-	Print bool   `kong:"help='Print profile entries instead of modifying config file',xor='action'"`
+	Diff      bool   `kong:"help='Print a diff of changes to the config file instead of modifying it',xor='action'"`
+	Force     bool   `kong:"help='Write a new config file without prompting'"`
+	Open      string `kong:"help='Specify how to open URLs: [clip|exec|open|granted-containers|open-url-in-container]'"`
+	Print     bool   `kong:"help='Print profile entries instead of modifying config file',xor='action'"`
+	AwsConfig string `kong:"help='Path to AWS config file',env='AWS_CONFIG_FILE',default='~/.aws/config'"`
 }
 
 func (cc *ConfigProfilesCmd) Run(ctx *RunContext) error {
@@ -67,35 +66,9 @@ func (cc *ConfigProfilesCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	profiles, err := ctx.Settings.GetAllProfiles(urlAction)
-	if err != nil {
-		return err
-	}
-
-	if err := profiles.UniqueCheck(ctx.Settings); err != nil {
-		return err
-	}
-
-	f, err := utils.NewFileEdit(CONFIG_TEMPLATE, profiles)
-	if err != nil {
-		return err
-	}
-
 	if ctx.Cli.ConfigProfiles.Print {
-		return f.Template.Execute(os.Stdout, profiles)
+		return awsconfig.PrintAwsConfig(ctx.Settings, urlAction)
 	}
-
-	oldConfig := awsConfigFile()
-	return f.UpdateConfig(ctx.Cli.ConfigProfiles.Diff, ctx.Cli.ConfigProfiles.Force, oldConfig)
-}
-
-// awsConfigFile returns the path the the users ~/.aws/config
-func awsConfigFile() string {
-	// did user set the value?
-	path := os.Getenv("AWS_CONFIG_FILE")
-	if path == "" {
-		path = utils.GetHomePath(AWS_CONFIG_FILE)
-	}
-	log.Debugf("path = %s", path)
-	return path
+	return awsconfig.UpdateAwsConfig(ctx.Settings, urlAction, ctx.Cli.ConfigProfiles.AwsConfig,
+		ctx.Cli.ConfigProfiles.Diff, ctx.Cli.ConfigProfiles.Force)
 }

--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -27,7 +27,7 @@ import (
 	"github.com/posener/complete"
 	// "github.com/davecgh/go-spew/spew"
 	"github.com/sirupsen/logrus"
-	"github.com/synfinatic/aws-sso-cli/internal/awsconfig"
+	"github.com/synfinatic/aws-sso-cli/internal/awscreds"
 	"github.com/synfinatic/aws-sso-cli/internal/helper"
 	"github.com/synfinatic/aws-sso-cli/internal/predictor"
 	"github.com/synfinatic/aws-sso-cli/internal/server"
@@ -139,7 +139,7 @@ func main() {
 
 	log = logrus.New()
 	ctx, override := parseArgs(&cli)
-	awsconfig.SetLogger(log)
+	awscreds.SetLogger(log)
 	helper.SetLogger(log)
 	predictor.SetLogger(log)
 	sso.SetLogger(log)

--- a/cmd/aws-sso/static_cmd.go
+++ b/cmd/aws-sso/static_cmd.go
@@ -31,7 +31,7 @@ import (
 	// "github.com/davecgh/go-spew/spew"
 	//	"github.com/manifoldco/promptui"
 	"github.com/manifoldco/promptui"
-	"github.com/synfinatic/aws-sso-cli/internal/awsconfig"
+	"github.com/synfinatic/aws-sso-cli/internal/awscreds"
 	"github.com/synfinatic/aws-sso-cli/internal/storage"
 	"github.com/synfinatic/aws-sso-cli/internal/utils"
 	"github.com/synfinatic/aws-sso-cli/sso"
@@ -129,7 +129,7 @@ func (cc *StaticAddCmd) Run(ctx *RunContext) error {
 	}
 
 	// check if key is valid
-	p := awsconfig.Profile{
+	p := awscreds.Profile{
 		FromConfig:      false,
 		Name:            profile,
 		AccessKeyId:     accessKey,
@@ -233,7 +233,7 @@ type StaticImportCmd struct{}
 
 // StaticImportCmd imports static credentials into the SecureStore
 func (cc *StaticImportCmd) Run(ctx *RunContext) error {
-	a, err := awsconfig.NewAwsConfig(awsconfig.CONFIG_FILE, awsconfig.CREDENTIALS_FILE)
+	a, err := awscreds.NewAwsConfig(awscreds.CONFIG_FILE, awscreds.CREDENTIALS_FILE)
 	if err != nil {
 		return err
 	}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -84,7 +84,7 @@ Flags:
  * `--open` -- Specify how to open URls: [clip|exec|open]
  * `--print` -- Print profile entries instead of modifying config file
  * `--force` -- Write a new config file without prompting
-
+ * `--aws-config` -- Override path to `~/.aws/config` file
 
 By default, each profile is named according to the [ProfileFormat](
 config.md#profileformat) config option or overridden by the user defined
@@ -386,6 +386,7 @@ Flags:
 
 The following environment variables are honored by `aws-sso`:
 
+ * `AWS_CONFIG_FILE` -- Override default path to `~/.aws/config` file
  * `AWS_SSO_FILE_PASSWORD` -- Password to use with the `file` SecureStore.
  * `AWS_SSO_CONFIG` -- Specify an alternate path to the `aws-sso` config file.
  * `AWS_SSO_BROWSER` -- Override default browser for AWS SSO login.

--- a/docs/config.md
+++ b/docs/config.md
@@ -524,6 +524,10 @@ are warranted in your `~/.aws/config`.
 **Note:** This option can be disabled temporarily on the command line by passing
 the `--no-config-check` flag.
 
+**Note:** If you are using a non-default path for your `~/.aws/config` file, then
+you must be sure to set the `AWS_CONFIG_FILE` environment variable to the correct
+path or disable this configuration option.
+
 #### LogLevel / LogLines
 
 By default, the `LogLevel` is 'warn'.  You can override it here or via

--- a/internal/awsconfig/config_test.go
+++ b/internal/awsconfig/config_test.go
@@ -1,0 +1,232 @@
+package awsconfig
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2023 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/synfinatic/aws-sso-cli/internal/url"
+	"github.com/synfinatic/aws-sso-cli/internal/utils"
+	"github.com/synfinatic/aws-sso-cli/sso"
+)
+
+func TestAwsConfigFile(t *testing.T) {
+	assert.Equal(t, "/dev/null", AwsConfigFile("/dev/null"))
+
+	os.Setenv("AWS_CONFIG_FILE", "/foo/bar")
+	assert.Equal(t, "/foo/bar", AwsConfigFile(""))
+
+	os.Unsetenv("AWS_CONFIG_FILE")
+	test := utils.GetHomePath("~/.foo.bar")
+	assert.Equal(t, test, AwsConfigFile("~/.foo.bar"))
+
+	assert.Equal(t, utils.GetHomePath("~/.aws/config"), AwsConfigFile(""))
+}
+
+func TestGetProfileMap(t *testing.T) {
+	s := &sso.Settings{
+		Cache: &sso.Cache{
+			SSO: map[string]*sso.SSOCache{
+				"Default": {
+					Roles: &sso.Roles{
+						Accounts: map[int64]*sso.AWSAccount{
+							12345: {
+								Alias: "test",
+								Name:  "testing",
+								Roles: map[string]*sso.AWSRole{
+									"Foo": {
+										Arn: "aws:arn:iam::12345:role/Foo",
+									},
+									"Bar": {
+										Arn: "aws:arn:iam::12345:role/Bar",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	profiles, err := getProfileMap(s, url.Open)
+	p := *profiles
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(p))
+	assert.Equal(t, 2, len(p["Default"]))
+
+	// now fail
+	s.Cache.SSO["Other"] = &sso.SSOCache{
+		Roles: &sso.Roles{
+			Accounts: map[int64]*sso.AWSAccount{
+				12345: {
+					Alias: "test",
+					Name:  "testing",
+					Roles: map[string]*sso.AWSRole{
+						"Foo": {
+							Arn: "aws:arn:iam::12345:role/Foo",
+						},
+					},
+				},
+			},
+		},
+	}
+	_, err = getProfileMap(s, url.Open)
+	assert.Error(t, err)
+}
+
+func TestPrintAwsConfig(t *testing.T) {
+	s := &sso.Settings{
+		Cache: &sso.Cache{
+			SSO: map[string]*sso.SSOCache{
+				"Default": {
+					Roles: &sso.Roles{
+						Accounts: map[int64]*sso.AWSAccount{
+							12345: {
+								Alias: "test",
+								Name:  "testing",
+								Roles: map[string]*sso.AWSRole{
+									"Foo": {
+										Arn: "aws:arn:iam::12345:role/Foo",
+									},
+									"Bar": {
+										Arn: "aws:arn:iam::12345:role/Bar",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var err error
+	stdout, err = os.CreateTemp("", "")
+	assert.NoError(t, err)
+	fname := stdout.Name()
+	defer os.Remove(fname)
+
+	err = PrintAwsConfig(s, url.Open)
+	assert.NoError(t, err)
+
+	_, err = stdout.Seek(0, 0)
+	assert.NoError(t, err)
+
+	buf := make([]byte, 1024*1024)
+	len, err := stdout.ReadAt(buf, 0)
+	assert.Error(t, err)
+	assert.Less(t, 300, len)
+	assert.Contains(t, string(buf), "[profile 000000012345:Bar]")
+	assert.Regexp(t, regexp.MustCompile(`credential_process = /[^ ]+/awsconfig.test -u open -S "Default" process --arn aws:arn:iam::12345:role/Bar`), string(buf))
+	assert.Regexp(t, regexp.MustCompile(`# BEGIN_AWS_SSO_CLI`), string(buf))
+	assert.Regexp(t, regexp.MustCompile(`# END_AWS_SSO_CLI`), string(buf))
+	stdout.Close()
+
+	// now fail
+	s.Cache.SSO["Other"] = &sso.SSOCache{
+		Roles: &sso.Roles{
+			Accounts: map[int64]*sso.AWSAccount{
+				12345: {
+					Alias: "test",
+					Name:  "testing",
+					Roles: map[string]*sso.AWSRole{
+						"Foo": {
+							Arn: "aws:arn:iam::12345:role/Foo",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err = PrintAwsConfig(s, url.Open)
+	assert.Error(t, err)
+}
+
+func TestUpdateAwsConfig(t *testing.T) {
+	s := &sso.Settings{
+		Cache: &sso.Cache{
+			SSO: map[string]*sso.SSOCache{
+				"Default": {
+					Roles: &sso.Roles{
+						Accounts: map[int64]*sso.AWSAccount{
+							12345: {
+								Alias: "test",
+								Name:  "testing",
+								Roles: map[string]*sso.AWSRole{
+									"Foo": {
+										Arn: "aws:arn:iam::12345:role/Foo",
+									},
+									"Bar": {
+										Arn: "aws:arn:iam::12345:role/Bar",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cfile, err := os.CreateTemp("", "")
+	assert.NoError(t, err)
+	fname := stdout.Name()
+	defer os.Remove(fname)
+	cfile.Close()
+
+	err = UpdateAwsConfig(s, url.Open, fname, false, true)
+	assert.NoError(t, err)
+
+	cfile, err = os.Open(fname)
+	assert.NoError(t, err)
+
+	buf := make([]byte, 1024*1024)
+	len, err := cfile.Read(buf)
+	assert.NoError(t, err)
+	assert.Less(t, 300, len)
+	assert.Contains(t, string(buf), "[profile 000000012345:Bar]")
+	assert.Regexp(t, regexp.MustCompile(`credential_process = /[^ ]+/awsconfig.test -u open -S "Default" process --arn aws:arn:iam::12345:role/Bar`), string(buf))
+	assert.Regexp(t, regexp.MustCompile(`# BEGIN_AWS_SSO_CLI`), string(buf))
+	assert.Regexp(t, regexp.MustCompile(`# END_AWS_SSO_CLI`), string(buf))
+
+	// now fail
+	s.Cache.SSO["Other"] = &sso.SSOCache{
+		Roles: &sso.Roles{
+			Accounts: map[int64]*sso.AWSAccount{
+				12345: {
+					Alias: "test",
+					Name:  "testing",
+					Roles: map[string]*sso.AWSRole{
+						"Foo": {
+							Arn: "aws:arn:iam::12345:role/Foo",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err = UpdateAwsConfig(s, url.Open, fname, false, true)
+	assert.Error(t, err)
+}

--- a/internal/awscreds/config.go
+++ b/internal/awscreds/config.go
@@ -1,0 +1,137 @@
+package awscreds
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2023 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"fmt"
+	//	"os"
+	"strings"
+
+	"github.com/synfinatic/aws-sso-cli/internal/storage"
+	"github.com/synfinatic/aws-sso-cli/internal/utils"
+	"gopkg.in/ini.v1"
+)
+
+const (
+	CONFIG_FILE      = "~/.aws/config"
+	CREDENTIALS_FILE = "~/.aws/credentials" // #nosec
+)
+
+type AwsConfig struct {
+	ConfigFile      string
+	Config          *ini.File
+	CredentialsFile string
+	Credentials     *ini.File
+	Profiles        map[string]map[string]interface{} // profile.go
+}
+
+// NewAwsConfig creates a new *AwsConfig struct
+func NewAwsConfig(config, credentials string) (*AwsConfig, error) {
+	var err error
+	a := AwsConfig{}
+	p := utils.GetHomePath(config)
+
+	if a.Config, err = ini.Load(p); err != nil {
+		return nil, fmt.Errorf("unable to open %s: %s", p, err.Error())
+	} else {
+		a.ConfigFile = config
+	}
+
+	p = utils.GetHomePath(credentials)
+	if a.Credentials, err = ini.Load(p); err == nil {
+		a.CredentialsFile = p
+	}
+
+	return &a, nil
+}
+
+// StaticProfiles returns a list of all the profiles with static API creds
+// stored in ~/.aws/config and ~/.aws/credentials
+func (a *AwsConfig) StaticProfiles() ([]Profile, error) {
+	profiles := []Profile{}
+	creds := a.Credentials
+
+	for _, profile := range a.Config.Sections() {
+		x := strings.Split(profile.Name(), " ")
+		if x[0] != "profile" || len(x) != 2 {
+			log.Errorf("invalid profile: %s", profile.Name())
+			continue
+		}
+
+		if HasStaticCreds(profile) {
+			log.Debugf("Found api keys for %s with in config file", x[1])
+			profiles = append(profiles,
+				Profile{
+					Name:            x[1],
+					AccessKeyId:     profile.Key("aws_access_key_id").String(),
+					SecretAccessKey: profile.Key("aws_secret_access_key").String(),
+					FromConfig:      true,
+				})
+		} else if creds != nil {
+			if cp, err := creds.GetSection(x[1]); err == nil {
+				if cp != nil && HasStaticCreds(cp) {
+					log.Debugf("Found api keys for %s in credentials file", x[1])
+					profiles = append(profiles,
+						Profile{
+							Name:            x[1],
+							AccessKeyId:     cp.Key("aws_access_key_id").String(),
+							SecretAccessKey: cp.Key("aws_secret_access_key").String(),
+							FromConfig:      false,
+						})
+				}
+			}
+		} else {
+			log.Errorf("skipping because no credentials file")
+		}
+	}
+	return profiles, nil
+}
+
+// UpdateSecureStore writes any new role ARN credentials to the provided SecureStorage
+func (a *AwsConfig) UpdateSecureStore(store storage.SecureStorage) error {
+	profiles, err := a.StaticProfiles()
+	if err != nil {
+		return err
+	}
+
+	for _, p := range profiles {
+		arn, err := p.GetArn()
+		if err != nil {
+			return err
+		}
+		accountid, username, _ := utils.ParseUserARN(arn)
+
+		creds := storage.StaticCredentials{
+			UserName:        username,
+			AccountId:       accountid,
+			AccessKeyId:     p.AccessKeyId,
+			SecretAccessKey: p.SecretAccessKey,
+		}
+		if err = store.SaveStaticCredentials(arn, creds); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Write updates the AWS ~/.aws/config file to use aws-sso via a credential_process
+// and removes the associated ~/.aws/credentials entries
+func (a *AwsConfig) Write() error {
+	return nil
+}

--- a/internal/awscreds/logger.go
+++ b/internal/awscreds/logger.go
@@ -1,4 +1,4 @@
-package awsconfig
+package awscreds
 
 /*
  * AWS SSO CLI

--- a/internal/awscreds/profile.go
+++ b/internal/awscreds/profile.go
@@ -1,4 +1,4 @@
-package awsconfig
+package awscreds
 
 /*
  * AWS SSO CLI

--- a/internal/awscreds/section.go
+++ b/internal/awscreds/section.go
@@ -1,4 +1,4 @@
-package awsconfig
+package awscreds
 
 /*
  * AWS SSO CLI


### PR DESCRIPTION
- AutoConfigCheck workflow now looks at the AWS_CONFIG_FILE env var
- `config-profiles` now offers an explict flag
- Refactor code

Fixes: #540