### PR TITLE
Remove `CacheRefresh` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@
  * Remove `config`, `config-profiles` and `completions` commands
     and replace with `setup`
  * Remove `flush` command.  Use `logout`
- * Remove `--no-cache` fla
+ * Remove `--no-cache` flag
+ * Remove `CacheRefresh` configuration option.  `aws-sso` will only update the cache
+    when you ask it to via `aws-sso cache`
 
 ## [v1.14.2] - 2023-10-19
 
@@ -123,7 +125,7 @@
 
 ### Changes
 
- * [CacheRefresh](docs/config.md#CacheRefresh) now defaults to 168 hours (7 days)
+ * `CacheRefresh` now defaults to 168 hours (7 days)
  * [FullTextSearch](docs/config.md#FullTextSearch) is enabled by default for interactive `list` mode.
  * [MaxRetry](docs/config.md#MaxRetry) defaults to 10
  * [MaxBackoff](docs/config.md#MaxBackoff) defaults to 5

--- a/cmd/aws-sso/config_wizard.go
+++ b/cmd/aws-sso/config_wizard.go
@@ -686,31 +686,6 @@ func promptProfileFormat(value string) string {
 	return items[i].Value
 }
 
-func promptCacheRefresh(defaultValue int64) int64 {
-	var val string
-	var err error
-
-	fmt.Printf("\n")
-
-	label := "Hours between AWS SSO cache refresh. 0 to disable. (CacheRefresh)"
-	for val == "" {
-		prompt := promptui.Prompt{
-			Label:     label,
-			Validate:  validateInteger,
-			Default:   fmt.Sprintf("%d", defaultValue),
-			Pointer:   promptui.PipeCursor,
-			Templates: makePromptTemplate(label),
-		}
-
-		if val, err = prompt.Run(); err != nil {
-			checkPromptError(err)
-		}
-	}
-	val = strings.TrimSpace(val)
-	x, _ := strconv.ParseInt(val, 10, 64)
-	return x
-}
-
 func promptConfigProfilesUrlAction(
 	defaultValue url.ConfigProfilesAction, urlAction url.Action) url.ConfigProfilesAction {
 	var err error

--- a/cmd/aws-sso/interactive.go
+++ b/cmd/aws-sso/interactive.go
@@ -40,13 +40,6 @@ func (ctx *RunContext) PromptExec(exec CompleterExec) error {
 	if err != nil {
 		return err
 	}
-	if err = ctx.Settings.Cache.Expired(sso); err != nil {
-		log.Infof(err.Error())
-		c := &CacheCmd{}
-		if err = c.Run(ctx); err != nil {
-			return err
-		}
-	}
 
 	sso.Refresh(ctx.Settings)
 	fmt.Printf("Please use `exit` or `Ctrl-D` to quit.\n")

--- a/cmd/aws-sso/list_cmd.go
+++ b/cmd/aws-sso/list_cmd.go
@@ -45,7 +45,6 @@ var DEFAULT_LIST_FIELDS []string = []string{"AccountIdPad", "AccountAlias", "Rol
 
 // what should this actually do?
 func (cc *ListCmd) Run(ctx *RunContext) error {
-	var err error
 	var prefixSearch []string
 
 	// If `-f` then print our fields and exit
@@ -70,17 +69,6 @@ func (cc *ListCmd) Run(ctx *RunContext) error {
 		}
 	}
 
-	s, err := ctx.Settings.GetSelectedSSO(ctx.Cli.SSO)
-	if err != nil {
-		return err
-	}
-	if err = ctx.Settings.Cache.Expired(s); err != nil {
-		c := &CacheCmd{}
-		if err = c.Run(ctx); err != nil {
-			log.WithError(err).Errorf("Unable to refresh local cache")
-		}
-	}
-
 	fields := ctx.Settings.ListFields
 	if len(ctx.Cli.List.Fields) > 0 {
 		fields = ctx.Cli.List.Fields
@@ -100,19 +88,6 @@ func (cc *ListCmd) Run(ctx *RunContext) error {
 type DefaultCmd struct{}
 
 func (cc *DefaultCmd) Run(ctx *RunContext) error {
-	s, err := ctx.Settings.GetSelectedSSO("")
-	if err != nil {
-		return err
-	}
-
-	// update cache?
-	if err = ctx.Settings.Cache.Expired(s); err != nil {
-		c := &CacheCmd{}
-		if err = c.Run(ctx); err != nil {
-			log.WithError(err).Errorf("Unable to refresh local cache")
-		}
-	}
-
 	return printRoles(ctx, ctx.Settings.ListFields, false, []string{}, "AccountId", false)
 }
 

--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -86,7 +86,6 @@ var DEFAULT_CONFIG map[string]interface{} = map[string]interface{}{
 	"PromptColors.SuggestionBGColor":            "Cyan",
 	"PromptColors.SuggestionTextColor":          "White",
 	"AutoConfigCheck":                           false,
-	"CacheRefresh":                              168, // 7 days in hours
 	"ConfigProfilesUrlAction":                   "open",
 	"ConsoleDuration":                           60,
 	"DefaultRegion":                             "us-east-1",

--- a/cmd/aws-sso/setup_wizard_cmd.go
+++ b/cmd/aws-sso/setup_wizard_cmd.go
@@ -99,7 +99,6 @@ func setupWizard(ctx *RunContext, reconfig, addSSO, advanced bool) error {
 			LogLevel:        "error",
 			DefaultRegion:   defaultRegion,
 			ConsoleDuration: 720,
-			CacheRefresh:    168,
 			AutoConfigCheck: false,
 			FullTextSearch:  true,
 			HistoryLimit:    10,
@@ -118,12 +117,7 @@ func setupWizard(ctx *RunContext, reconfig, addSSO, advanced bool) error {
 	s.ProfileFormat = promptProfileFormat(s.ProfileFormat)
 
 	if advanced {
-		// first, caching
-		s.CacheRefresh = promptCacheRefresh(s.CacheRefresh)
-
-		if s.CacheRefresh > 0 {
-			s.AutoConfigCheck = promptAutoConfigCheck(s.AutoConfigCheck)
-		}
+		s.AutoConfigCheck = promptAutoConfigCheck(s.AutoConfigCheck)
 
 		// full text search?
 		s.FullTextSearch = promptFullTextSearch(s.FullTextSearch)

--- a/cmd/aws-sso/tags_cmd.go
+++ b/cmd/aws-sso/tags_cmd.go
@@ -50,19 +50,6 @@ func (cc *TagsCmd) Run(ctx *RunContext) error {
 		if err != nil {
 			log.WithError(err).Errorf("Unable to save cache")
 		}
-	} else {
-		s, err := ctx.Settings.GetSelectedSSO(ctx.Cli.SSO)
-		if err != nil {
-			return err
-		}
-
-		if err := set.Cache.Expired(s); err != nil {
-			log.Warn(err.Error())
-			c := &CacheCmd{}
-			if err = c.Run(ctx); err != nil {
-				return err
-			}
-		}
 	}
 	roles := []*sso.AWSRoleFlat{}
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -9,7 +9,7 @@ see how long your credentials have until they expire, see the [list command](com
 
 ### Why can't aws-sso find my new role?
 
-Most likely, this is because the aws-sso [cache](config.md#CacheRefresh) is out of
+Most likely, this is because the aws-sso cache is out of
 date.  You can force a refresh of the cache by running [aws-sso cache](commands.md#cache).
 
 Note, if you have just been assigned a new PermissionSet in IAM Identity Center, it
@@ -387,10 +387,7 @@ by not incurring the backoff delay penalty) or adjust the MaxRetry and/or
 ### Warning: Fetching roles for 46 accounts, this might take a while...
 
 Due to the AWS API and rate limits, users with many AWS Accounts may see
-this warning.  If this happens more often than is acceptable, you can
-set [CacheRefresh](config.md#CacheRefresh) to a higher value
-(cache roles for longer) or you can completely disable the auto-refresh of
-the cache by setting `CacheRefresh` to `0`.
+this warning.  
 
 --
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -36,7 +36,6 @@ SSOConfig:
 # See description below for these options
 DefaultRegion: <AWS_DEFAULT_REGION>
 DefaultSSO: <name of AWS SSO>
-CacheRefresh: <hours>
 AutoConfigCheck: [False|True]
 Threads: <integer>
 MaxRetry: <integer>
@@ -219,15 +218,6 @@ selected unless you manually specify it here, on the CLI (`--sso`), or via
 the `AWS_SSO` environment variable.
 
 ### SSO Cache Options
-
-#### CacheRefresh
-
-This is the number of hours between automatically refreshing your AWS SSO cache
-to detect any changes in the roles you have been granted access to.  The default
-is 168 (7 days).  Disable this feature by setting to any value <= 0.
-
-**Note:** If this feature is disabled, then [AutoConfigCheck](#autoconfigcheck)
-is also disabled.
 
 #### Threads
 
@@ -523,10 +513,6 @@ Specify which fields to display via the `list` command.  Valid options are:
  * `Via` -- Role Chain Via
 
 #### AutoConfigCheck
-
-When set to `True`, when your AWS SSO roles are automatically refreshed (see
-[CacheRefresh](#cacherefresh)) `aws-sso` will also check to see if any changes
-are warranted in your `~/.aws/config`.
 
 **Note:** This option requires you to also set 
 [ConfigProfilesUrlAction](#configprofilesurlaction).

--- a/sso/cache.go
+++ b/sso/cache.go
@@ -99,31 +99,6 @@ func (c *Cache) GetSSO() *SSOCache {
 	return c.SSO[c.ssoName]
 }
 
-// Expired returns if our Roles cache data is too old.
-// If configFile is a valid file, we check the lastModificationTime of that file
-// vs. the ConfigCreatedAt to determine if the cache needs to be updated
-func (c *Cache) Expired(s *SSOConfig) error {
-	if c.Version < CACHE_VERSION {
-		return fmt.Errorf("Local cache is out of date; current cache version %d is less than %d", c.Version, CACHE_VERSION)
-	}
-
-	// negative values disable refresh
-	if s.settings.CacheRefresh <= 0 {
-		return nil
-	}
-
-	ttl := s.settings.CacheRefresh * 60 * 60 // convert hours to seconds
-	cache := c.GetSSO()
-	if cache.LastUpdate+ttl < time.Now().Unix() {
-		return fmt.Errorf("Local cache is out of date; TTL has been exceeded.")
-	}
-
-	if s.CreatedAt() > c.ConfigCreatedAt {
-		return fmt.Errorf("Local cache is out of date; config.yaml modified.")
-	}
-	return nil
-}
-
 func (c *Cache) CacheFile() string {
 	return c.settings.cacheFile
 }

--- a/sso/cache_test.go
+++ b/sso/cache_test.go
@@ -325,28 +325,6 @@ func (suite *CacheTestSuite) TestDeleteOldHistory() {
 	assert.Contains(t, hook.LastEntry().Message, "Unable to parse")
 }
 
-func (suite *CacheTestSuite) TestExpired() {
-	t := suite.T()
-	s := SSOConfig{
-		settings: &Settings{},
-	}
-
-	// invalid version
-	c := &Cache{
-		Version: 1, // invalid
-	}
-
-	assert.Error(t, c.Expired(&s))
-
-	c.Version = CACHE_VERSION
-
-	s.settings.CacheRefresh = 0
-	assert.NoError(t, suite.cache.Expired(&s))
-
-	s.settings.CacheRefresh = 1
-	assert.Error(t, suite.cache.Expired(&s))
-}
-
 func (suite *CacheTestSuite) TestGetRole() {
 	t := suite.T()
 	r, _ := suite.cache.GetRole(TEST_ROLE_ARN)

--- a/sso/settings.go
+++ b/sso/settings.go
@@ -53,7 +53,6 @@ type Settings struct {
 	DefaultRegion             string                   `koanf:"DefaultRegion" yaml:"DefaultRegion,omitempty"`
 	ConsoleDuration           int32                    `koanf:"ConsoleDuration" yaml:"ConsoleDuration,omitempty"`
 	JsonStore                 string                   `koanf:"JsonStore" yaml:"JsonStore,omitempty"`
-	CacheRefresh              int64                    `koanf:"CacheRefresh" yaml:"CacheRefresh,omitempty"`
 	Threads                   int                      `koanf:"Threads" yaml:"Threads,omitempty"`
 	MaxBackoff                int                      `koanf:"MaxBackoff" yaml:"MaxBackoff,omitempty"`
 	MaxRetry                  int                      `koanf:"MaxRetry" yaml:"MaxRetry,omitempty"`


### PR DESCRIPTION
No longer auto-refresh the cache.  Users should
manually update it via `aws-sso cache`

Refs: #610