### PR TITLE
fix(#1075): Populate accountid and role correctly for exec when using UI

### DIFF
--- a/cmd/aws-sso/exec_cmd.go
+++ b/cmd/aws-sso/exec_cmd.go
@@ -79,7 +79,7 @@ func (cc *ExecCmd) Run(ctx *RunContext) error {
 
 // Executes Cmd+Args in the context of the AWS Role creds
 func execCmd(ctx *RunContext, accountid int64, role string) error {
-	region := ctx.Settings.GetDefaultRegion(ctx.Cli.Exec.AccountId, ctx.Cli.Exec.Role, ctx.Cli.Exec.NoRegion)
+	region := ctx.Settings.GetDefaultRegion(accountid, role, ctx.Cli.Exec.NoRegion)
 
 	ctx.Settings.Cache.AddHistory(utils.MakeRoleARN(accountid, role))
 	if err := ctx.Settings.Cache.Save(false); err != nil {


### PR DESCRIPTION
This fixes #1075 by ensuring that the accountid and role used by the exec command for getting the DefaultRegion is correctly poplutade for both the commandline parameters and the interactive UI, rather than just the commandline parameters.