### PR TITLE
fix crash due to go variable context change

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,23 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Run Wizard",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/aws-sso/",
+            "args": ["setup", "wizard", "--config=foo.yaml", "--hostname=synfinatic", "--region=us-east-2", "--profile-format=Friendly"]
+        },
+        {
+            "name": "List Profiles",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/aws-sso/",
+            "args": ["list", "--config=${workspaceFolder}/config.yaml"]
+        },
+
+        {
             "name": "Run ECS Server",
             "type": "go",
             "request": "launch",

--- a/internal/sso/awssso.go
+++ b/internal/sso/awssso.go
@@ -239,9 +239,9 @@ func (as *AWSSSO) ListAccounts(input *sso.ListAccountsInput) (*sso.ListAccountsO
 				as.rolesLock.Lock()
 				log.Error("AccessToken Unauthorized Error; refreshing", "error", err.Error())
 
-				if err = as.reauthenticate(); err != nil {
+				if err2 := as.reauthenticate(); err2 != nil {
 					// fail hard now
-					return output, err
+					return output, err2
 				}
 				input.AccessToken = aws.String(as.Token.AccessToken)
 				as.rolesLock.Unlock()


### PR DESCRIPTION
Go v1.22 changes how variables are shadowed which was causing ListAccounts() to return an empty list