### PR TITLE
remove --no-config-check from helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # AWS SSO CLI Changelog
 
+## [v2.0.0] - XXXX-XX-XX
+
+### Bugs
+
+ * `aws-sso-profile` helper generates error about `--no-config-check` flag
+
 ## [v2.0.0-beta4] - 2024-09-29
 
 ### Bugs

--- a/internal/helper/aws-sso.fish
+++ b/internal/helper/aws-sso.fish
@@ -9,7 +9,7 @@ complete -f -c aws-sso -a "(__complete_aws-sso)"
 
 function aws-sso-profile
   set --local _args (string split -- ' ' $AWS_SSO_HELPER_ARGS)
-  set -q AWS_SSO_HELPER_ARGS; or set --local _args -L error --no-config-check
+  set -q AWS_SSO_HELPER_ARGS; or set --local _args -L error
   if [ -n "$AWS_PROFILE" ]
       echo "Unable to assume a role while AWS_PROFILE is set"
       return 1
@@ -28,7 +28,7 @@ end
 
 function __aws_sso_profile_complete
   set --local _args (string split -- ' ' $AWS_SSO_HELPER_ARGS)
-  set -q AWS_SSO_HELPER_ARGS; or set --local _args -L error --no-config-check
+  set -q AWS_SSO_HELPER_ARGS; or set --local _args -L error
   set -l cur (commandline -t)
 
   set -l cmd "{{ .Executable }} list $_args --csv -P Profile=$cur Profile"

--- a/internal/helper/bash_profile.sh
+++ b/internal/helper/bash_profile.sh
@@ -1,6 +1,6 @@
 __aws_sso_profile_complete() {
     COMPREPLY=()
-    local _args=${AWS_SSO_HELPER_ARGS:- -L error --no-config-check}
+    local _args=${AWS_SSO_HELPER_ARGS:- -L error}
     local cur
     _get_comp_words_by_ref -n : cur
 
@@ -10,7 +10,7 @@ __aws_sso_profile_complete() {
 }
 
 aws-sso-profile() {
-    local _args=${AWS_SSO_HELPER_ARGS:- -L error --no-config-check}
+    local _args=${AWS_SSO_HELPER_ARGS:- -L error}
     if [ -n "$AWS_PROFILE" ]; then
         echo "Unable to assume a role while AWS_PROFILE is set"
         return 1
@@ -28,7 +28,7 @@ aws-sso-profile() {
 }
 
 aws-sso-clear() {
-    local _args=${AWS_SSO_HELPER_ARGS:- -L error --no-config-check}
+    local _args=${AWS_SSO_HELPER_ARGS:- -L error}
     if [ -z "$AWS_SSO_PROFILE" ]; then
         echo "AWS_SSO_PROFILE is not set"
         return 1


### PR DESCRIPTION
--no-config-check is no longer valid/needed in 2.x and we need to remove these flags from the helpers to avoid errors