### PR TITLE
Fix fish shell completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs
 
  * Fix bug where JsonStore was not being created #612
+ * Fix fish shell completion
 
 ### New Features
 

--- a/internal/helper/aws-sso.fish
+++ b/internal/helper/aws-sso.fish
@@ -4,3 +4,4 @@ function __complete_aws-sso
     and set COMP_LINE "$COMP_LINE "
     {{ .Executable }}
 end
+complete -f -c aws-sso -a "(__complete_aws-sso)"

--- a/internal/utils/fileedit.go
+++ b/internal/utils/fileedit.go
@@ -115,6 +115,10 @@ func (f *FileEdit) GenerateNewFile(configFile string) ([]byte, error) {
 	// read & write up to the prefix
 	input, err := os.Open(configFile)
 	if err != nil {
+		if err = EnsureDirExists(configFile); err != nil {
+			return []byte{}, err
+		}
+
 		input, err = os.Create(configFile)
 		if err != nil {
 			return []byte{}, err


### PR DESCRIPTION
Original code didn't work at all and failed to install if the ~/.config/fish/completions/ directory didn't exist