### PR TITLE
aws-sso-profile with no args should return usage.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bugs
 
  * Disable linker warnings on macOS with -race flag
+ * `aws-sso-profile` returns usage when run without args #836
 
 ## [v1.15.1] - 2024-04-30
 

--- a/internal/helper/aws-sso.fish
+++ b/internal/helper/aws-sso.fish
@@ -13,6 +13,12 @@ function aws-sso-profile
       echo "Unable to assume a role while AWS_PROFILE is set"
       return 1
   end
+
+  if [ -z "$argv[1]" ]
+      echo "Usage: aws-sso-profile <profile>"
+      return 1
+  end
+
   eval $({{ .Executable }} $_args eval -p $argv[1])
   if [ "$AWS_SSO_PROFILE" != "$1" ]
       return 1

--- a/internal/helper/bash_profile.sh
+++ b/internal/helper/bash_profile.sh
@@ -15,6 +15,12 @@ aws-sso-profile() {
         echo "Unable to assume a role while AWS_PROFILE is set"
         return 1
     fi
+
+    if [ -z "$1" ]; then
+        echo "Usage: aws-sso-profile <profile>"
+        return 1
+    fi
+
     eval $({{ .Executable }} $_args eval -p "$1")
     if [ "$AWS_SSO_PROFILE" != "$1" ]; then
         return 1

--- a/internal/helper/zshrc.sh
+++ b/internal/helper/zshrc.sh
@@ -20,6 +20,12 @@ aws-sso-profile() {
         echo "Unable to assume a role while AWS_PROFILE is set"
         return 1
     fi
+
+    if [ -z "$1" ]; then
+        echo "Usage: aws-sso-profile <profile>"
+        return 1
+    fi
+
     eval $({{ .Executable }} ${=_args} eval -p "$1")
     if [ "$AWS_SSO_PROFILE" != "$1" ]; then
         return 1


### PR DESCRIPTION
Fixes: #836