### PR TITLE
Continue work on login command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@
  * No longer show help for sub-commands by default 
  * Warnings about invalid accounts/roles in config.yaml are now Debug messages #980
  * Default ProfileFormat is now the `Friendly` format #992
- * `config`, `config-profiles` and `completions` are now sub-commands of `setup` #975
+ * Refactor commands under `setup`: #975
+   * `config` is now `setup wizard` and `ConfigProfilesUrlAction` config option is no longer used
+   * `config-profiles` is now `setup profiles`
+   * `completions` is now `setup completions`
+ * Remove `--open` option from `process` command #291
  * Only the and `cache` command will auto-update the contents of `~/.aws/config` #974
  * `tags` command no longer supports the `--force-update` option
  * Change default log level from `warn` to `info`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
    * `config` is now `setup wizard` and `ConfigProfilesUrlAction` config option is no longer used
    * `config-profiles` is now `setup profiles`
    * `completions` is now `setup completions`
+   * Make `--url-action` and `--sts-refresh` command specific options
+   * Refactor `ecs ssl` commands to be just flags.
  * Remove `--open` option from `process` command #291
  * Only the and `cache` command will auto-update the contents of `~/.aws/config` #974
  * `tags` command no longer supports the `--force-update` option

--- a/cmd/aws-sso/cache_cmd.go
+++ b/cmd/aws-sso/cache_cmd.go
@@ -57,8 +57,7 @@ func (cc *CacheCmd) Run(ctx *RunContext) error {
 		// should we update our config??
 		if !ctx.Cli.Cache.NoConfigCheck && ctx.Settings.AutoConfigCheck {
 			if ctx.Settings.ConfigProfilesUrlAction != url.ConfigProfilesUndef {
-				action, _ := url.NewAction(string(ctx.Settings.ConfigProfilesUrlAction))
-				err := awsconfig.UpdateAwsConfig(ctx.Settings, action, "", true, false)
+				err := awsconfig.UpdateAwsConfig(ctx.Settings, "", true, false)
 				if err != nil {
 					log.Errorf("Unable to auto-update aws config file: %s", err.Error())
 				}

--- a/cmd/aws-sso/credentials_cmd.go
+++ b/cmd/aws-sso/credentials_cmd.go
@@ -23,7 +23,7 @@ func (cc *CredentialsCmd) Run(ctx *RunContext) error {
 			return err
 		}
 
-		pCreds := GetRoleCredentials(ctx, AwsSSO, roleFlat.AccountId, roleFlat.RoleName)
+		pCreds := GetRoleCredentials(ctx, AwsSSO, ctx.Cli.Console.STSRefresh, roleFlat.AccountId, roleFlat.RoleName)
 
 		creds = append(creds, awsconfig.ProfileCredentials{
 			Profile:         profile,

--- a/cmd/aws-sso/ecs_client_cmd.go
+++ b/cmd/aws-sso/ecs_client_cmd.go
@@ -33,10 +33,11 @@ import (
 
 type EcsLoadCmd struct {
 	// AWS Params
-	Arn       string `kong:"short='a',help='ARN of role to load',env='AWS_SSO_ROLE_ARN',predictor='arn'"`
-	AccountId int64  `kong:"name='account',short='A',help='AWS AccountID of role to load',env='AWS_SSO_ACCOUNT_ID',predictor='accountId',xor='account'"`
-	Role      string `kong:"short='R',help='Name of AWS Role to load',env='AWS_SSO_ROLE_NAME',predictor='role',xor='role'"`
-	Profile   string `kong:"short='p',help='Name of AWS Profile to load',predictor='profile',xor='account,role'"`
+	Arn        string `kong:"short='a',help='ARN of role to load',env='AWS_SSO_ROLE_ARN',predictor='arn'"`
+	AccountId  int64  `kong:"name='account',short='A',help='AWS AccountID of role to load',env='AWS_SSO_ACCOUNT_ID',predictor='accountId',xor='account'"`
+	Role       string `kong:"short='R',help='Name of AWS Role to load',env='AWS_SSO_ROLE_NAME',predictor='role',xor='role'"`
+	Profile    string `kong:"short='p',help='Name of AWS Profile to load',predictor='profile',xor='account,role'"`
+	STSRefresh bool   `kong:"help='Force refresh of STS Token Credentials'"`
 
 	// Other params
 	Server  string `kong:"help='Endpoint of aws-sso ECS Server',env='AWS_SSO_ECS_SERVER',default='localhost:4144'"`
@@ -82,7 +83,7 @@ func (cc *EcsProfileCmd) Run(ctx *RunContext) error {
 func ecsLoadCmd(ctx *RunContext, accountId int64, role string) error {
 	c := newClient(ctx.Cli.Ecs.Load.Server, ctx)
 
-	creds := GetRoleCredentials(ctx, AwsSSO, accountId, role)
+	creds := GetRoleCredentials(ctx, AwsSSO, ctx.Cli.Ecs.Load.STSRefresh, accountId, role)
 
 	cache := ctx.Settings.Cache.GetSSO()
 	rFlat, err := cache.Roles.GetRole(accountId, role)

--- a/cmd/aws-sso/exec_cmd.go
+++ b/cmd/aws-sso/exec_cmd.go
@@ -31,11 +31,12 @@ import (
 
 type ExecCmd struct {
 	// AWS Params
-	Arn       string `kong:"short='a',help='ARN of role to assume',env='AWS_SSO_ROLE_ARN',predictor='arn'"`
-	AccountId int64  `kong:"name='account',short='A',help='AWS AccountID of role to assume',env='AWS_SSO_ACCOUNT_ID',predictor='accountId'"`
-	Role      string `kong:"short='R',help='Name of AWS Role to assume',env='AWS_SSO_ROLE_NAME',predictor='role'"`
-	Profile   string `kong:"short='p',help='Name of AWS Profile to assume',predictor='profile'"`
-	NoRegion  bool   `kong:"short='n',help='Do not set AWS_DEFAULT_REGION from config.yaml'"`
+	Arn        string `kong:"short='a',help='ARN of role to assume',env='AWS_SSO_ROLE_ARN',predictor='arn'"`
+	AccountId  int64  `kong:"name='account',short='A',help='AWS AccountID of role to assume',env='AWS_SSO_ACCOUNT_ID',predictor='accountId'"`
+	Role       string `kong:"short='R',help='Name of AWS Role to assume',env='AWS_SSO_ROLE_NAME',predictor='role'"`
+	Profile    string `kong:"short='p',help='Name of AWS Profile to assume',predictor='profile'"`
+	NoRegion   bool   `kong:"short='n',help='Do not set AWS_DEFAULT_REGION from config.yaml'"`
+	STSRefresh bool   `kong:"help='Force refresh of STS Token Credentials'"`
 
 	// Exec Params
 	Cmd  string   `kong:"arg,optional,name='command',help='Command to execute',env='SHELL'"`
@@ -93,7 +94,7 @@ func execCmd(ctx *RunContext, accountid int64, role string) error {
 
 func execShellEnvs(ctx *RunContext, accountid int64, role, region string) map[string]string {
 	var err error
-	credsPtr := GetRoleCredentials(ctx, AwsSSO, accountid, role)
+	credsPtr := GetRoleCredentials(ctx, AwsSSO, ctx.Cli.Exec.STSRefresh, accountid, role)
 	creds := *credsPtr
 
 	ssoName, _ := ctx.Settings.GetSelectedSSOName(ctx.Cli.SSO)

--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -264,6 +264,10 @@ func parseArgs(cli *CLI) (*kong.Context, sso.OverrideSettings) {
 			Title: "Commands requiring login:",
 			Key:   "login-required",
 		},
+		{
+			Title: "Add SSL Certificate/Key:",
+			Key:   "add-ssl",
+		},
 	}
 
 	parser := kong.Must(

--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -84,7 +84,6 @@ var DEFAULT_CONFIG map[string]interface{} = map[string]interface{}{
 	"PromptColors.SuggestionTextColor":          "White",
 	"AutoConfigCheck":                           false,
 	"CacheRefresh":                              168, // 7 days in hours
-	"ConfigProfilesUrlAction":                   "open",
 	"ConsoleDuration":                           60,
 	"DefaultRegion":                             "us-east-1",
 	"DefaultSSO":                                "Default",
@@ -113,7 +112,6 @@ type CLI struct {
 
 	// Commands
 	Cache        CacheCmd        `kong:"cmd,help='Force reload of cached AWS SSO role info and config.yaml'"`
-	Setup        SetupCmd        `kong:"cmd,help='Setup Wizard, Completions, etc'"`
 	Console      ConsoleCmd      `kong:"cmd,help='Open AWS Console using specificed AWS role/profile'"`
 	Credentials  CredentialsCmd  `kong:"cmd,help='Generate static AWS credentials for use with AWS CLI'"`
 	Default      DefaultCmd      `kong:"cmd,hidden,default='1'"` // list command without args
@@ -124,7 +122,8 @@ type CLI struct {
 	Login        LoginCmd        `kong:"cmd,help='Login to an AWS Identity Center instance'"`
 	Logout       LogoutCmd       `kong:"cmd,help='Logout from an AWS Identity Center instance and invalidate all credentials'"`
 	ListSSORoles ListSSORolesCmd `kong:"cmd,hidden,help='List AWS SSO Roles (debugging)'"`
-	Process      ProcessCmd      `kong:"cmd,help='Generate JSON for credential_process in ~/.aws/config'"`
+	Process      ProcessCmd      `kong:"cmd,help='Generate JSON for AWS SDK credential_process command'"`
+	Setup        SetupCmd        `kong:"cmd,help='Setup Wizard, Completions, Profiles, etc'"`
 	Tags         TagsCmd         `kong:"cmd,help='List tags'"`
 	Time         TimeCmd         `kong:"cmd,help='Print how much time before current STS Token expires'"`
 	Version      VersionCmd      `kong:"cmd,help='Print version and exit'"`
@@ -162,7 +161,7 @@ func main() {
 			log.Fatalf("%s", err.Error())
 		}
 		return
-	case "ecs server":
+	case "ecs server", "ecs list", "ecs unload", "ecs profile":
 		// side-step the rest of the setup...
 		if err = ctx.Run(&runCtx); err != nil {
 			log.Fatalf("%s", err.Error())
@@ -192,7 +191,7 @@ func main() {
 	}
 
 	switch ctx.Command() {
-	case "list", "login", "ecs list", "ecs unload", "ecs profile":
+	case "list", "login", "tags":
 		// Initialize our AwsSSO variable & SecureStore
 		c := &runCtx
 		s, err := c.Settings.GetSelectedSSO(c.Cli.SSO)

--- a/cmd/aws-sso/process_cmd.go
+++ b/cmd/aws-sso/process_cmd.go
@@ -29,10 +29,11 @@ import (
 
 type ProcessCmd struct {
 	// AWS Params
-	Arn       string `kong:"short='a',help='ARN of role to assume',xor='arn-1',xor='arn-2',predictor='arn'"`
-	AccountId int64  `kong:"name='account',short='A',help='AWS AccountID of role to assume',xor='arn-1',predictor='accountId'"`
-	Role      string `kong:"short='R',help='Name of AWS Role to assume',xor='arn-2',predictor='role'"`
-	Profile   string `kong:"short='p',help='Name of AWS Profile to assume',xor='arn-1',xor='arn-2',predictor='profile'"`
+	Arn        string `kong:"short='a',help='ARN of role to assume',xor='arn-1',xor='arn-2',predictor='arn'"`
+	AccountId  int64  `kong:"name='account',short='A',help='AWS AccountID of role to assume',xor='arn-1',predictor='accountId'"`
+	Role       string `kong:"short='R',help='Name of AWS Role to assume',xor='arn-2',predictor='role'"`
+	Profile    string `kong:"short='p',help='Name of AWS Profile to assume',xor='arn-1',xor='arn-2',predictor='profile'"`
+	STSRefresh bool   `kong:"help='Force refresh of STS Token Credentials'"`
 }
 
 func (cc *ProcessCmd) Run(ctx *RunContext) error {
@@ -93,7 +94,7 @@ func (cpo *CredentialProcessOutput) Output() (string, error) {
 }
 
 func credentialProcess(ctx *RunContext, accountId int64, role string) error {
-	creds := GetRoleCredentials(ctx, AwsSSO, accountId, role)
+	creds := GetRoleCredentials(ctx, AwsSSO, ctx.Cli.Process.STSRefresh, accountId, role)
 
 	cpo := NewCredentialsProcessOutput(creds)
 	out, err := cpo.Output()

--- a/cmd/aws-sso/process_cmd.go
+++ b/cmd/aws-sso/process_cmd.go
@@ -38,11 +38,6 @@ type ProcessCmd struct {
 func (cc *ProcessCmd) Run(ctx *RunContext) error {
 	var err error
 
-	switch ctx.Cli.UrlAction {
-	case "print", "printurl":
-		return fmt.Errorf("unsupported --url-action=print|printurl option")
-	}
-
 	role := ctx.Cli.Process.Role
 	account := ctx.Cli.Process.AccountId
 
@@ -63,7 +58,7 @@ func (cc *ProcessCmd) Run(ctx *RunContext) error {
 	}
 
 	if role == "" || account == 0 {
-		return fmt.Errorf("Please specify --arn or --account and --role")
+		return fmt.Errorf("please specify --arn or --account and --role")
 	}
 
 	return credentialProcess(ctx, account, role)

--- a/cmd/aws-sso/setup_profiles_cmd.go
+++ b/cmd/aws-sso/setup_profiles_cmd.go
@@ -19,10 +19,7 @@ package main
  */
 
 import (
-	"fmt"
-
 	"github.com/synfinatic/aws-sso-cli/internal/awsconfig"
-	"github.com/synfinatic/aws-sso-cli/internal/url"
 )
 
 const (
@@ -37,28 +34,12 @@ credential_process = {{ $profile.BinaryPath }} -u {{ $profile.Open }} -S "{{ $pr
 type SetupProfilesCmd struct {
 	Diff      bool   `kong:"help='Print a diff of changes to the config file instead of modifying it',xor='action'"`
 	Force     bool   `kong:"help='Write a new config file without prompting'"`
-	Open      string `kong:"help='Specify how to open URLs: [clip|exec|open|granted-containers|open-url-in-container]'"`
 	Print     bool   `kong:"help='Print profile entries instead of modifying config file',xor='action'"`
 	AwsConfig string `kong:"help='Path to AWS config file',env='AWS_CONFIG_FILE',default='~/.aws/config'"`
 }
 
 func (cc *SetupProfilesCmd) Run(ctx *RunContext) error {
 	var err error
-	var action url.ConfigProfilesAction
-
-	if ctx.Cli.Setup.Profiles.Open != "" {
-		if action, err = url.NewConfigProfilesAction(ctx.Cli.Setup.Profiles.Open); err != nil {
-			return err
-		}
-	} else {
-		action = ctx.Settings.ConfigProfilesUrlAction
-	}
-
-	if action == url.ConfigProfilesUndef {
-		return fmt.Errorf("%s", "please specify --open [clip|exec|open|granted-containers|open-url-in-container]")
-	}
-
-	urlAction, _ := url.NewAction(string(action))
 
 	// always refresh our cache
 	c := &CacheCmd{}
@@ -67,8 +48,8 @@ func (cc *SetupProfilesCmd) Run(ctx *RunContext) error {
 	}
 
 	if ctx.Cli.Setup.Profiles.Print {
-		return awsconfig.PrintAwsConfig(ctx.Settings, urlAction)
+		return awsconfig.PrintAwsConfig(ctx.Settings)
 	}
-	return awsconfig.UpdateAwsConfig(ctx.Settings, urlAction, ctx.Cli.Setup.Profiles.AwsConfig,
+	return awsconfig.UpdateAwsConfig(ctx.Settings, ctx.Cli.Setup.Profiles.AwsConfig,
 		ctx.Cli.Setup.Profiles.Diff, ctx.Cli.Setup.Profiles.Force)
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -295,7 +295,6 @@ for every role accessible via AWS SSO CLI.
 Flags:
 
  * `--diff` -- Print a diff of changes to the config file instead of modifying it
- * `--open` -- Specify how to open URls: [clip|exec|open|granted-containers|open-url-in-container]
  * `--print` -- Print profile entries instead of modifying config file
  * `--force` -- Write a new config file without prompting
  * `--aws-config` -- Override path to `~/.aws/config` file
@@ -317,18 +316,9 @@ _automatically refresh_.  This means, if you do not have a valid AWS SSO token,
 you will be prompted to authentiate via your SSO provider and subsequent
 requests to obtain new IAM STS credentials will automatically happen as needed.
 
-**Note:** Due to a limitation in the AWS tooling, `print` and `printurl` are not
-supported values for `--url-action`.  Hence, you must use `open` or `exec` to
-auto-open URLs in your browser (recommended) or `clip` to automatically copy
-URLs to your clipboard.  _No user prompting is possible._
-
 **Note:** You should run this command any time your list of AWS roles changes
 in order to update the `~/.aws/config` file or enable [AutoConfigCheck](
-config.md#autoconfigcheck) and [ConfigProfilesUrlAction](
-config.md#configprofilesurlaction).
-
-**Note:** If `ConfigProfilesUrlAction` is set, then `--open` is optional,
-otherwise it is required.
+config.md#autoconfigcheck).
 
 **Note:** It is important that you do _NOT_ remove the `# BEGIN_AWS_SSO_CLI` and
 `# END_AWS_SSO_CLI` lines from your config file!  These markers are used to track

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7,9 +7,7 @@
  * `--config <file>` -- Specify alternative config file (`$AWS_SSO_CONFIG`)
  * `--level <level>`, `-L` -- Change default log level: [error|warn|info|debug|trace]
  * `--lines` -- Print file number with logs
- * `--url-action`, `-u` -- How to handle URLs for your SSO provider
  * `--sso <name>`, `-S` -- Specify non-default AWS SSO instance to use (`$AWS_SSO`)
- * `--sts-refresh` -- Force refresh of STS Token Credentials
 
 ## Commands
 
@@ -48,6 +46,8 @@ Flags:
  * `--account <account>`, `-A` -- AWS AccountID of role to assume (`$AWS_SSO_ACCOUNT_ID`)
  * `--role <role>`, `-R` -- Name of AWS Role to assume (requires `--account`) (`$AWS_SSO_ROLE_NAME`)
  * `--profile <profile>`, `-p` -- Name of AWS Profile to assume
+ * `--url-action`, `-u` -- How to handle URLs for your SSO provider
+ * `--sts-refresh` -- Force refresh of STS Token Credentials
 
 The generated URL is good for 15 minutes after it is created.
 
@@ -81,6 +81,7 @@ Flags:
  * `--file <path>`, `-f` -- Specify the file to generate.  Default is to print to STDOUT ($AWS_SHARED_CREDENTIALS_FILE).
  * `--append`, `-a` -- Append to the file instead of overwriting it.
  * `--profile <profile>,...`, `-p` -- One or more profiles to include in the output.
+ * `--sts-refresh` -- Force refresh of STS Token Credentials
 
 **Note:** This command honors the same [$AWS_SHARED_CREDENTIALS_FILE](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html)
 that is supported by the AWS SDK to load credentials.  Since these credentials are temporary, it is
@@ -163,6 +164,7 @@ Flags:
  * `--role <role>`, `-R` -- Name of AWS Role to assume (`$AWS_SSO_ROLE_NAME`)
  * `--profile <profile>`, `-p` -- Name of AWS Profile to assume
  * `--no-region` -- Do not set the [AWS_DEFAULT_REGION](config.md#DefaultRegion) from config.yaml
+ * `--sts-refresh` -- Force refresh of STS Token Credentials
 
 Arguments: `[<command>] [<args> ...]`
 
@@ -192,6 +194,7 @@ Flags:
  * `--account <account>`, `-A` -- AWS AccountID of role to assume
  * `--role <role>`, `-R` -- Name of AWS Role to assume (requires `--account`)
  * `--profile <profile>`, `-p` -- Name of AWS Profile to assume
+ * `--sts-refresh` -- Force refresh of STS Token Credentials
 
 Priority is given to:
 
@@ -251,6 +254,8 @@ used to fetch IAM Role credentials.
 Flags:
 
  * `--no-config-check` -- Disable automatic updating of `~/.aws/config`
+ * `--url-action`, `-u` -- How to handle URLs for your SSO provider
+ * `--sts-refresh` -- Force refresh of STS Token Credentials
  * `--threads <int>` -- Number of threads to use with AWS (default: 5)
 
 ---

--- a/docs/config.md
+++ b/docs/config.md
@@ -53,7 +53,6 @@ MaxBackoff: <integer>
 
 Browser: <path to web browser>
 UrlAction: [clip|exec|print|printurl|open|granted-containers|open-url-in-container]
-ConfigProfilesUrlAction: [clip|exec|open|granted-containers|open-url-in-container]
 ConfigProfilesBinaryPath: <path to aws-sso binary>
 UrlExecCommand:
     - <command>
@@ -357,27 +356,6 @@ https://docs.aws.amazon.com/singlesignon/latest/userguide/howtosessionduration.h
 
 ### AWS_PROFILE Integration
 
-#### ConfigProfilesUrlAction
-
-The `aws-sso config-profiles` command by default will use the same action
-to open URL's as defined in [UrlAction](#authurlaction--browser--urlaction--urlexeccommand),
-but you can override it via the `ConfigProfilesUrlAction`.
-
-If `UrlAction` is `print` or `printurl`, then this settings will default to `open`.
-
-Due to limitations with the AWS SDK, only the following options are valid:
-
- * `clip`
- * `exec`
- * `open`
- * `granted-containers`
- * `open-url-in-container`
-
-**Note:** This option is required if you also want to use [AutoConfigCheck](#autoconfigcheck).
-
-**Note:** This config option was previously known as `ConfigUrlAction` which
-has been deprecated.
-
 #### ConfigProfilesBinaryPath
 
 Override execution path for `aws-sso` when generating named AWS profiles via the
@@ -552,8 +530,6 @@ Specify which fields to display via the `list` command.  Valid options are:
 When set to `True`, when your AWS SSO roles are automatically refreshed (see
 [CacheRefresh](#cacherefresh)) `aws-sso` will also check to see if any changes
 are warranted in your `~/.aws/config`.
-
-**Note:** This option requires you to also set [ConfigProfilesUrlAction](#configprofilesurlaction).
 
 **Note:** This option can be disabled temporarily on the command line by passing
 the `--no-config-check` flag.

--- a/docs/ecs-commands.md
+++ b/docs/ecs-commands.md
@@ -79,7 +79,7 @@ Flags:
 
 ---
 
-### ecs ssl save
+### ecs ssl
 
  Configures the SSL Certificate and Private Key to enable SSL/TLS.  Saves the
  SSL certificate and private key to the SecureStore.
@@ -89,21 +89,10 @@ Flags:
 
  Flags:
 
+  * `--delete` -- Disables SSL and deletes both the SSL certificate and private key from the Secure Store
+  * `--print` -- Prints the SSL certificate
   * `--certificate` -- Path to SSL certificate file in PEM format
   * `--private-key` -- Path to SSL private key in PEM format
-
----
-
-### ecs ssl delete
-
-Delete the SSL certificate and private key from the Secure Store and disables
-SSL/TLS for the ECS Server.
-
----
-
-### ecs ssl print
-
-Prints the SSL public certificate stored in the SecureStore.
 
 ---
 

--- a/internal/awsconfig/config.go
+++ b/internal/awsconfig/config.go
@@ -22,7 +22,6 @@ import (
 	"os"
 
 	"github.com/synfinatic/aws-sso-cli/internal/sso"
-	"github.com/synfinatic/aws-sso-cli/internal/url"
 	"github.com/synfinatic/aws-sso-cli/internal/utils"
 )
 
@@ -30,7 +29,7 @@ const (
 	AWS_CONFIG_FILE = "~/.aws/config"
 	CONFIG_TEMPLATE = `{{range $sso, $struct := . }}{{ range $arn, $profile := $struct }}
 [profile {{ $profile.Profile }}]
-credential_process = {{ $profile.BinaryPath }} -u {{ $profile.Open }} -S "{{ $profile.Sso }}" process --arn {{ $profile.Arn }}
+credential_process = {{ $profile.BinaryPath }} -S "{{ $profile.Sso }}" process --arn {{ $profile.Arn }}
 {{ if len $profile.DefaultRegion }}region = {{ printf "%s\n" $profile.DefaultRegion }}{{ end -}}
 {{ range $key, $value := $profile.ConfigVariables }}{{ $key }} = {{ $value }}
 {{end}}{{end}}{{end}}`
@@ -49,8 +48,8 @@ func AwsConfigFile(cfile string) string {
 var stdout = os.Stdout
 
 // PrintAwsConfig just prints what our new AWS config file block would look like
-func PrintAwsConfig(s *sso.Settings, action url.Action) error {
-	profiles, err := getProfileMap(s, action)
+func PrintAwsConfig(s *sso.Settings) error {
+	profiles, err := getProfileMap(s)
 	if err != nil {
 		return err
 	}
@@ -65,8 +64,8 @@ func PrintAwsConfig(s *sso.Settings, action url.Action) error {
 
 // UpdateAwsConfig updates our AWS config file, optionally presenting a diff for
 // review or possibly making the change without prompting
-func UpdateAwsConfig(s *sso.Settings, action url.Action, cfile string, diff, force bool) error {
-	profiles, err := getProfileMap(s, action)
+func UpdateAwsConfig(s *sso.Settings, cfile string, diff, force bool) error {
+	profiles, err := getProfileMap(s)
 	if err != nil {
 		return err
 	}
@@ -82,8 +81,8 @@ func UpdateAwsConfig(s *sso.Settings, action url.Action, cfile string, diff, for
 }
 
 // getProfileMap returns our validated sso.ProfileMap
-func getProfileMap(s *sso.Settings, action url.Action) (*sso.ProfileMap, error) {
-	profiles, err := s.GetAllProfiles(action)
+func getProfileMap(s *sso.Settings) (*sso.ProfileMap, error) {
+	profiles, err := s.GetAllProfiles()
 	if err != nil {
 		return profiles, err
 	}

--- a/internal/awsconfig/config_test.go
+++ b/internal/awsconfig/config_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/synfinatic/aws-sso-cli/internal/sso"
-	"github.com/synfinatic/aws-sso-cli/internal/url"
 	"github.com/synfinatic/aws-sso-cli/internal/utils"
 )
 
@@ -68,7 +67,7 @@ func TestGetProfileMap(t *testing.T) {
 		},
 	}
 
-	profiles, err := getProfileMap(s, url.Open)
+	profiles, err := getProfileMap(s)
 	p := *profiles
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(p))
@@ -90,7 +89,7 @@ func TestGetProfileMap(t *testing.T) {
 			},
 		},
 	}
-	_, err = getProfileMap(s, url.Open)
+	_, err = getProfileMap(s)
 	assert.Error(t, err)
 }
 
@@ -126,7 +125,7 @@ func TestPrintAwsConfig(t *testing.T) {
 	fname := stdout.Name()
 	defer os.Remove(fname)
 
-	err = PrintAwsConfig(s, url.Open)
+	err = PrintAwsConfig(s)
 	assert.NoError(t, err)
 
 	_, err = stdout.Seek(0, 0)
@@ -137,7 +136,7 @@ func TestPrintAwsConfig(t *testing.T) {
 	assert.Error(t, err)
 	assert.Less(t, 300, len)
 	assert.Contains(t, string(buf), "[profile 000000012345:Bar]")
-	assert.Regexp(t, regexp.MustCompile(`credential_process = /[^ ]+/awsconfig.test -u open -S "Default" process --arn aws:arn:iam::12345:role/Bar`), string(buf))
+	assert.Regexp(t, regexp.MustCompile(`credential_process = /[^ ]+/awsconfig.test -S "Default" process --arn aws:arn:iam::12345:role/Bar`), string(buf))
 	assert.Regexp(t, regexp.MustCompile(`# BEGIN_AWS_SSO_CLI`), string(buf))
 	assert.Regexp(t, regexp.MustCompile(`# END_AWS_SSO_CLI`), string(buf))
 	stdout.Close()
@@ -159,7 +158,7 @@ func TestPrintAwsConfig(t *testing.T) {
 		},
 	}
 
-	err = PrintAwsConfig(s, url.Open)
+	err = PrintAwsConfig(s)
 	assert.Error(t, err)
 }
 
@@ -195,7 +194,7 @@ func TestUpdateAwsConfig(t *testing.T) {
 	defer os.Remove(fname)
 	cfile.Close()
 
-	err = UpdateAwsConfig(s, url.Open, fname, false, true)
+	err = UpdateAwsConfig(s, fname, false, true)
 	assert.NoError(t, err)
 
 	cfile, err = os.Open(fname)
@@ -206,7 +205,7 @@ func TestUpdateAwsConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Less(t, 300, len)
 	assert.Contains(t, string(buf), "[profile 000000012345:Bar]")
-	assert.Regexp(t, regexp.MustCompile(`credential_process = /[^ ]+/awsconfig.test -u open -S "Default" process --arn aws:arn:iam::12345:role/Bar`), string(buf))
+	assert.Regexp(t, regexp.MustCompile(`credential_process = /[^ ]+/awsconfig.test -S "Default" process --arn aws:arn:iam::12345:role/Bar`), string(buf))
 	assert.Regexp(t, regexp.MustCompile(`# BEGIN_AWS_SSO_CLI`), string(buf))
 	assert.Regexp(t, regexp.MustCompile(`# END_AWS_SSO_CLI`), string(buf))
 
@@ -227,6 +226,6 @@ func TestUpdateAwsConfig(t *testing.T) {
 		},
 	}
 
-	err = UpdateAwsConfig(s, url.Open, fname, false, true)
+	err = UpdateAwsConfig(s, fname, false, true)
 	assert.Error(t, err)
 }

--- a/internal/sso/settings.go
+++ b/internal/sso/settings.go
@@ -434,7 +434,7 @@ var getExecutable func() (string, error) = func() (string, error) {
 
 // GetAllProfiles returns a map of the ProfileConfig for each SSOConfig.
 // takes the binary path to `open` URL with if set
-func (s *Settings) GetAllProfiles(open url.Action) (*ProfileMap, error) {
+func (s *Settings) GetAllProfiles() (*ProfileMap, error) {
 	profiles := ProfileMap{}
 	var err error
 
@@ -462,7 +462,6 @@ func (s *Settings) GetAllProfiles(open url.Action) (*ProfileMap, error) {
 				BinaryPath:      binaryPath,
 				ConfigVariables: s.ConfigVariables,
 				DefaultRegion:   role.DefaultRegion,
-				Open:            string(open),
 				Profile:         profile,
 				Sso:             ssoName,
 			}

--- a/internal/sso/settings.go
+++ b/internal/sso/settings.go
@@ -130,7 +130,6 @@ type OverrideSettings struct {
 	DefaultSSO string
 	LogLevel   string
 	LogLines   bool
-	UrlAction  url.Action
 	Threads    int
 }
 
@@ -337,10 +336,6 @@ func (s *Settings) setOverrides(override OverrideSettings) {
 	}
 	if override.DefaultSSO != "" {
 		s.DefaultSSO = override.DefaultSSO
-	}
-
-	if override.UrlAction != "" {
-		s.UrlAction = override.UrlAction
 	}
 
 	if override.Threads > 0 {

--- a/internal/sso/settings_test.go
+++ b/internal/sso/settings_test.go
@@ -323,7 +323,6 @@ func (suite *SettingsTestSuite) TestSetOverrides() {
 		LogLines:   true,
 		Browser:    "my-browser",
 		DefaultSSO: "hello",
-		UrlAction:  url.PrintUrl,
 		Threads:    10,
 	}
 
@@ -333,7 +332,6 @@ func (suite *SettingsTestSuite) TestSetOverrides() {
 	assert.True(t, log.ReportCaller)
 	assert.Equal(t, "my-browser", s.Browser)
 	assert.Equal(t, "hello", s.DefaultSSO)
-	assert.Equal(t, url.PrintUrl, s.UrlAction)
 	assert.Equal(t, 10, s.Threads)
 }
 

--- a/internal/sso/settings_test.go
+++ b/internal/sso/settings_test.go
@@ -260,12 +260,12 @@ func (suite *SettingsTestSuite) TestGetAllProfiles() {
 	t := suite.T()
 
 	getExecutable = func() (string, error) { return "", fmt.Errorf("failed") }
-	_, err := suite.settings.GetAllProfiles("open firefox")
+	_, err := suite.settings.GetAllProfiles()
 	assert.Error(t, err)
 
 	getExecutable = os.Executable
 
-	profiles, err := suite.settings.GetAllProfiles("open firefox")
+	profiles, err := suite.settings.GetAllProfiles()
 	assert.NoError(t, err)
 
 	assert.Len(t, *profiles, 1)
@@ -281,7 +281,6 @@ func (suite *SettingsTestSuite) TestGetAllProfiles() {
 	assert.Equal(t, x.Arn, "arn:aws:iam::833365043586:role/AWSAdministratorAccess")
 	assert.NotEmpty(t, x.BinaryPath)
 	assert.Equal(t, map[string]interface{}(nil), x.ConfigVariables)
-	assert.Equal(t, "open firefox", x.Open)
 	assert.Equal(t, "Log archive/AWSAdministratorAccess", x.Profile)
 	assert.Equal(t, "Default", x.Sso)
 
@@ -300,7 +299,7 @@ func (suite *SettingsTestSuite) TestGetAllProfiles() {
 	assert.Error(t, profiles.UniqueCheck(suite.settings))
 
 	suite.settings.ProfileFormat = "{{ .GetAllProfilesFailure }}"
-	_, err = suite.settings.GetAllProfiles("open firefox")
+	_, err = suite.settings.GetAllProfiles()
 	assert.Error(t, err)
 
 	suite.settings.ProfileFormat = oldFormat


### PR DESCRIPTION
- login is not needed for all commands.
- process command doesn't open URLs anymore so... - Remove `--open` flag from `process` command - Remove `ConfigProfilesUrlAction` config option

Refs: #291