### PR TITLE
helper functions for fish (#361)

### DIFF
--- a/internal/helper/aws-sso.fish
+++ b/internal/helper/aws-sso.fish
@@ -5,3 +5,26 @@ function __complete_aws-sso
     {{ .Executable }}
 end
 complete -f -c aws-sso -a "(__complete_aws-sso)"
+
+function aws-sso-profile
+  set --local _args (string split -- ' ' $AWS_SSO_HELPER_ARGS)
+  set -q AWS_SSO_HELPER_ARGS; or set --local _args -L error --no-config-check
+  if [ -n "$AWS_PROFILE" ]
+      echo "Unable to assume a role while AWS_PROFILE is set"
+      return 1
+  end
+  eval $({{ .Executable }} $_args eval -p $argv[1])
+  if [ "$AWS_SSO_PROFILE" != "$1" ]
+      return 1
+  end
+end
+
+function aws-sso-clear
+  set --local _args (string split -- ' ' $AWS_SSO_HELPER_ARGS)
+  set -q AWS_SSO_HELPER_ARGS; or set --local _args -L error
+  if [ -z "$AWS_PROFILE" ]
+      echo "AWS_PROFILE ist not set"
+      return 1
+  end
+  eval "$({{ .Executable }} $_args eval -c | string replace "unset" "set --erase" )"
+end

--- a/internal/helper/aws-sso.fish
+++ b/internal/helper/aws-sso.fish
@@ -23,7 +23,7 @@ function aws-sso-clear
   set --local _args (string split -- ' ' $AWS_SSO_HELPER_ARGS)
   set -q AWS_SSO_HELPER_ARGS; or set --local _args -L error
   if [ -z "$AWS_PROFILE" ]
-      echo "AWS_PROFILE ist not set"
+      echo "AWS_PROFILE is not set"
       return 1
   end
   eval "$({{ .Executable }} $_args eval -c | string replace "unset" "set --erase" )"


### PR DESCRIPTION
Two fish functions as direct translations from zsh functions, trying to close #361.

Im using fish version 3.7.1 and assume that the subcommand syntax in `aws-sso-clear` (`$(command)`) needs atleast fish version > 3.0.0.