### PR TITLE
`login` command checks AWS account list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changes
 
  * Require running `aws-sso login`.  No more auto-login.  #291
+    * `login` does a quick cache invalidation check using the number of AWS Accounts #576
+ * `aws-sso` commands other than `cache` and `login` no longer can trigger a cache refresh or
+    update of `~/.aws/config` file
  * Remove `config`, `config-profiles` and `completions` commands
     and replace with `setup`
  * Remove `--no-cache` flag

--- a/cmd/aws-sso/cache_cmd.go
+++ b/cmd/aws-sso/cache_cmd.go
@@ -20,9 +20,15 @@ package main
 
 import (
 	"fmt"
+
+	"github.com/synfinatic/aws-sso-cli/internal/awsconfig"
+	"github.com/synfinatic/aws-sso-cli/internal/url"
 )
 
-type CacheCmd struct{}
+type CacheCmd struct {
+	NoConfigCheck bool `kong:"help='Disable automatic ~/.aws/config updates'"`
+	Threads       int  `kong:"help='Override number of threads for talking to AWS'"`
+}
 
 func (cc *CacheCmd) Run(ctx *RunContext) error {
 	s, err := ctx.Settings.GetSelectedSSO(ctx.Cli.SSO)
@@ -44,6 +50,17 @@ func (cc *CacheCmd) Run(ctx *RunContext) error {
 	err = ctx.Settings.Cache.Save(true)
 	if err != nil {
 		return fmt.Errorf("Unable to save role cache: %s", err.Error())
+	}
+
+	// should we update our config??
+	if !ctx.Cli.Cache.NoConfigCheck && ctx.Settings.AutoConfigCheck {
+		if ctx.Settings.ConfigProfilesUrlAction != url.ConfigProfilesUndef {
+			action, _ := url.NewAction(string(ctx.Settings.ConfigProfilesUrlAction))
+			err := awsconfig.UpdateAwsConfig(ctx.Settings, action, "", true, false)
+			if err != nil {
+				log.Errorf("Unable to auto-update aws config file: %s", err.Error())
+			}
+		}
 	}
 
 	return nil

--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -106,15 +106,13 @@ var DEFAULT_CONFIG map[string]interface{} = map[string]interface{}{
 
 type CLI struct {
 	// Common Arguments
-	Browser       string `kong:"short='b',help='Path to browser to open URLs with',env='AWS_SSO_BROWSER'"`
-	ConfigFile    string `kong:"name='config',default='${CONFIG_FILE}',help='Config file',env='AWS_SSO_CONFIG'"`
-	LogLevel      string `kong:"short='L',name='level',help='Logging level [error|warn|info|debug|trace] (default: warn)'"`
-	Lines         bool   `kong:"help='Print line number in logs'"`
-	UrlAction     string `kong:"short='u',help='How to handle URLs [clip|exec|open|print|printurl|granted-containers|open-url-in-container] (default: open)'"`
-	SSO           string `kong:"short='S',help='Override default AWS SSO Instance',env='AWS_SSO',predictor='sso'"`
-	STSRefresh    bool   `kong:"help='Force refresh of STS Token Credentials'"`
-	NoConfigCheck bool   `kong:"help='Disable automatic ~/.aws/config updates'"`
-	Threads       int    `kong:"help='Override number of threads for talking to AWS'"`
+	Browser    string `kong:"short='b',help='Path to browser to open URLs with',env='AWS_SSO_BROWSER'"`
+	ConfigFile string `kong:"name='config',default='${CONFIG_FILE}',help='Config file',env='AWS_SSO_CONFIG'"`
+	LogLevel   string `kong:"short='L',name='level',help='Logging level [error|warn|info|debug|trace] (default: warn)'"`
+	Lines      bool   `kong:"help='Print line number in logs'"`
+	UrlAction  string `kong:"short='u',help='How to handle URLs [clip|exec|open|print|printurl|granted-containers|open-url-in-container] (default: open)'"`
+	SSO        string `kong:"short='S',help='Override default AWS SSO Instance',env='AWS_SSO',predictor='sso'"`
+	STSRefresh bool   `kong:"help='Force refresh of STS Token Credentials'"`
 
 	// Commands
 	Cache   CacheCmd   `kong:"cmd,help='Update cached AWS SSO role info'"`
@@ -295,12 +293,20 @@ func parseArgs(cli *CLI) (*kong.Context, sso.OverrideSettings) {
 		log.Fatalf("Invalid --url-action %s", cli.UrlAction)
 	}
 
+	// only cache and login commands have `--threads` flag
+	threads := 0
+	if cli.Login.Threads > 0 {
+		threads = cli.Login.Threads
+	} else if cli.Cache.Threads > 0 {
+		threads = cli.Cache.Threads
+	}
+
 	override := sso.OverrideSettings{
 		Browser:    cli.Browser,
 		DefaultSSO: cli.SSO,
 		LogLevel:   cli.LogLevel,
 		LogLines:   cli.Lines,
-		Threads:    cli.Threads,
+		Threads:    threads,
 		UrlAction:  action,
 	}
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,7 +10,6 @@
  * `--url-action`, `-u` -- How to handle URLs for your SSO provider
  * `--sso <name>`, `-S` -- Specify non-default AWS SSO instance to use (`$AWS_SSO`)
  * `--sts-refresh` -- Force refresh of STS Token Credentials
- * `--no-config-check` -- Disable automatic updating of `~/.aws/config`
 
 ## Commands
 
@@ -270,8 +269,10 @@ AWS SSO CLI caches information about your AWS Accounts, Roles and Tags for
 better perfomance.  By default it will refresh this information after 24
 hours, but you can force this data to be refreshed immediately.
 
-Cache data is also automatically updated anytime the `config.yaml` file is
-modified.
+Flags:
+
+ * `--no-config-check` -- Disable automatic `~/.aws/config` updates if the cache is refreshed 
+ * `--threads <count>` -- Override the number of threads used to refresh the list of AWS SSO Roles
 
 ---
 
@@ -314,6 +315,15 @@ case-sensitive manner.
 
 Login via AWS IAM Identity Center (AWS SSO) and retrieve a security token
 used to fetch IAM Role credentials.
+
+As part of the login process, `aws-sso` will fetch a list of AWS Accounts 
+and compare that to the cached list.  If the AWS Accounts changes, it will
+force a [cache refresh](#cache) of the list of AWS Accounts and Roles.
+
+Flags:
+
+ * `--no-config-check` -- Disable automatic `~/.aws/config` updates if the cache is refreshed 
+ * `--threads <count>` -- Override the number of threads used to refresh the list of AWS SSO Roles
 
 ---
 


### PR DESCRIPTION
Every time you login we do a quick validation that the list of accounts you have access to doesn't change, and will trigger a cache refresh if there are changes.

Fixes: #576