### PR TITLE
No auto-config check except login/cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
  * Warnings about invalid accounts/roles in config.yaml are now Debug messages #980
  * Default ProfileFormat is now the `Friendly` format #992
  * `config`, `config-profiles` and `completions` are now sub-commands of `setup` #975
+ * Only the and `cache` command will auto-update the contents of `~/.aws/config` #974
+ * `tags` command no longer supports the `--force-update` option
 
 ### New Features
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,8 +10,6 @@
  * `--url-action`, `-u` -- How to handle URLs for your SSO provider
  * `--sso <name>`, `-S` -- Specify non-default AWS SSO instance to use (`$AWS_SSO`)
  * `--sts-refresh` -- Force refresh of STS Token Credentials
- * `--no-config-check` -- Disable automatic updating of `~/.aws/config`
- * `--threads <int>` -- Number of threads to use with AWS (default: 5)
 
 ## Commands
 
@@ -23,6 +21,11 @@ hours, but you can force this data to be refreshed immediately.
 
 Cache data is also automatically updated anytime the `config.yaml` file is
 modified.
+
+Flags:
+
+ * `--no-config-check` -- Disable automatic updating of `~/.aws/config`
+ * `--threads <int>` -- Number of threads to use with AWS (default: 5)
 
 ---
 
@@ -244,6 +247,11 @@ case-sensitive manner.
 
 Login via AWS IAM Identity Center (AWS SSO) and retrieve a security token
 used to fetch IAM Role credentials.
+
+Flags:
+
+ * `--no-config-check` -- Disable automatic updating of `~/.aws/config`
+ * `--threads <int>` -- Number of threads to use with AWS (default: 5)
 
 ---
 


### PR DESCRIPTION
No longer check if we should update the `~/.aws/config` file except for the login and cache commands.

tags command no longer supports --force-update

Fixes: #974