### PR TITLE
use SSO name for config-profiles block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@
 
 ## [v1.16.0] - XXXX-XX-XX
 
-### Changes 
+### Bug Fixes
 
- * `config-profiles` command now uses the name of the SSO for the block #696
+ * Fix tab completion for --profile flag with fish
+ * `config-profiles` now works for multiple AWS SSO instances #696, #740
+
+### Changes
+
+ * update to AWS ssooidc v1.24.5
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [v1.16.0] - XXXX-XX-XX
 
+### Changes 
+
+ * `config-profiles` command now uses the name of the SSO for the block #696
+
 ### New Features
 
  * Add credentials command #867

--- a/cmd/aws-sso/config_profiles_cmd.go
+++ b/cmd/aws-sso/config_profiles_cmd.go
@@ -55,7 +55,7 @@ func (cc *ConfigProfilesCmd) Run(ctx *RunContext) error {
 	}
 
 	if action == url.ConfigProfilesUndef {
-		return fmt.Errorf("Please specify --open [clip|exec|open|granted-containers|open-url-in-container]")
+		return fmt.Errorf("%s", "please specify --open [clip|exec|open|granted-containers|open-url-in-container]")
 	}
 
 	urlAction, _ := url.NewAction(string(action))

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 )
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.27.1
+	github.com/aws/aws-sdk-go-v2 v1.27.2
 	github.com/riywo/loginshell v0.0.0-20200815045211-7d26008be1ab
 	golang.org/x/term v0.21.0
 	gopkg.in/ini.v1 v1.67.0
@@ -73,7 +73,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.17
 	github.com/aws/aws-sdk-go-v2/service/iam v1.24.0
 	github.com/aws/aws-sdk-go-v2/service/sso v1.20.10
-	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.24.4
+	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.24.5
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.11
 	golang.org/x/net v0.23.0
 )
