### PR TITLE
Auto update cache during login if config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### New Features
+
+ * Update cache during login when relevant settings in the config.yaml changes #555
+
+### Changes
+
+ * Bump cache file version to 4.
+
 ## [v2.0.0-beta1] - 2023-11-11
 
 ### Bugs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ are undoubtably wrong.  The trick is of course figuring out which is
 which.
 
 With that said, please reach out before you start working on a new
-feature so we can discuss.  Easiest way is to 
+feature so we can discuss.  Easiest way is to
 [open a feature request](
 https://github.com/synfinatic/aws-sso-cli/issues/new?assignees=&labels=enhancement&projects=&template=feature_request.md&title=)
 and start a conversation.

--- a/cmd/aws-sso/login_cmd.go
+++ b/cmd/aws-sso/login_cmd.go
@@ -41,6 +41,20 @@ func (cc *LoginCmd) Run(ctx *RunContext) error {
 	if err != nil {
 		log.Fatalf("%s", err.Error())
 	}
+
+	needsRefresh := ctx.Settings.Cache.SSO[ssoName].NeedsRefresh(ctx.Settings.SSO[ssoName], ctx.Settings)
+
+	if needsRefresh {
+		log.Infof("Detected config file changes; automatically refreshing our cache...")
+		c := &CacheCmd{
+			NoConfigCheck: ctx.Cli.Login.NoConfigCheck,
+			Threads:       ctx.Cli.Login.Threads,
+		}
+		if err = c.Run(ctx); err != nil {
+			log.WithError(err).Errorf("Unable to refresh local cache")
+		}
+	}
+
 	cachedAccounts := ctx.Settings.Cache.SSO[ssoName].Roles.Accounts
 
 	delta := false

--- a/sso/cache_test.go
+++ b/sso/cache_test.go
@@ -42,6 +42,7 @@ type CacheTestSuite struct {
 	suite.Suite
 	cache     *Cache
 	cacheFile string
+	settings  *Settings
 }
 
 type ProfileTests map[string]Roles
@@ -53,10 +54,14 @@ func TestCacheTestSuite(t *testing.T) {
 	f.Close()
 
 	settings := &Settings{
+		SSO: map[string]*SSOConfig{
+			"Default": {},
+		},
 		HistoryLimit:   1,
 		HistoryMinutes: 90,
 		DefaultSSO:     "Default",
 		cacheFile:      f.Name(),
+		ProfileFormat:  "{{ .AccountIdPad }}:{{ .RoleName }}", // old format is easier
 	}
 
 	input, err := os.ReadFile(TEST_CACHE_FILE)
@@ -71,12 +76,19 @@ func TestCacheTestSuite(t *testing.T) {
 	s := &CacheTestSuite{
 		cache:     c,
 		cacheFile: f.Name(),
+		settings:  settings,
 	}
 	suite.Run(t, s)
 }
 
 func (suite *CacheTestSuite) TearDownAllSuite() {
 	os.Remove(suite.cacheFile)
+}
+
+func (suite *CacheTestSuite) TestNeedsRefresh() {
+	t := suite.T()
+
+	assert.True(t, suite.cache.SSO["Default"].NeedsRefresh(suite.settings.SSO["Default"], suite.settings))
 }
 
 func (suite *CacheTestSuite) TestAddHistory() {

--- a/sso/testdata/cache.json
+++ b/sso/testdata/cache.json
@@ -1,9 +1,10 @@
 {
   "ConfigCreatedAt": 1635710861,
-  "Version": 3,
+  "Version": 4,
   "SSO": {
     "Default": {
       "LastUpdate": 1635913188,
+      "ConfigHash": "xxx",
       "Roles": {
         "Accounts": {
           "025823461518": {


### PR DESCRIPTION
Unlike in v1.x, we only update if `ProfileFormat`
changes or something in your SSOConfig[Name].Accounts section changes.

Also fix crash when config.yaml SSOConfig account/role information
is incomplete.

Bump cache version to 4

Fixes: #555