### PR TITLE
cleanup docs and remove completions pre-1.9

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,8 +5,8 @@ coverage:
   status:
     project:
       target: auto
-      threshold: 0%
-      paths:
-        - internal/*
-        - sso/*
+      threshold: 0.25%
+
+ignore:
+  - cmd/**
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,4 @@
-GNU General Public License
-==========================
+# GNU General Public License
 
 _Version 3, 29 June 2007_  
 _Copyright © 2007 Free Software Foundation, Inc. &lt;<http://fsf.org/>&gt;_
@@ -593,4 +592,3 @@ more useful to permit linking proprietary applications with the library. If this
 what you want to do, use the GNU Lesser General Public License instead of this
 License. But first, please read
 &lt;<http://www.gnu.org/philosophy/why-not-lgpl.html>&gt;.
-

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -278,16 +278,17 @@ quickstart.md#enabling-auto-completion-in-your-shell).
 
 Flags:
 
+ * `--source` -- Print out the completions for sourcing into the current shell
  * `--install` -- Install the new v1.9+ shell completions scripts
  * `--uninstall` -- Uninstall the new v1.9+ shell completions scripts
- * `--uninstall-pre-19` -- Uninstall the legacy pre-v1.9 scripts
  * `--shell <shell>` -- Override the detected shell
  * `--shell-script <file>` -- Override the default shell script file to modify
 
-**Note:** You should uninstall the older pre-v1.9 completions before installing
-the new version.  Once the new version is installed, `--uninstall-pre-19` will
-refuse to run so you will have to either manually edit the file or run
-`--uninstall`, then `--uninstall-pre-19` and finally `--install` again.
+---
+
+### setup ecs
+
+See the [setup ecs](ecs-commands.md#setup-ecs) commands in the ECS Server command documentation.
 
 ---
 

--- a/docs/ecs-commands.md
+++ b/docs/ecs-commands.md
@@ -4,7 +4,9 @@ For information about the ECS Server functionality, see the [ecs-server](ecs-ser
 
 ## Commands
 
-### setup ecs auth
+### setup ecs
+
+#### setup ecs auth
 
 Configures the HTTP Authentication BearerToken.  Once set, all future client
 requests to the ECS Server will need to provide the correct credentials.  
@@ -20,7 +22,7 @@ Flags:
 
 ---
 
-### setup ecs ssl
+#### setup ecs ssl
 
  Configures the SSL Certificate and Private Key to enable SSL/TLS.  Saves the
  SSL certificate and private key to the SecureStore.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,13 +12,13 @@
         now part of [homebrew-core](
         https://github.com/Homebrew/homebrew-core/blob/master/Formula/a/aws-sso-cli.rb).
  * Option 4: Build from source:
-    1. Install [GoLang](https://golang.org) v1.17+ and GNU Make
+    1. Install [GoLang](https://golang.org) v1.22+ and GNU Make
     1. Clone this repo
     1. Run `make` (or `gmake` for GNU Make)
     1. Your binary will be created in the `dist` directory
     1. Run `make install` to install in /usr/local/bin
  * Option 5: `go install`:
-    1. Install [GoLang](https://golang.org) v1.19+ and GNU Make
+    1. Install [GoLang](https://golang.org) v1.22+ and GNU Make
     1. `go install github.com/synfinatic/aws-sso-cli/cmd/aws-sso@latest`
 
 Note: macOS binaries must be build on macOS to enable Keychain support.
@@ -47,8 +47,8 @@ For more information about configuring `aws-sso` read the
 [configuration guide](config.md).
 
 You can re-run through the configuration wizard at any time by running
-`aws-sso config`.  By default, this only does a very basic setup; for a more
-advanced setup, use `aws-sso config --advanced`.
+`aws-sso setup wizard`.  By default, this only does a very basic setup; for a more
+advanced setup, use `aws-sso setup wizard --advanced`.
 
 ## Enabling auto-completion in your shell
 
@@ -65,34 +65,11 @@ shell for those changes to take effect.
 Guided setup should of prompted you to install auto-completions, but
 you can always re-run it for a different shell:
 
-`aws-sso completions -I`
+`aws-sso setup completions -I`
 
 or if you wish to uninstall them:
 
-`aws-sso completions -U`
-
----
-
-### Upgrading from before v1.9.0
-
-First, there is no longer an `install-completions` command as of v1.9.0,
-that functionality (and more) has been moved to `completions`.
-
-You should _first_ uninstall the old completions (sorry) and then install
-the new versions.  This manual uninstall/re-install is a one time thing,
-but necessary.
-
- 1. `aws-sso completions --uninstall-pre-19`
- 2. `aws-sso completions -I`
-
-Users of older versions will note that starting in v1.9.0, running
-`completions -I` or `completions -U` will present you a diff of file changes
-for you to accept.
-
-Also, unlike with older versions, only your current shell is modified when
-you run `completions -I` or `completions -U`, but
-`completions --uninstall-pre-19` uses the original code/library and will
-modify your `bash`, `zsh` and `fish` init scripts.
+`aws-sso setup completions -U`
 
 ---
 
@@ -101,7 +78,7 @@ modify your `bash`, `zsh` and `fish` init scripts.
 Upgrading from versions 1.9.0 or better is just like installing for
 first time users:
 
-`aws-sso completions -I`
+`aws-sso setup completions -I`
 
 Any changes will be presented to you in diff format and you will be given
 the option to accept or reject the changes.
@@ -111,7 +88,7 @@ the option to accept or reject the changes.
 ### More information
 
 More information on auto-completion can be found in the documentation
-for the [completions command](commands.md#completions).
+for the [setup completions](commands.md#setup-completions) command.
 
 ## Use `aws-sso` on the CLI for AWS API calls
 
@@ -191,7 +168,7 @@ and the `$AWS_PROFILE` environment variable, AWS SSO CLI can support that as wel
 
 #### Configuration
 
-Run: `aws-sso config-profiles`
+Run: `aws-sso setup profiles`
 
 This will add the following lines (example) to your `~/.aws/config` file:
 


### PR DESCRIPTION
 * Update docs that are a bit out of date for 2.0.0
 * Remove completions --uninstall-pre19 flag
 * Cleanup license file to remove lint warnings

Fixes: #1031