@@ -81,8 +81,8 @@ require (
 require (
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.4 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.8 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.8 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.9 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.9 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.11.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aws/aws-sdk-go-v2 v1.9.2/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
 github.com/aws/aws-sdk-go-v2 v1.21.2/go.mod h1:ErQhvNuEMhJjweavOYhxVkn2RUx7kQXVATHrjKtxIpM=
-github.com/aws/aws-sdk-go-v2 v1.27.1 h1:xypCL2owhog46iFxBKKpBcw+bPTX/RJzwNj8uSilENw=
-github.com/aws/aws-sdk-go-v2 v1.27.1/go.mod h1:ffIFB97e2yNsv4aTSGkqtHnppsIJzw7G7BReUZ3jCXM=
+github.com/aws/aws-sdk-go-v2 v1.27.2 h1:pLsTXqX93rimAOZG2FIYraDQstZaaGVVN4tNw65v0h8=
+github.com/aws/aws-sdk-go-v2 v1.27.2/go.mod h1:ffIFB97e2yNsv4aTSGkqtHnppsIJzw7G7BReUZ3jCXM=
 github.com/aws/aws-sdk-go-v2/config v1.8.3/go.mod h1:4AEiLtAb8kLs7vgw2ZV3p2VZ1+hBavOc84hqxVNpCyw=
 github.com/aws/aws-sdk-go-v2/config v1.27.17 h1:L0JZN7Gh7pT6u5CJReKsLhGKparqNKui+mcpxMXjDZc=
 github.com/aws/aws-sdk-go-v2/config v1.27.17/go.mod h1:MzM3balLZeaafYcPz8IihAmam/aCz6niPQI0FdprxW0=
@@ -46,11 +46,11 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.6.0/go.mod h1:gqlclDEZp4aqJOanc
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.4 h1:0cSfTYYL9qiRcdi4Dvz+8s3JUgNR2qvbgZkXcwPEEEk=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.4/go.mod h1:Wjn5O9eS7uSi7vlPKt/v0MLTncANn9EMmoDvnzJli6o=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.43/go.mod h1:auo+PiyLl0n1l8A0e8RIeR8tOzYPfZZH/JNlrJ8igTQ=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.8 h1:RnLB7p6aaFMRfyQkD6ckxR7myCC9SABIqSz4czYUUbU=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.8/go.mod h1:XH7dQJd+56wEbP1I4e4Duo+QhSMxNArE8VP7NuUOTeM=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.9 h1:cy8ahBJuhtM8GTTSyOkfy6WVPV1IE+SS5/wfXUYuulw=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.9/go.mod h1:CZBXGLaJnEZI6EVNcPd7a6B5IC5cA/GkRWtu9fp3S6Y=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.37/go.mod h1:Qe+2KtKml+FEsQF/DHmDV+xjtche/hwoF75EG4UlHW8=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.8 h1:jzApk2f58L9yW9q1GEab3BMMFWUkkiZhyrRUtbwUbKU=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.8/go.mod h1:WqO+FftfO3tGePUtQxPXM6iODVfqMwsVMgTbG/ZXIdQ=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.9 h1:A4SYk07ef04+vxZToz9LWvAXl9LW0NClpPpMsi31cz0=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.9/go.mod h1:5jJcHuwDagxN+ErjQ3PU3ocf6Ylc/p9x+BLO/+X4iXw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.2.4/go.mod h1:ZcBrrI3zBKlhGFNYWvju0I3TR93I7YIgAfy82Fh4lcQ=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0 h1:hT8rVHwugYE2lEfdFE0QWVo81lF7jMrYJVDWI+f+VxU=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.0/go.mod h1:8tu/lYfQfFe6IGnaOdrpVgEL2IrrDOf6/m9RQum4NkY=
@@ -65,8 +65,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.11.10/go.mod h1:g
 github.com/aws/aws-sdk-go-v2/service/sso v1.4.2/go.mod h1:NBvT9R1MEF+Ud6ApJKM0G+IkPchKS7p7c2YPKwHmBOk=
 github.com/aws/aws-sdk-go-v2/service/sso v1.20.10 h1:ItKVmFwbyb/ZnCWf+nu3XBVmUirpO9eGEQd7urnBA0s=
 github.com/aws/aws-sdk-go-v2/service/sso v1.20.10/go.mod h1:5XKooCTi9VB/xZmJDvh7uZ+v3uQ7QdX6diOyhvPA+/w=
-github.com/aws/aws-sdk-go-v2/service/ssooidc v1.24.4 h1:QMSCYDg3Iyls0KZc/dk3JtS2c1lFfqbmYO10qBPPkJk=
-github.com/aws/aws-sdk-go-v2/service/ssooidc v1.24.4/go.mod h1:MZ/PVYU/mRbmSF6WK3ybCYHjA2mig8utVokDEVLDgE0=
+github.com/aws/aws-sdk-go-v2/service/ssooidc v1.24.5 h1:iXjh3uaH3vsVcnyZX7MqCoCfcyxIrVE9iOQruRaWPrQ=
+github.com/aws/aws-sdk-go-v2/service/ssooidc v1.24.5/go.mod h1:5ZXesEuy/QcO0WUnt+4sDkxhdXRHTu2yG0uCSH8B6os=
 github.com/aws/aws-sdk-go-v2/service/sts v1.7.2/go.mod h1:8EzeIqfWt2wWT4rJVu3f21TfrhJ8AEMzVybRNSb/b4g=
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.11 h1:HYS0csS7UJxdYRoG+bGgUYrSwVnV3/ece/wHm90TApM=
 github.com/aws/aws-sdk-go-v2/service/sts v1.28.11/go.mod h1:QXnthRM35zI92048MMwfFChjFmoufTdhtHmouwNfhhU=

--- a/internal/awsconfig/config.go
+++ b/internal/awsconfig/config.go
@@ -77,7 +77,7 @@ func UpdateAwsConfig(s *sso.Settings, action url.Action, cfile string, diff, for
 	}
 
 	oldConfig := AwsConfigFile(cfile)
-	_, err = f.UpdateConfig(diff, force, oldConfig)
+	_, _, err = f.UpdateConfig(diff, force, oldConfig)
 	return err
 }
 

--- a/internal/awsconfig/config.go
+++ b/internal/awsconfig/config.go
@@ -55,7 +55,7 @@ func PrintAwsConfig(s *sso.Settings, action url.Action) error {
 		return err
 	}
 
-	f, err := utils.NewFileEdit(CONFIG_TEMPLATE, profiles)
+	f, err := utils.NewFileEdit(CONFIG_TEMPLATE, s.DefaultSSO, profiles)
 	if err != nil {
 		return err
 	}
@@ -71,13 +71,14 @@ func UpdateAwsConfig(s *sso.Settings, action url.Action, cfile string, diff, for
 		return err
 	}
 
-	f, err := utils.NewFileEdit(CONFIG_TEMPLATE, profiles)
+	f, err := utils.NewFileEdit(CONFIG_TEMPLATE, s.DefaultSSO, profiles)
 	if err != nil {
 		return err
 	}
 
 	oldConfig := AwsConfigFile(cfile)
-	return f.UpdateConfig(diff, force, oldConfig)
+	_, err = f.UpdateConfig(diff, force, oldConfig)
+	return err
 }
 
 // getProfileMap returns our validated sso.ProfileMap

