### PR TITLE
feature: add support for installing completions at package build time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* Add `aws-sso-cli completion --source` flag to generate completion script and
+  print to stdout. #779
+
 ## [v1.14.3] - 2024-01-15
 
 ### Bugs

--- a/cmd/aws-sso/completions_cmd.go
+++ b/cmd/aws-sso/completions_cmd.go
@@ -39,7 +39,8 @@ func (cc *CompleteCmd) Run(ctx *RunContext) error {
 	var err error
 
 	if ctx.Cli.Completions.Source {
-		err = helper.SourceHelper(ctx.Cli.Completions.Shell)
+		err = helper.NewSourceHelper(os.Executable, os.Stdout).
+			Generate(ctx.Cli.Completions.Shell)
 	} else if ctx.Cli.Completions.Install {
 		// install the current auto-complete helper
 		err = helper.InstallHelper(ctx.Cli.Completions.Shell, ctx.Cli.Completions.ShellScript)

--- a/cmd/aws-sso/completions_cmd.go
+++ b/cmd/aws-sso/completions_cmd.go
@@ -27,6 +27,7 @@ import (
 )
 
 type CompleteCmd struct {
+	Source         bool   `kong:"help='Print out completions for sourcing in the active shell',xor='action'"`
 	Install        bool   `kong:"short='I',help='Install shell completions',xor='action'"`
 	Uninstall      bool   `kong:"short='U',help='Uninstall shell completions',xor='action'"`
 	UninstallPre19 bool   `kong:"help='Uninstall pre-v1.9 shell completion integration',xor='action',xor='shell,script'"`
@@ -37,7 +38,9 @@ type CompleteCmd struct {
 func (cc *CompleteCmd) Run(ctx *RunContext) error {
 	var err error
 
-	if ctx.Cli.Completions.Install {
+	if ctx.Cli.Completions.Source {
+		err = helper.SourceHelper(ctx.Cli.Completions.Shell)
+	} else if ctx.Cli.Completions.Install {
 		// install the current auto-complete helper
 		err = helper.InstallHelper(ctx.Cli.Completions.Shell, ctx.Cli.Completions.ShellScript)
 	} else if ctx.Cli.Completions.Uninstall {

--- a/internal/helper/helper_test.go
+++ b/internal/helper/helper_test.go
@@ -1,0 +1,68 @@
+package helper
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"unicode"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSourceHelper(t *testing.T) {
+	testcases := []struct {
+		shell          string
+		expectedError  error
+		expectedOutput []byte
+	}{
+		{
+			shell: "bash",
+			expectedOutput: []byte(`
+complete -F __aws_sso_profile_complete aws-sso-profile
+complete -C /bin/aws-sso-cli aws-sso
+`),
+		},
+		{
+			shell: "zsh",
+			expectedOutput: []byte(`
+compdef __aws_sso_profile_complete aws-sso-profile
+complete -C /bin/aws-sso-cli aws-sso
+`),
+		},
+		{
+			shell: "fish",
+			expectedOutput: []byte(`
+function __complete_aws-sso
+    set -lx COMP_LINE (commandline -cp)
+    test -z (commandline -ct)
+    and set COMP_LINE "$COMP_LINE "
+    /bin/aws-sso-cli
+end
+complete -f -c aws-sso -a "(__complete_aws-sso)"
+`),
+		},
+		{
+			shell:         "nushell",
+			expectedError: errors.New("unsupported shell: nushell"),
+		},
+	}
+
+	for _, tc := range testcases {
+		var (
+			tc     = tc
+			output = bytes.NewBuffer(nil)
+			h      = &SourceHelper{
+				getExe: func() (string, error) {
+					return "/bin/aws-sso-cli", nil
+				},
+				output: output,
+			}
+		)
+
+		t.Run(tc.shell, func(t *testing.T) {
+			err := h.Generate(tc.shell)
+			require.Equal(t, tc.expectedError, err)
+			require.Contains(t, output.String(), string(bytes.TrimLeftFunc(tc.expectedOutput, unicode.IsSpace)))
+		})
+	}
+}

--- a/internal/helper/helper_test.go
+++ b/internal/helper/helper_test.go
@@ -48,18 +48,20 @@ complete -f -c aws-sso -a "(__complete_aws-sso)"
 	}
 
 	for _, tc := range testcases {
-		var (
-			tc     = tc
-			output = bytes.NewBuffer(nil)
-			h      = &SourceHelper{
-				getExe: func() (string, error) {
-					return "/bin/aws-sso-cli", nil
-				},
-				output: output,
-			}
-		)
+		tc := tc
 
 		t.Run(tc.shell, func(t *testing.T) {
+			t.Parallel()
+			var (
+				output = bytes.NewBuffer(nil)
+				h      = &SourceHelper{
+					getExe: func() (string, error) {
+						return "/bin/aws-sso-cli", nil
+					},
+					output: output,
+				}
+			)
+
 			err := h.Generate(tc.shell)
 			require.Equal(t, tc.expectedError, err)
 			require.Contains(t, output.String(), string(bytes.TrimLeftFunc(tc.expectedOutput, unicode.IsSpace)))

--- a/internal/utils/fileedit.go
+++ b/internal/utils/fileedit.go
@@ -47,6 +47,21 @@ type FileEdit struct {
 
 var prompt = askUser
 
+func GenerateSource(fileTemplate string, vars interface{}) ([]byte, error) {
+	templ, err := template.New("template").Parse(fileTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	err = templ.Execute(&buf, vars)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
 func NewFileEdit(fileTemplate string, vars interface{}) (*FileEdit, error) {
 	var t string
 

--- a/internal/utils/fileedit_test.go
+++ b/internal/utils/fileedit_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFileEdit(t *testing.T) {
@@ -186,4 +187,44 @@ func TestPrompter(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte(
 		fmt.Sprintf(FILE_TEMPLATE, CONFIG_PREFIX, "foo", CONFIG_SUFFIX)), fBytes)
+}
+
+func TestGenerateSource(t *testing.T) {
+	testcases := []struct {
+		name        string
+		tpl         string
+		expectedErr error
+		expected    string
+	}{
+		{
+			name: "template with no variables",
+			tpl: `
+I'm a text template if you can believe that
+`,
+			expected: `
+I'm a text template if you can believe that
+`,
+		},
+		{
+			name: "template",
+			tpl: `
+{{.Name}}
+`,
+			expected: `
+template
+`,
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			output, err := GenerateSource(tc.tpl, map[string]interface{}{
+				"Name": tc.name,
+			})
+			require.Equal(t, tc.expectedErr, err)
+			require.Equal(t, tc.expected, string(output))
+		})
+	}
 }


### PR DESCRIPTION
Enables installing the completions at build time (aka during package building) and also simplifies the management of completions in the long run as the only required modification to the shell rc file can be a single line.

**I need some pointers on how to add this feature into the documentation, I wasn't able to figure it out but I also didn't give it 100%.**

This feature makes the processing of installing the completions into the standard system locations at package build time line up with how the cobra framework does it as well as many other CLI frameworks.

For instance the following is from the nixpkg of a command that uses cobra.

https://github.com/nix-community/gomod2nix/blob/master/default.nix#L39

```nix
  postInstall = lib.optionalString (stdenv.buildPlatform == stdenv.targetPlatform) ''
    installShellCompletion --cmd gomod2nix \
      --bash <($out/bin/gomod2nix completion bash) \
      --fish <($out/bin/gomod2nix completion fish) \
      --zsh <($out/bin/gomod2nix completion zsh)
  '' + ''
    wrapProgram $out/bin/gomod2nix --prefix PATH : ${lib.makeBinPath [ go ]}
  '';
```

For comparison, the aws-sso-cli package would then do something like the following.

```diff
---
 pkgs/tools/admin/aws-sso-cli/default.nix | 7 ++++++-
 1 file changed, 6 insertions(+), 1 deletion(-)

diff --git a/pkgs/tools/admin/aws-sso-cli/default.nix b/pkgs/tools/admin/aws-sso-cli/default.nix
index 998da596c06889..d9fc445c8bd929 100644
--- a/pkgs/tools/admin/aws-sso-cli/default.nix
+++ b/pkgs/tools/admin/aws-sso-cli/default.nix
@@ -23,7 +23,12 @@ buildGoModule rec {
     "-X main.Tag=nixpkgs"
   ];
 
-  postInstall = ''
+  postInstall = lib.optionalString (stdenv.buildPlatform == stdenv.targetPlatform) ''
+    installShellCompletion --cmd aws-sso \
+      --bash <($out/bin/aws-sso completions --source --shell=bash) \
+      --fish <($out/bin/aws-sso completions --source --shell=fish) \
+      --zsh <($out/bin/aws-sso completions --source --shell=zsh)
+  '' + ''
     wrapProgram $out/bin/aws-sso \
       --suffix PATH : ${lib.makeBinPath [ xdg-utils ]}
   '';
```

https://github.com/ghthor/nixpkgs/commit/c7c2ea66242d9bef6525070d064603a057722776

