### PR TITLE
Add `--no-cache` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # AWS SSO CLI Changelog
 
+## [Unreleased]
+
+### Changes
+
+ * Print user code during SSO authentication workflow #572
+
+### New Features
+
+ * Add `--no-cache` to `console`, `config-profiles`, `exec` and `list` #574
+
 ## [v1.13.1] - 2023-08-28
 
 ### Bugs

--- a/cmd/aws-sso/config_profiles_cmd.go
+++ b/cmd/aws-sso/config_profiles_cmd.go
@@ -60,7 +60,7 @@ func (cc *ConfigProfilesCmd) Run(ctx *RunContext) error {
 
 	urlAction, _ := url.NewAction(string(action))
 
-	// refresh our cache
+	// always refresh our cache
 	c := &CacheCmd{}
 	if err = c.Run(ctx); err != nil {
 		return err

--- a/cmd/aws-sso/console_cmd.go
+++ b/cmd/aws-sso/console_cmd.go
@@ -44,9 +44,10 @@ const AWS_FEDERATED_URL = "https://signin.aws.amazon.com/federation"
 
 type ConsoleCmd struct {
 	// Console actually should honor the --region flag
-	Region   string `kong:"help='AWS Region',env='AWS_DEFAULT_REGION',predictor='region'"`
 	Duration int32  `kong:"short='d',help='AWS Session duration in minutes (default 60)'"` // default stored in DEFAULT_CONFIG
 	Prompt   bool   `kong:"short='P',help='Force interactive prompt to select role'"`
+	NoCache  bool   `kong:"help='Do not use cache'"`
+	Region   string `kong:"help='AWS Region',env='AWS_DEFAULT_REGION',predictor='region'"`
 
 	Arn       string `kong:"short='a',help='ARN of role to assume',env='AWS_SSO_ROLE_ARN',predictor='arn'"`
 	AccountId int64  `kong:"name='account',short='A',help='AWS AccountID of role to assume',env='AWS_SSO_ACCOUNT_ID',predictor='accountId'"`
@@ -66,6 +67,13 @@ func (cc *ConsoleCmd) Run(ctx *RunContext) error {
 
 	if ctx.Settings.ConsoleDuration > 0 && (ctx.Settings.ConsoleDuration < 15 || ctx.Settings.ConsoleDuration > 720) {
 		return fmt.Errorf("Invalid --duration %d.  Must be between 15 and 720", ctx.Settings.ConsoleDuration)
+	}
+
+	if ctx.Cli.Console.NoCache {
+		c := &CacheCmd{}
+		if err := c.Run(ctx); err != nil {
+			return err
+		}
 	}
 
 	// do we force interactive prompt?

--- a/cmd/aws-sso/exec_cmd.go
+++ b/cmd/aws-sso/exec_cmd.go
@@ -34,6 +34,7 @@ type ExecCmd struct {
 	AccountId int64  `kong:"name='account',short='A',help='AWS AccountID of role to assume',env='AWS_SSO_ACCOUNT_ID',predictor='accountId'"`
 	Role      string `kong:"short='R',help='Name of AWS Role to assume',env='AWS_SSO_ROLE_NAME',predictor='role'"`
 	Profile   string `kong:"short='p',help='Name of AWS Profile to assume',predictor='profile'"`
+	NoCache   bool   `kong:"help='Do not use cache'"`
 	NoRegion  bool   `kong:"short='n',help='Do not set AWS_DEFAULT_REGION from config.yaml'"`
 
 	// Exec Params
@@ -56,6 +57,13 @@ func (cc *ExecCmd) Run(ctx *RunContext) error {
 	if awssso, err := sci.Update(ctx); err == nil {
 		// successful lookup?
 		return execCmd(ctx, awssso, sci.AccountId, sci.RoleName)
+	}
+
+	if ctx.Cli.Exec.NoCache {
+		c := &CacheCmd{}
+		if err = c.Run(ctx); err != nil {
+			return err
+		}
 	}
 
 	return ctx.PromptExec(execCmd)

--- a/cmd/aws-sso/list_cmd.go
+++ b/cmd/aws-sso/list_cmd.go
@@ -36,6 +36,7 @@ type ListCmd struct {
 	CSV        bool     `kong:"help='Generate CSV instead of a table',xor='listfields'"`
 	Prefix     string   `kong:"short='P',help='Filter based on the <FieldName>=<Prefix>'"`
 	Fields     []string `kong:"optional,arg,help='Fields to display',env='AWS_SSO_FIELDS',predictor='fieldList',xor='listfields'"`
+	NoCache    bool     `kong:"help='Do not use cache'"`
 	Sort       string   `kong:"short='s',help='Sort results by the <FieldName>',default='AccountId',env='AWS_SSO_FIELD_SORT',predictor='fieldList'"`
 	Reverse    bool     `kong:"help='Reverse sort results',env='AWS_SSO_FIELD_SORT_REVERSE'"`
 }
@@ -52,6 +53,13 @@ func (cc *ListCmd) Run(ctx *RunContext) error {
 	if ctx.Cli.List.ListFields {
 		listAllFields()
 		return nil
+	}
+
+	if ctx.Cli.List.NoCache {
+		c := &CacheCmd{}
+		if err = c.Run(ctx); err != nil {
+			return err
+		}
 	}
 
 	if ctx.Cli.List.Prefix != "" {

--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -125,7 +125,7 @@ type CLI struct {
 	List           ListCmd           `kong:"cmd,help='List all accounts / roles (default command)'"`
 	Logout         LogoutCmd         `kong:"cmd,help='Logout in browser and invalidate all credentials'"`
 	Process        ProcessCmd        `kong:"cmd,help='Generate JSON for credential_process in ~/.aws/config'"`
-	Static         StaticCmd         `kong:"cmd,help='Manage static AWS API credentials',hidden"`
+	Static         StaticCmd         `kong:"cmd,hidden,help='Manage static AWS API credentials'"`
 	Tags           TagsCmd           `kong:"cmd,help='List tags'"`
 	Time           TimeCmd           `kong:"cmd,help='Print how much time before current STS Token expires'"`
 	Completions    CompleteCmd       `kong:"cmd,help='Manage shell completions'"`

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -71,14 +71,17 @@ as appropriate.
 
 ### Why can't aws-sso find my new role?
 
-If you have just been assigned a new PermissionSet in IAM Identity Center, it
+Most likely, this is because the aws-sso [cache](config.md#CacheRefresh) is out of
+date.  You can force a refresh of the cache by running [aws-sso cache](commands.md#cache).
+
+Note, if you have just been assigned a new PermissionSet in IAM Identity Center, it
 tends to show up in the IAM Identity Center web console
-(https://xxxxx.awsapps.com/start) before it is made available to the
+(https://xxxxx.awsapps.com/start) before it is made available to `aws-sso` via the
 [ListAccountRoles](https://docs.aws.amazon.com/singlesignon/latest/PortalAPIReference/API_ListAccountRoles.html)
 API call.  Unfortunately, this seems to be a limitation with AWS and you just
 have to wait a few minutes.
 
-You can see what the AWS ListAccountRoles API is returning via `aws-sso cache -L debug`t
+You can see what the AWS ListAccountRoles API is returning via `aws-sso cache -L debug`
 
 ### Spaces are invalid in Profile names
 


### PR DESCRIPTION
Force refreshing the cache and query AWS on a per-command basis for config-profiles, console, exec and list.

Fixes: #574