### PR TITLE
Don't store broken roles in the cache.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs
 
  * No longer ignore the `--threads` CLI option
+ * Warn users of invalid AWS Accounts/Roles defined in the config.yaml #962
 
 ### New Features
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,7 +51,6 @@ func ConfigDir(expand bool) string {
 func ConfigFile(expand bool) string {
 	var path string
 	fi, err := os.Stat(utils.GetHomePath(OLD_CONFIG_DIR))
-	fmt.Printf("fi: %v, err: %v\n", fi, err)
 	if err == nil && fi.IsDir() {
 		path = fmt.Sprintf(CONFIG_FILE, OLD_CONFIG_DIR)
 	} else {

--- a/sso/cache_test.go
+++ b/sso/cache_test.go
@@ -580,6 +580,28 @@ func (suite *CacheTestSuite) TestPruneSSO() {
 	assert.NotContains(t, c.SSO, "Invalid")
 }
 
+func (suite *CacheTestSuite) TestAddConfigRoles() {
+	t := suite.T()
+
+	config := &SSOConfig{
+		Accounts: map[string]*SSOAccount{
+			"123456789012": {
+				Roles: map[string]*SSORole{
+					"Foo": {},
+					"Bar": {},
+				},
+			},
+		},
+	}
+
+	roles := &Roles{
+		Accounts: map[int64]*AWSAccount{},
+	}
+
+	err := suite.cache.addConfigRoles(roles, config)
+	assert.NoError(t, err)
+}
+
 func TestOpenCacheFailure(t *testing.T) {
 	s := &Settings{}
 	c, err := OpenCache("/dev/null", s)


### PR DESCRIPTION
If you had a role defined in config.yaml we would present the role in the `list` command, even if it didn't exist.  Now we generate a warning and filter them out.

Fixes: #962