### PR TITLE
Add login command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,18 @@
 ### New Features
 
  * Config Wizard now prompts for `ProfileFormat` #590
+ * Add `login` command #291
 
 ### Changes
 
- * Documentation is now built via Docker #587
+ * Documentation is now managed by [mkdocs](https://www.mkdocs.org)
  * Improved demos in documentation #551
  * Update many dependencies
+ * Add dependabot
+
+### Deprecated
+
+ * `aws-sso flush -t sso` should not be used.  Use `aws-sso logout` instead.
 
 ## [v1.14.0] - 2023-10-13
 
@@ -296,9 +302,11 @@
  * Renamed the `config` command to update `~/.aws/config` to be `config-profiles`
      which is hopefully more clear
  * `config` command now runs the configuration wizard
- * Deprecated `ConfigUrlAction` option.  Will be automatically upgraded by
-    the `aws-sso config` wizard.
  * `ConfigProfilesUrlAction` replaces `ConfigUrlAction`
+
+### Deprecated
+ * `ConfigUrlAction` option.  Will be automatically upgraded by
+    the `aws-sso config` wizard.
 
 ### Bugs
 

--- a/cmd/aws-sso/cache_cmd.go
+++ b/cmd/aws-sso/cache_cmd.go
@@ -25,7 +25,6 @@ import (
 type CacheCmd struct{}
 
 func (cc *CacheCmd) Run(ctx *RunContext) error {
-	awssso := doAuth(ctx)
 	s, err := ctx.Settings.GetSelectedSSO(ctx.Cli.SSO)
 	if err != nil {
 		log.Fatalf("%s", err.Error())
@@ -36,7 +35,7 @@ func (cc *CacheCmd) Run(ctx *RunContext) error {
 		log.Fatalf(err.Error())
 	}
 
-	err = ctx.Settings.Cache.Refresh(awssso, s, ssoName)
+	err = ctx.Settings.Cache.Refresh(AwsSSO, s, ssoName)
 	if err != nil {
 		return fmt.Errorf("Unable to refresh role cache: %s", err.Error())
 	}

--- a/cmd/aws-sso/console_cmd.go
+++ b/cmd/aws-sso/console_cmd.go
@@ -37,7 +37,6 @@ import (
 	"github.com/synfinatic/aws-sso-cli/internal/storage"
 	"github.com/synfinatic/aws-sso-cli/internal/url"
 	"github.com/synfinatic/aws-sso-cli/internal/utils"
-	"github.com/synfinatic/aws-sso-cli/sso"
 )
 
 const AWS_FEDERATED_URL = "https://signin.aws.amazon.com/federation"
@@ -83,9 +82,9 @@ func (cc *ConsoleCmd) Run(ctx *RunContext) error {
 
 	// Check our CLI args
 	sci := NewSelectCliArgs(ctx.Cli.Console.Arn, ctx.Cli.Console.AccountId, ctx.Cli.Console.Role, ctx.Cli.Console.Profile)
-	if awssso, err := sci.Update(ctx); err == nil {
+	if err := sci.Update(ctx); err == nil {
 		// successful lookup?
-		return openConsole(ctx, awssso, sci.AccountId, sci.RoleName)
+		return openConsole(ctx, sci.AccountId, sci.RoleName)
 	}
 
 	// Check our various ENV vars
@@ -162,10 +161,9 @@ func consoleViaEnvVars(ctx *RunContext) error {
 }
 
 func consoleViaSDK(ctx *RunContext) error {
-	awssso := doAuth(ctx)
 	rFlat, err := ctx.Settings.Cache.GetSSO().Roles.GetRoleByProfile(ctx.Cli.Console.AwsProfile, ctx.Settings)
 	if err == nil {
-		return openConsole(ctx, awssso, rFlat.AccountId, rFlat.RoleName)
+		return openConsole(ctx, rFlat.AccountId, rFlat.RoleName)
 	}
 
 	region := ctx.Settings.DefaultRegion
@@ -225,7 +223,7 @@ func haveAWSEnvVars(ctx *RunContext) bool {
 }
 
 // opens the AWS console or just prints the URL
-func openConsole(ctx *RunContext, awssso *sso.AWSSSO, accountid int64, role string) error {
+func openConsole(ctx *RunContext, accountid int64, role string) error {
 	region := ctx.Settings.GetDefaultRegion(accountid, role, false)
 	if ctx.Cli.Console.Region != "" {
 		region = ctx.Cli.Console.Region
@@ -241,7 +239,7 @@ func openConsole(ctx *RunContext, awssso *sso.AWSSSO, accountid int64, role stri
 		log.WithError(err).Warnf("Unable to update cache")
 	}
 
-	creds := GetRoleCredentials(ctx, awssso, accountid, role)
+	creds := GetRoleCredentials(ctx, AwsSSO, accountid, role)
 	return openConsoleAccessKey(ctx, creds, duration, region, accountid, role)
 }
 

--- a/cmd/aws-sso/ecs_client_cmd.go
+++ b/cmd/aws-sso/ecs_client_cmd.go
@@ -27,7 +27,6 @@ import (
 	"github.com/synfinatic/aws-sso-cli/internal/ecs"
 	"github.com/synfinatic/aws-sso-cli/internal/ecs/client"
 	"github.com/synfinatic/aws-sso-cli/internal/utils"
-	"github.com/synfinatic/aws-sso-cli/sso"
 	"github.com/synfinatic/gotable"
 )
 
@@ -56,9 +55,9 @@ type EcsUnloadCmd struct {
 
 func (cc *EcsLoadCmd) Run(ctx *RunContext) error {
 	sci := NewSelectCliArgs(ctx.Cli.Ecs.Load.Arn, ctx.Cli.Ecs.Load.AccountId, ctx.Cli.Ecs.Load.Role, ctx.Cli.Ecs.Load.Profile)
-	if awssso, err := sci.Update(ctx); err == nil {
+	if err := sci.Update(ctx); err == nil {
 		// successful lookup?
-		return ecsLoadCmd(ctx, awssso, sci.AccountId, sci.RoleName)
+		return ecsLoadCmd(ctx, sci.AccountId, sci.RoleName)
 	}
 
 	return ctx.PromptExec(ecsLoadCmd)
@@ -89,10 +88,10 @@ func (cc *EcsUnloadCmd) Run(ctx *RunContext) error {
 }
 
 // Loads our AWS API creds into the ECS Server
-func ecsLoadCmd(ctx *RunContext, awssso *sso.AWSSSO, accountId int64, role string) error {
-	creds := GetRoleCredentials(ctx, awssso, accountId, role)
+func ecsLoadCmd(ctx *RunContext, accountId int64, role string) error {
+	creds := GetRoleCredentials(ctx, AwsSSO, accountId, role)
 
-	cache := ctx.Settings.Cache.GetSSO() // ctx.Settings.Cache.Refresh(awssso, ssoConfig, ctx.Cli.SSO)
+	cache := ctx.Settings.Cache.GetSSO()
 	rFlat, err := cache.Roles.GetRole(accountId, role)
 	if err != nil {
 		return err

--- a/cmd/aws-sso/eval_cmd.go
+++ b/cmd/aws-sso/eval_cmd.go
@@ -82,9 +82,7 @@ func (cc *EvalCmd) Run(ctx *RunContext) error {
 	}
 	region := ctx.Settings.GetDefaultRegion(accountid, role, ctx.Cli.Eval.NoRegion)
 
-	awssso := doAuth(ctx)
-
-	for k, v := range execShellEnvs(ctx, awssso, accountid, role, region) {
+	for k, v := range execShellEnvs(ctx, accountid, role, region) {
 		if isBashLike() {
 			if len(v) == 0 {
 				fmt.Printf("unset %s\n", k)

--- a/cmd/aws-sso/flush_cmd.go
+++ b/cmd/aws-sso/flush_cmd.go
@@ -23,7 +23,7 @@ import (
 
 // FlushCmd defines the Kong args for the flush command
 type FlushCmd struct {
-	Type string `kong:"short='t',default='sts',enum='sts,sso,all',help='Type of credentials to flush [sts|sso|all]'"`
+	Type string `kong:"short='t',default='sts',enum='sts,sso,all',help='Type of credentials to flush [sts|sso|all] (deprecated)'"`
 }
 
 // Run executes the flush command
@@ -50,8 +50,10 @@ func (cc *FlushCmd) Run(ctx *RunContext) error {
 	return nil
 }
 
+// flushSso is stupid and doesn't do anything useful really because
+// AWS will gladly re-issue new security token just based on your
+// DeviceAuthorization token
 func flushSso(ctx *RunContext, awssso *sso.AWSSSO) {
-	// Deleting the token response invalidates all our STS tokens
 	err := ctx.Store.DeleteCreateTokenResponse(awssso.StoreKey())
 	if err != nil {
 		log.WithError(err).Errorf("Unable to delete TokenResponse")
@@ -60,6 +62,7 @@ func flushSso(ctx *RunContext, awssso *sso.AWSSSO) {
 	}
 }
 
+// flushSts flushes our IAM STS Role credentials from the secure store
 func flushSts(ctx *RunContext, awssso *sso.AWSSSO) {
 	cache := ctx.Settings.Cache.GetSSO()
 	for _, role := range cache.Roles.GetAllRoles() {

--- a/cmd/aws-sso/interactive.go
+++ b/cmd/aws-sso/interactive.go
@@ -31,7 +31,7 @@ import (
 	"github.com/synfinatic/aws-sso-cli/sso"
 )
 
-type CompleterExec = func(*RunContext, *sso.AWSSSO, int64, string) error
+type CompleterExec = func(*RunContext, int64, string) error
 
 // PromptExec runs the interactive prompter and then on success runs our
 // CompleterExec function
@@ -149,8 +149,8 @@ func (tc *TagsCompleter) Executor(args string) {
 	if err != nil {
 		log.Fatalf("Unable to parse %s: %s", roleArn, err.Error())
 	}
-	awsSSO := doAuth(tc.ctx)
-	err = tc.exec(tc.ctx, awsSSO, aId, rName)
+
+	err = tc.exec(tc.ctx, aId, rName)
 	if err != nil {
 		log.Fatalf("Unable to exec: %s", err.Error())
 	}

--- a/cmd/aws-sso/list_cmd.go
+++ b/cmd/aws-sso/list_cmd.go
@@ -195,15 +195,6 @@ func printRoles(ctx *RunContext, fields []string, csv bool, prefixSearch []strin
 	if csv {
 		err = gotable.GenerateCSV(tr, fields)
 	} else {
-		// Determine when our AWS SSO session expires
-		// list doesn't call doAuth() so we have to initialize our global *AwsSSO manually
-		var s *sso.SSOConfig
-		s, err = ctx.Settings.GetSelectedSSO(ctx.Cli.SSO)
-		if err != nil {
-			log.Fatalf("%s", err.Error())
-		}
-		AwsSSO = sso.NewAWSSSO(s, &ctx.Store)
-
 		expires := ""
 		ctr := storage.CreateTokenResponse{}
 		if err := ctx.Store.GetCreateTokenResponse(AwsSSO.StoreKey(), &ctr); err != nil {

--- a/cmd/aws-sso/logout_cmd.go
+++ b/cmd/aws-sso/logout_cmd.go
@@ -34,11 +34,6 @@ func (cc *LogoutCmd) Run(ctx *RunContext) error {
 	}
 	awssso := sso.NewAWSSSO(s, &ctx.Store)
 
-	// Call logout to invalidate our session
-	if err := awssso.Logout(); err != nil {
-		log.WithError(err).Errorf("Unable to logout of AWS IAM Identity Center")
-	}
-
 	// this is what we do anyways
 	flushSso(ctx, awssso)
 	flushSts(ctx, awssso)

--- a/cmd/aws-sso/process_cmd.go
+++ b/cmd/aws-sso/process_cmd.go
@@ -25,7 +25,6 @@ import (
 	// log "github.com/sirupsen/logrus"
 	"github.com/synfinatic/aws-sso-cli/internal/storage"
 	"github.com/synfinatic/aws-sso-cli/internal/utils"
-	"github.com/synfinatic/aws-sso-cli/sso"
 )
 
 type ProcessCmd struct {
@@ -67,8 +66,7 @@ func (cc *ProcessCmd) Run(ctx *RunContext) error {
 		return fmt.Errorf("Please specify --arn or --account and --role")
 	}
 
-	awssso := doAuth(ctx)
-	return credentialProcess(ctx, awssso, account, role)
+	return credentialProcess(ctx, account, role)
 }
 
 type CredentialProcessOutput struct {
@@ -99,8 +97,8 @@ func (cpo *CredentialProcessOutput) Output() (string, error) {
 	return string(b), nil
 }
 
-func credentialProcess(ctx *RunContext, awssso *sso.AWSSSO, accountId int64, role string) error {
-	creds := GetRoleCredentials(ctx, awssso, accountId, role)
+func credentialProcess(ctx *RunContext, accountId int64, role string) error {
+	creds := GetRoleCredentials(ctx, AwsSSO, accountId, role)
 
 	cpo := NewCredentialsProcessOutput(creds)
 	out, err := cpo.Output()

--- a/cmd/aws-sso/select_args.go
+++ b/cmd/aws-sso/select_args.go
@@ -1,0 +1,68 @@
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2023 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"fmt"
+
+	"github.com/synfinatic/aws-sso-cli/internal/utils"
+)
+
+type SelectCliArgs struct {
+	Arn       string
+	AccountId int64
+	RoleName  string
+	Profile   string
+}
+
+func NewSelectCliArgs(arn string, accountId int64, role, profile string) *SelectCliArgs {
+	return &SelectCliArgs{
+		Arn:       arn,
+		AccountId: accountId,
+		RoleName:  role,
+		Profile:   profile,
+	}
+}
+
+func (a *SelectCliArgs) Update(ctx *RunContext) error {
+	if a.AccountId != 0 && a.RoleName != "" {
+		return nil
+	} else if a.Profile != "" {
+		cache := ctx.Settings.Cache.GetSSO()
+		rFlat, err := cache.Roles.GetRoleByProfile(a.Profile, ctx.Settings)
+		if err != nil {
+			return err
+		}
+
+		a.AccountId = rFlat.AccountId
+		a.RoleName = rFlat.RoleName
+
+		return nil
+	} else if a.Arn != "" {
+		accountId, role, err := utils.ParseRoleARN(a.Arn)
+		if err != nil {
+			return err
+		}
+		a.AccountId = accountId
+		a.RoleName = role
+
+		return nil
+	}
+	return fmt.Errorf("Please specify both --account and --role")
+}

--- a/cmd/aws-sso/tags_cmd.go
+++ b/cmd/aws-sso/tags_cmd.go
@@ -36,18 +36,13 @@ func (cc *TagsCmd) Run(ctx *RunContext) error {
 	cache := ctx.Settings.Cache.GetSSO()
 	if ctx.Cli.Tags.ForceUpdate {
 		s := set.SSO[ctx.Cli.SSO]
-		awssso := sso.NewAWSSSO(s, &ctx.Store)
-		err := awssso.Authenticate(ctx.Settings.UrlAction, ctx.Settings.Browser)
-		if err != nil {
-			log.WithError(err).Fatalf("Unable to authenticate")
-		}
 
 		ssoName, err := ctx.Settings.GetSelectedSSOName(ctx.Cli.SSO)
 		if err != nil {
 			log.Fatalf(err.Error())
 		}
 
-		err = set.Cache.Refresh(awssso, s, ssoName)
+		err = set.Cache.Refresh(AwsSSO, s, ssoName)
 		if err != nil {
 			log.WithError(err).Fatalf("Unable to refresh role cache")
 		}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -269,6 +269,13 @@ case-sensitive manner.
 
 ---
 
+### login
+
+Login via AWS IAM Identity Center (AWS SSO) and retrieve a security token
+used to fetch IAM Role credentials.
+
+---
+
 ### logout
 
 Invalidates all AWS credentials with AWS for the selected SSO instance, 
@@ -288,8 +295,8 @@ Flags:
 
  * `--type`, `-t` -- Type of credentials to flush:
     * `sts` -- Flush temporary STS credentials for IAM roles
-    * `sso` -- Flush temporary AWS SSO credentials
-    * `all` -- Flush temporary STS and SSO credentials
+    * `sso` -- Flush temporary AWS SSO credentials (deprecated)
+    * `all` -- Flush temporary STS and SSO credentials (deprecated)
 
 **Note:** Flushing non-expired SSO credentials will not cause new credentials to be issued
 on the next call to the AWS SSO API, but rather the existing credentials will be refreshed
@@ -297,6 +304,10 @@ from the browser session.
 
 **Note:** Flushing credentials does not invalidate them with AWS.  If you wish
 to do that, use the [logout](#logout) command.
+
+**Note:** Flushing the `sso` credentials is deprecated.  In the future, this
+command will accept no arguments and only support flushing the STS credentials
+from the security store.  Use the [logout](#logout) command instead of `-t sso`.
 
 ---
 

--- a/sso/cache_test.go
+++ b/sso/cache_test.go
@@ -328,20 +328,23 @@ func (suite *CacheTestSuite) TestDeleteOldHistory() {
 func (suite *CacheTestSuite) TestExpired() {
 	t := suite.T()
 	s := SSOConfig{
-		settings: &Settings{
-			CacheRefresh: 24,
-		},
+		settings: &Settings{},
 	}
-	assert.Error(t, suite.cache.Expired(&s))
-	s.settings.CacheRefresh = 0
-	assert.NoError(t, suite.cache.Expired(&s))
 
 	// invalid version
 	c := &Cache{
 		Version: 1, // invalid
 	}
-	err := c.Expired(&s)
-	assert.Error(t, err)
+
+	assert.Error(t, c.Expired(&s))
+
+	c.Version = CACHE_VERSION
+
+	s.settings.CacheRefresh = 0
+	assert.NoError(t, suite.cache.Expired(&s))
+
+	s.settings.CacheRefresh = 1
+	assert.Error(t, suite.cache.Expired(&s))
 }
 
 func (suite *CacheTestSuite) TestGetRole() {


### PR DESCRIPTION
- add `login` command to do the needful.  This is the only way now.
- Commands which do not need to access the AWS SSO API do not require login
- Deprecate `flush -t sso`

Fixes: #291