### PR TITLE
Support Nix packaging of shell integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
  * `aws-sso-profile` helper generates error about `--no-config-check` flag
  * Honor `DefaultRegion` in config.yaml when using interactive prompt #1075
  * Lock SecureStore across multiple `aws-sso` executions #1084
+ * `setup completions` and most `ecs` commands no longer require a valid config #1180
 
 ## [v2.0.0-beta4] - 2024-09-29
 

--- a/cmd/aws-sso/completions_cmd.go
+++ b/cmd/aws-sso/completions_cmd.go
@@ -34,7 +34,8 @@ type CompleteCmd struct {
 
 // AfterApply determines if SSO auth token is required
 func (c CompleteCmd) AfterApply(runCtx *RunContext) error {
-	runCtx.Auth = AUTH_SKIP
+	// completions doesn't require any config
+	runCtx.Auth = AUTH_NO_CONFIG
 	return nil
 }
 
@@ -42,7 +43,7 @@ func (cc *CompleteCmd) Run(ctx *RunContext) error {
 	var err error
 
 	if ctx.Cli.Setup.Completions.Source {
-		return helper.NewSourceHelper(os.Executable, os.Stdout).Generate(ctx.Cli.Setup.Completions.Shell)
+		err = helper.NewSourceHelper(os.Executable, os.Stdout).Generate(ctx.Cli.Setup.Completions.Shell)
 	} else if ctx.Cli.Setup.Completions.Install {
 		// install the current auto-complete helper
 		err = helper.InstallHelper(ctx.Cli.Setup.Completions.Shell, ctx.Cli.Setup.Completions.ShellScript)

--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -160,6 +160,7 @@ func main() {
 		if err = runCtx.Kctx.Run(&runCtx); err != nil {
 			log.Fatal(err.Error())
 		}
+		return // don't do anything else
 	}
 
 	// Load the config file


### PR DESCRIPTION
Don't prompt for configuration when generating shell completions or when interacting with ECS server unless absolutely necessary.

Fixes: #1180