### PR TITLE
fix shell completion generation for nixpkgs build

### DIFF
--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -155,11 +155,13 @@ func main() {
 
 	override := parseArgs(&runCtx)
 
-	if runCtx.Auth == AUTH_NO_CONFIG {
+	if runCtx.Auth == AUTH_NO_CONFIG ||
+		runCtx.Kctx.Command() == "setup completions" {
 		// side-step the rest of the setup...
 		if err = runCtx.Kctx.Run(&runCtx); err != nil {
 			log.Fatal(err.Error())
 		}
+		return
 	}
 
 	// Load the config file


### PR DESCRIPTION
## What Changed

Added an early exit when the command is `aws-sso setup completions`. Without this early exit, the command tries to setup the config which is not needed to generate the completion scripts.