### PR TITLE
Inform users they don't need to redact accountIDs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,6 +21,12 @@ A clear and concise description of what the bug is.
  1. Command...
  2. ???
 
+**Note:** You do not need to redact AWS AccountIDs from outputs or config.
+[Per Amazon](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-identifiers.html#),
+"While account IDs, like any identifying information, should be
+used and shared carefully, they are not considered secret,
+sensitive, or confidential information."
+
 **Expected behavior:**
 A clear and concise description of what you expected to happen.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -271,7 +271,7 @@ hours, but you can force this data to be refreshed immediately.
 
 Flags:
 
- * `--no-config-check` -- Disable automatic `~/.aws/config` updates if the cache is refreshed 
+ * `--no-config-check` -- Disable automatic `~/.aws/config` updates if the cache is refreshed
  * `--threads <count>` -- Override the number of threads used to refresh the list of AWS SSO Roles
 
 ---
@@ -316,13 +316,13 @@ case-sensitive manner.
 Login via AWS IAM Identity Center (AWS SSO) and retrieve a security token
 used to fetch IAM Role credentials.
 
-As part of the login process, `aws-sso` will fetch a list of AWS Accounts 
+As part of the login process, `aws-sso` will fetch a list of AWS Accounts
 and compare that to the cached list.  If the AWS Accounts changes, it will
 force a [cache refresh](#cache) of the list of AWS Accounts and Roles.
 
 Flags:
 
- * `--no-config-check` -- Disable automatic `~/.aws/config` updates if the cache is refreshed 
+ * `--no-config-check` -- Disable automatic `~/.aws/config` updates if the cache is refreshed
  * `--threads <count>` -- Override the number of threads used to refresh the list of AWS SSO Roles
 
 ---


### PR DESCRIPTION
remove trailing spaces in markdown