### PR TITLE
Include RoleArn and invalid bad routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # AWS SSO CLI Changelog
 
-## [v1.13.1] - 2023-08-23
+## [v1.13.1] - 2023-08-28
 
 ### Bugs
 
  * Fix fetching creds from ECS Server #557
  * Fix ECS Server to be more RESTful and document the API
+ * ECS Server now includes `RoleArn` in output #561
 
 ### Changes 
 

--- a/docs/ecs-server.md
+++ b/docs/ecs-server.md
@@ -93,7 +93,7 @@ If you would like to remove the default IAM Role credentials:
 
 ## Storing multiple roles at a time
 
-There may be cases where you would like to make multiple roles available at the 
+There may be cases where you would like to make multiple roles available at the
 same time without running multiple copies of the ECS server via `aws-sso ecs run`.
 Each role is stored in a unique named slot based on the `ProfileName` which is
 either set via [Profile](config.md#Profile) or the [ProfileFormat](
@@ -130,8 +130,8 @@ The ECS Server API endpoint generates errors with the following JSON format:
 
 ```json
 {
-    code: "<error code>",
-    message: "<message string>"
+    "code": "<HTTP error code>",
+    "message": "<message>"
 }
 ```
 
@@ -146,19 +146,113 @@ this feature if you want it!
 Support for using [HTTPS](https://github.com/synfinatic/aws-sso-cli/issues/518)
 is TBD.  Please vote for this feature if you want it!
 
-## REST API 
+## REST API
 
 ### Default credentials
 
- * `GET /` -- Fetch default credentials
- * `GET /profile` -- Fetch profile name of the default credentials
- * `PUT /` -- Upload default credentials 
- * `DELETE /` -- Delete default credentials
+#### GET /
+Fetch default credentials.
+
+```json
+{
+    "AccessKeyId": "ASI....",
+    "SecretAccessKeyId": "<Secret Access Key ID>",
+    "Token": "<Temprorary security token>",
+    "Expiration": "<Date in RFC3339 / ISO8601 format>",
+    "RoleArn": "<ARN of the role>",
+}
+```
+
+#### GET /profile
+Fetch profile name of the default credentials.
+
+```json
+{
+    "ProfileName": "<aws-sso profile name>",
+    "AccountId": "<AWS Account ID>",
+    "RoleName": "<IAM Role name>",
+    "Expiration": <Unix epoch seconds>,
+    "Expires": "<how long until expires string>"
+}
+```
+
+#### PUT /
+Upload default credentials.
+
+```json
+{
+    "code": "<HTTP error code>",
+    "message": "<message>"
+}
+```
+
+#### DELETE /
+Delete default credentials.
+
+```json
+{
+    "code": "<HTTP error code>",
+    "message": "<message>"
+}
+```
 
 ### Slotted credentials
 
- * `GET /creds` -- Fetch list of default credentials
- * `GET /creds/<profile>` -- Fetch credentials of the named profile 
- * `PUT /creds/<profile>` -- Upload credentials of the named profile 
- * `DELETE /creds/<profile>` -- Delete credentials of the named profile
- * `DELETE /creds`  -- Delete all named credentials
+#### GET /slot
+Fetch list of default credentials.
+
+```json
+[
+    {
+        "ProfileName": "<profile name>",
+        "AccountId": "<AWS Account ID>",
+        "RoleName": "<IAM Role Name>",
+        "Expiration": <Unix Epoch Seconds>,
+        "Expires": "<how long until expires string>"
+    },
+    <more entries...>
+]
+```
+
+#### GET /slot/\<profile\>
+Fetch credentials of the named profile.
+
+```json
+{
+    "AccessKeyId": "ASI....",
+    "SecretAccessKeyId": "<secret access key id value>",
+    "Token": "<temprorary security token>",
+    "Expiration": "<date in RFC3339 / ISO8601 format>",
+    "RoleArn": "<ARN of the role>",
+}
+```
+
+#### PUT /slot/\<profile\>
+Upload credentials of the named profile.
+
+```json
+{
+    "code": "<HTTP error code>",
+    "message": "<message>"
+}
+```
+
+#### DELETE /slot/\<profile\>
+Delete credentials of the named profile.
+
+```json
+{
+    "code": "<HTTP error code>",
+    "message": "<message>"
+}
+```
+
+#### DELETE /slot
+Delete all named credentials.
+
+```json
+{
+    "code": "<HTTP error code>",
+    "message": "<message>"
+}
+```

--- a/internal/ecs/client_request_test.go
+++ b/internal/ecs/client_request_test.go
@@ -92,31 +92,3 @@ func TestReadClientRequest(t *testing.T) {
 	_, err = ReadClientRequest(r)
 	assert.ErrorContains(t, err, "parsing json")
 }
-
-func TestWriteCreds(t *testing.T) {
-	w := httptest.NewRecorder()
-	soon := time.Now().Add(90 * time.Second)
-	creds := &storage.RoleCredentials{
-		AccessKeyId:     "AccessKeyId",
-		SecretAccessKey: "SecretAccessKey",
-		SessionToken:    "Token",
-		Expiration:      soon.UnixMilli(),
-	}
-	WriteCreds(w, creds)
-
-	r := w.Result()
-	outCreds := map[string]string{}
-	err := json.NewDecoder(r.Body).Decode(&outCreds)
-	assert.NoError(t, err)
-	assert.Equal(t, "Token", outCreds["Token"])
-
-	w = httptest.NewRecorder()
-
-	creds.Expiration = time.Now().UnixMilli()
-	WriteCreds(w, creds)
-	r = w.Result()
-	msg := Message{}
-	err = json.NewDecoder(r.Body).Decode(&msg)
-	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%d", http.StatusNotFound), msg.Code)
-}

--- a/internal/ecs/http.go
+++ b/internal/ecs/http.go
@@ -15,6 +15,7 @@ type Message struct {
 }
 
 // WriteCreds returns the JSON of the provided creds to the HTTP client
+// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
 func WriteCreds(w http.ResponseWriter, creds *storage.RoleCredentials) {
 	if creds.Expired() {
 		Expired(w)
@@ -23,9 +24,10 @@ func WriteCreds(w http.ResponseWriter, creds *storage.RoleCredentials) {
 
 	resp := map[string]string{
 		"AccessKeyId":     creds.AccessKeyId,
+		"Expiration":      creds.ExpireISO8601(),
+		"RoleArn":         creds.RoleArn(),
 		"SecretAccessKey": creds.SecretAccessKey,
 		"Token":           creds.SessionToken,
-		"Expiration":      creds.ExpireISO8601(),
 	}
 	JSONResponse(w, resp)
 }

--- a/internal/ecs/server/default.go
+++ b/internal/ecs/server/default.go
@@ -29,6 +29,12 @@ type DefaultHandler struct {
 }
 
 func (p DefaultHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.String() != "/" {
+		log.Errorf("Invalid %s request: %s", r.Method, r.URL.String())
+		ecs.Unavailable(w)
+		return
+	}
+
 	switch r.Method {
 	case http.MethodGet:
 		p.Get(w, r)
@@ -37,7 +43,7 @@ func (p DefaultHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case http.MethodDelete:
 		p.Delete(w, r)
 	default:
-		log.Errorf("Invalid request: %s", r.URL.String())
+		log.Errorf("Invalid %s request: %s", r.Method, r.URL.String())
 		ecs.Invalid(w)
 	}
 }

--- a/internal/ecs/server/default_test.go
+++ b/internal/ecs/server/default_test.go
@@ -74,6 +74,12 @@ func TestDefaultGet(t *testing.T) {
 	res, err = http.Get(url) //nolint
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusNotFound, res.StatusCode)
+
+	// invalid request
+	url = fmt.Sprintf("%s/foo", ts.URL)
+	res, err = http.Get(url) //nolint
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, res.StatusCode)
 }
 
 func submitRequest(t *testing.T, url string, cr ecs.ECSClientRequest) (*http.Response, error) {


### PR DESCRIPTION
- Returned credentials via ECS server now include the RoleARN
- Bad paths processed by the default route now return a 404

Fixes: #561