### PR TITLE
Allow the use of --accountAlias in eval command

### DIFF
--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/alecthomas/kong"
 	"github.com/posener/complete"
+
 	// "github.com/davecgh/go-spew/spew"
 	"github.com/sirupsen/logrus"
 	"github.com/synfinatic/aws-sso-cli/internal/awscreds"
@@ -243,13 +244,14 @@ func parseArgs(cli *CLI) (*kong.Context, sso.OverrideSettings) {
 	kongplete.Complete(parser,
 		kongplete.WithPredictors(
 			map[string]complete.Predictor{
-				"accountId": p.AccountComplete(),
-				"arn":       p.ArnComplete(),
-				"fieldList": p.FieldListComplete(),
-				"profile":   p.ProfileComplete(),
-				"region":    p.RegionComplete(),
-				"role":      p.RoleComplete(),
-				"sso":       p.SsoComplete(),
+				"accountAlias": p.AccountAliasComplete(),
+				"accountId":    p.AccountComplete(),
+				"arn":          p.ArnComplete(),
+				"fieldList":    p.FieldListComplete(),
+				"profile":      p.ProfileComplete(),
+				"region":       p.RegionComplete(),
+				"role":         p.RoleComplete(),
+				"sso":          p.SsoComplete(),
 			},
 		),
 	)

--- a/internal/predictor/predictor.go
+++ b/internal/predictor/predictor.go
@@ -30,11 +30,12 @@ import (
 )
 
 type Predictor struct {
-	configFile string
-	accountids []string
-	arns       []string
-	roles      []string
-	profiles   []string
+	configFile   string
+	accountAlias []string
+	accountids   []string
+	arns         []string
+	roles        []string
+	profiles     []string
 }
 
 // NewPredictor loads our cache file (if exists) and loads the values
@@ -117,6 +118,10 @@ func (p *Predictor) FieldListComplete() complete.Predictor {
 	}
 
 	return complete.PredictSet(set...)
+}
+
+func (p *Predictor) AccountAliasComplete() complete.Predictor {
+	return complete.PredictSet(p.accountAlias...)
 }
 
 // AccountComplete returns a list of all the valid AWS Accounts we have in the cache


### PR DESCRIPTION
Makes use of account alias when using the eval command, so that 

`aws-sso eval --account <bunch o numbers> --role AdminFun`

can also be expressed in the form

`aws-sso eval --accountAlias production --role AdminFun`