### PR TITLE
console command requires authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,22 @@
 # AWS SSO CLI Changelog
 
-## [Unreleased]
+## [v2.0.0] - 2024-XX-XX
 
 ### Bugs
 
- * Fix running the ECS server outside of docker #104a
+ * Fix running the ECS server outside of docker #104
+ * Fix crash while fetching AWS account list
+ * Fix `console` command failing due to lack of authentication
+ * Fix `--lines` argument
+
+### New Features
+
+ * Add basic xonsh shell support
+
+### Changes
+
+ * Bump various 3rd party libraries
+ * Improve github actions for builds
 
 ## [v2.0.0-beta3] - 2024-08-19
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT_VERSION        := 2.0.0-beta3
+PROJECT_VERSION        := 2.0.0
 DOCKER_REPO            := synfinatic
 PROJECT_NAME           := aws-sso
 DOCKER_PROJECT_NAME    := aws-sso-cli-ecs-server

--- a/cmd/aws-sso/console_cmd.go
+++ b/cmd/aws-sso/console_cmd.go
@@ -62,7 +62,7 @@ type ConsoleCmd struct {
 
 // AfterApply determines if SSO auth token is required
 func (c ConsoleCmd) AfterApply(runCtx *RunContext) error {
-	runCtx.Auth = AUTH_SKIP
+	runCtx.Auth = AUTH_REQUIRED
 	return nil
 }
 


### PR DESCRIPTION
`aws-sso console` would fail if user had not already fetched IAM credentials because auth is required.