### PR TITLE
Fix some small bugs

### DIFF
--- a/internal/sso/cache.go
+++ b/internal/sso/cache.go
@@ -499,7 +499,7 @@ func fetchSSORole(id int, as *AWSSSO, aInfo <-chan AccountInfo, rInfo chan<- []R
 // and using our SSOCache
 func processSSORoles(roles []RoleInfo, cache *SSOCache, r *Roles) {
 	for _, role := range roles {
-		log.Debug("Processing %s:%s", role.AccountId, role.RoleName)
+		log.Debug(fmt.Sprintf("Processing %s:%s", role.AccountId, role.RoleName))
 		accountId := role.GetAccountId64()
 
 		if _, ok := r.Accounts[accountId]; !ok {

--- a/internal/storage/keyring.go
+++ b/internal/storage/keyring.go
@@ -155,10 +155,10 @@ func fileKeyringPassword(prompt string) (string, error) {
 	}
 	s := string(b)
 	if s == "" {
-		fmt.Println()
+		fmt.Fprintf(os.Stderr, "\n")
 		panic("Aborting with empty password")
 	}
-	fmt.Println()
+	fmt.Fprintf(os.Stderr, "\n")
 	return s, nil
 }
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -194,11 +194,23 @@ func AccountIdToString(a int64) (string, error) {
 
 // AccountIdToInt64 returns an int64 version of AWS AccountID in base10
 func AccountIdToInt64(a string) (int64, error) {
-	x, err := strconv.ParseInt(a, 10, 64)
-	if err != nil {
-		return 0, err
+	var x int64
+	var err error
+
+	if strings.Contains(a, "e+") {
+		// AWS AccountID is in scientific notation
+		f, err := strconv.ParseFloat(a, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid AWS AccountId: %s", a)
+		}
+		x = int64(f)
+	} else {
+		x, err = strconv.ParseInt(a, 10, 64)
+		if err != nil {
+			return 0, err
+		}
 	}
-	if x < 0 {
+	if x < 0 || x > MAX_AWS_ACCOUNTID {
 		return 0, fmt.Errorf("invalid AWS AccountId: %s", a)
 	}
 	return x, nil

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -199,6 +199,17 @@ func (suite *UtilsTestSuite) TestAccountToInt64() {
 
 	_, err = AccountIdToInt64("-1")
 	assert.Error(t, err)
+
+	a, err = AccountIdToInt64("7.2668187369e+10")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(72668187369), a)
+
+	a, err = AccountIdToInt64("1e+1")
+	assert.NoError(t, err)
+	assert.Equal(t, int64(10), a)
+
+	_, err = AccountIdToInt64("10e+s4")
+	assert.Error(t, err)
 }
 
 func (suite *UtilsTestSuite) TestParseTimeString() {


### PR DESCRIPTION
- Bad debug log was printing the format string
- Unable to parse scientific notation for AWS AccountIDs
- Prompting for passwords didn't properly push terminal to the next line