--- a/internal/helper/aws-sso.fish
+++ b/internal/helper/aws-sso.fish
@@ -2,6 +2,7 @@ function __complete_aws-sso
     set -lx COMP_LINE (commandline -cp)
     test -z (commandline -ct)
     and set COMP_LINE "$COMP_LINE "
+    export __NO_ESCAPE_COLONS=1
     {{ .Executable }}
 end
 complete -f -c aws-sso -a "(__complete_aws-sso)"

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -95,6 +95,8 @@ type SourceHelper struct {
 	output io.Writer
 }
 
+// NewSourceHelper returns a new SourceHelper and takes a function
+// to get the current executable path and an io.Writer to write the output to
 func NewSourceHelper(getExe func() (string, error), output io.Writer) *SourceHelper {
 	return &SourceHelper{
 		getExe: os.Executable,
@@ -117,6 +119,8 @@ func (h SourceHelper) Generate(shell string) error {
 	return printConfig(c, execPath, h.output)
 }
 
+var forceIt bool = false // used just for testing
+
 // InstallHelper installs any helper code into our shell startup script(s)
 func InstallHelper(shell string, path string) error {
 	c, defaultPath, err := getScript(shell)
@@ -125,9 +129,9 @@ func InstallHelper(shell string, path string) error {
 	}
 
 	if path == "" {
-		err = installConfigFile(defaultPath, c)
+		err = installConfigFile(defaultPath, c, forceIt)
 	} else {
-		err = installConfigFile(path, c)
+		err = installConfigFile(path, c, forceIt)
 	}
 
 	return err
@@ -135,37 +139,46 @@ func InstallHelper(shell string, path string) error {
 
 // UninstallHelper removes any helper code from our shell startup script(s)
 func UninstallHelper(shell string, path string) error {
-	c, defaultPath, err := getScript(shell)
+	_, defaultPath, err := getScript(shell)
 	if err != nil {
 		return err
 	}
 
 	if path == "" {
-		err = uninstallConfigFile(defaultPath, c)
+		err = uninstallConfigFile(defaultPath)
 	} else {
-		err = uninstallConfigFile(path, c)
+		err = uninstallConfigFile(path)
 	}
 	return err
 }
 
-func printConfig(contents []byte, execPath string, output io.Writer) error {
+// printConfig writes the given template to the output
+// It will replace any variables in the file with the given args
+func printConfig(template []byte, execPath string, output io.Writer) error {
 	var err error
-	var source []byte
+	var fileContents []byte
 
 	args := map[string]string{
 		"Executable": execPath,
 	}
 
-	if source, err = utils.GenerateSource(string(contents), args); err != nil {
+	// generate the source with the given args using the template
+	if fileContents, err = utils.GenerateSource(string(template), args); err != nil {
 		return err
 	}
+	if len(fileContents) == 0 {
+		return fmt.Errorf("no data generated")
+	}
 
-	_, err = io.Copy(output, bytes.NewReader(source))
+	len, err := io.Copy(output, bytes.NewReader(fileContents))
+	if len == 0 {
+		return fmt.Errorf("no data written to output")
+	}
 	return err
 }
 
 // installConfigFile adds our blob to the given file
-func installConfigFile(path string, contents []byte) error {
+func installConfigFile(path string, contents []byte, force bool) error {
 	var err error
 	var exec string
 	var fe *utils.FileEdit
@@ -182,7 +195,7 @@ func installConfigFile(path string, contents []byte) error {
 		return err
 	}
 
-	_, err = fe.UpdateConfig(false, false, path)
+	_, _, err = fe.UpdateConfig(false, force, path)
 	if err != nil {
 		return err
 	}
@@ -191,7 +204,7 @@ func installConfigFile(path string, contents []byte) error {
 }
 
 // uninstallConfigFile removes our blob from the given file
-func uninstallConfigFile(path string, contents []byte) error {
+func uninstallConfigFile(path string) error {
 	var err error
 	var fe *utils.FileEdit
 
@@ -199,7 +212,7 @@ func uninstallConfigFile(path string, contents []byte) error {
 		return nil
 	}
 
-	_, err = fe.UpdateConfig(false, false, path)
+	_, _, err = fe.UpdateConfig(false, false, path)
 	if err != nil {
 		log.Warnf("unable to remove config: %s", err.Error())
 	}

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -178,11 +178,12 @@ func installConfigFile(path string, contents []byte) error {
 		"Executable": exec,
 	}
 
-	if fe, err = utils.NewFileEdit(string(contents), args); err != nil {
+	if fe, err = utils.NewFileEdit(string(contents), "", args); err != nil {
 		return err
 	}
 
-	if err = fe.UpdateConfig(false, false, path); err != nil {
+	_, err = fe.UpdateConfig(false, false, path)
+	if err != nil {
 		return err
 	}
 
@@ -194,11 +195,12 @@ func uninstallConfigFile(path string, contents []byte) error {
 	var err error
 	var fe *utils.FileEdit
 
-	if fe, err = utils.NewFileEdit("", ""); err != nil {
+	if fe, err = utils.NewFileEdit("", "", ""); err != nil {
 		return nil
 	}
 
-	if err = fe.UpdateConfig(false, false, path); err != nil {
+	_, err = fe.UpdateConfig(false, false, path)
+	if err != nil {
 		log.Warnf("unable to remove config: %s", err.Error())
 	}
 

--- a/internal/helper/helper_test.go
+++ b/internal/helper/helper_test.go
@@ -3,9 +3,13 @@ package helper
 import (
 	"bytes"
 	"errors"
+	"io"
+	"os"
+	"path"
 	"testing"
 	"unicode"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,6 +40,7 @@ function __complete_aws-sso
     set -lx COMP_LINE (commandline -cp)
     test -z (commandline -ct)
     and set COMP_LINE "$COMP_LINE "
+    export __NO_ESCAPE_COLONS=1
     /bin/aws-sso-cli
 end
 complete -f -c aws-sso -a "(__complete_aws-sso)"
@@ -67,4 +72,87 @@ complete -f -c aws-sso -a "(__complete_aws-sso)"
 			require.Contains(t, output.String(), string(bytes.TrimLeftFunc(tc.expectedOutput, unicode.IsSpace)))
 		})
 	}
+}
+
+func TestConfigFiles(t *testing.T) {
+	t.Parallel()
+	files := ConfigFiles()
+	require.Len(t, files, 3)
+}
+
+func TestNewSourceHelper(t *testing.T) {
+	t.Parallel()
+	f := func() (string, error) {
+		return "", nil
+	}
+	h := NewSourceHelper(f, os.Stdout)
+	assert.NotNil(t, h)
+}
+
+func TestGetFishScript(t *testing.T) {
+	t.Parallel()
+	f := getFishScript()
+	assert.Contains(t, f, path.Join("fish", "completions", "aws-sso.fish"))
+}
+
+func TestDetectShellBash(t *testing.T) {
+	t.Parallel()
+	shell, err := detectShell()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, shell)
+}
+
+func TestGenerate(t *testing.T) {
+	t.Parallel()
+	buf := bytes.Buffer{}
+	_ = io.Writer(&buf)
+
+	sh := &SourceHelper{
+		getExe: func() (string, error) {
+			return "/usr/local/bin/aws-sso", nil
+		},
+		output: &buf,
+	}
+	err := sh.Generate("bash")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, buf.String())
+}
+func TestPrintConfig(t *testing.T) {
+	t.Parallel()
+	c, p, err := getScript("bash")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, c)
+	assert.NotEmpty(t, p)
+	assert.Contains(t, string(c), "{{ .Executable }}") // this is a template
+
+	buf := bytes.Buffer{}
+	_ = io.Writer(&buf)
+	err = printConfig(c, "/usr/local/bin/aws-sso", &buf)
+	assert.NoError(t, err)
+	output := buf.String()
+	assert.NotContains(t, output, "{{ .Executable }}")
+	assert.Contains(t, output, "/usr/local/bin/aws-sso")
+
+	buf.Reset()
+	err = printConfig([]byte{}, "", &buf)
+	assert.Error(t, err)
+}
+
+func TestInstallHelper(t *testing.T) {
+	t.Parallel()
+	err := UninstallHelper("foobar", "")
+	assert.Error(t, err)
+
+	forceIt = true
+	defer func() { forceIt = false }()
+
+	tempFile, err := os.CreateTemp("", "")
+	assert.NoError(t, err)
+	defer os.Remove(tempFile.Name())
+
+	err = InstallHelper("bash", tempFile.Name())
+	assert.NoError(t, err)
+
+	err = UninstallHelper("bash", tempFile.Name())
+	assert.NoError(t, err)
 }

--- a/internal/predictor/predictor.go
+++ b/internal/predictor/predictor.go
@@ -171,7 +171,12 @@ func (p *Predictor) ProfileComplete() complete.Predictor {
 	// The `:` character is considered a word delimiter by bash complete
 	// so we need to escape them
 	for _, x := range p.profiles {
-		profiles = append(profiles, strings.ReplaceAll(x, ":", "\\:"))
+		if os.Getenv("__NO_ESCAPE_COLONS") == "" {
+			profiles = append(profiles, strings.ReplaceAll(x, ":", "\\:"))
+		} else {
+			// fish doesn't treat colons as word delimiters
+			profiles = append(profiles, x)
+		}
 	}
 
 	return complete.PredictSet(profiles...)

--- a/internal/predictor/predictor_test.go
+++ b/internal/predictor/predictor_test.go
@@ -36,6 +36,17 @@ func TestNewPredictor(t *testing.T) {
 	assert.NotEmpty(t, p.arns)
 	assert.NotEmpty(t, p.profiles)
 	assert.NotEmpty(t, p.roles)
+
+	p = NewPredictor("/dev/null", "./testdata/settings.yaml")
+	assert.NotNil(t, p)
+	assert.Equal(t, p.configFile, "./testdata/settings.yaml")
+	assert.Empty(t, p.accountids)
+	assert.Empty(t, p.arns)
+	assert.Empty(t, p.profiles)
+	assert.Empty(t, p.roles)
+
+	p = NewPredictor("/dev/null", "/dev/null")
+	assert.NotNil(t, p)
 }
 
 func TestCompletions(t *testing.T) {


### PR DESCRIPTION
Deal with users with multiple SSOConfig's and who use `config-profiles` command.  We no longer will replace the previous config block in the ~/.aws/config file.