### PR TITLE
Wizard setup on remote hosts

### DIFF
--- a/cmd/aws-sso/config_wizard.go
+++ b/cmd/aws-sso/config_wizard.go
@@ -310,24 +310,8 @@ func promptUrlAction(defaultValue url.Action) url.Action {
 
 	items := []selectOptions{
 		{
-			Name:  "Copy to clipboard",
-			Value: "clip",
-		},
-		{
 			Name:  "Execute custom command",
 			Value: "exec",
-		},
-		{
-			Name:  "Open in (default) browser",
-			Value: "open",
-		},
-		{
-			Name:  "Open in Firefox with Granted Containers plugin",
-			Value: "granted-containers",
-		},
-		{
-			Name:  "Open in Firefox with Open Url in Container plugin",
-			Value: "open-url-in-container",
 		},
 		{
 			Name:  "Print message with URL",
@@ -337,6 +321,28 @@ func promptUrlAction(defaultValue url.Action) url.Action {
 			Name:  "Print only the URL",
 			Value: "printurl",
 		},
+	}
+
+	// only valid on localhost
+	if !utils.IsRemoteHost() {
+		items = append(items,
+			selectOptions{
+				Name:  "Copy to clipboard",
+				Value: "clip",
+			},
+			selectOptions{
+				Name:  "Open in (default) browser",
+				Value: "open",
+			},
+			selectOptions{
+				Name:  "Open in Firefox with Granted Containers plugin",
+				Value: "granted-containers",
+			},
+			selectOptions{
+				Name:  "Open in Firefox with Open Url in Container plugin",
+				Value: "open-url-in-container",
+			},
+		)
 	}
 
 	dValue := string(defaultValue)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -204,3 +204,11 @@ func StrListContains(str string, list []string) bool {
 	}
 	return false
 }
+
+// IsRemoteHost returns if we are running on a remote host or not
+func IsRemoteHost() bool {
+	// right now we just look for the SSH_TTY env var which should be set
+	// anytime you ssh to a remote host
+	_, inSSHSession := os.LookupEnv("SSH_TTY")
+	return inSSHSession
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -250,3 +250,11 @@ func TestStrListContains(t *testing.T) {
 	assert.True(t, StrListContains("yes", x))
 	assert.False(t, StrListContains("nope", x))
 }
+
+func TestIsRemoteHost(t *testing.T) {
+	os.Setenv("SSH_TTY", "FOOBAR")
+	assert.True(t, IsRemoteHost())
+
+	os.Unsetenv("SSH_TTY")
+	assert.False(t, IsRemoteHost())
+}


### PR DESCRIPTION
On remote hosts, we can't use a web browser (unless you're doing old school X remote tricks?) so we force you to select between exec/print.  Otherwise,
you need to select advanced mode.

Fixes: #757