### PR TITLE
Fix Via config assume role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
  * Honor `DefaultRegion` in config.yaml when using interactive prompt #1075
  * Lock SecureStore across multiple `aws-sso` executions #1084
  * `setup completions` and most `ecs` commands no longer require a valid config #1180
+ * Improve documentation and bug fix for the `Via` configuration option #1202, #1087
 
 ## [v2.0.0-beta4] - 2024-09-29
 

--- a/cmd/aws-sso/console_cmd.go
+++ b/cmd/aws-sso/console_cmd.go
@@ -279,7 +279,7 @@ func openConsoleAccessKey(ctx *RunContext, creds *storage.RoleCredentials,
 	loginResponse := LoginResponse{}
 	err = json.Unmarshal(body, &loginResponse)
 	if err != nil {
-		log.Trace("LoginResponse", "body", body)
+		log.Debug("LoginResponse", "body", string(body))
 		return fmt.Errorf("error parsing Login response: %s", err.Error())
 	}
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -205,6 +205,35 @@ roles in AWS accounts that are not included in your organization's AWS SSO
 scope or roles that were not defined via an [AWS SSO Permission Set](
 https://docs.aws.amazon.com/singlesignon/latest/userguide/permissionsetsconcept.html).
 
+The value of the `Via` must be that of an ARN.  If the initial role is a role managed
+via AWS Identity Center, use the standard IAM Role ARN format of: `arn:aws:iam::<acccountid>:role/<rolename>`
+and NOT the actual IAM Role that Identity Center creates which is of the format:
+`arn:aws:iam::<accountid>:/role/aws-reserved/sso.amazonaws.com/<sso-region>/AWSReservedSSO_<rolename>_<random>`
+
+Note: `aws-sso` does not manage, create or configure the necessasry IAM permissions on
+either role to grant permissions to successfully perform the `sts:AssumeRole` action.
+For this functionality to work, you must configure the IAM permissions to allow this
+operation to be successful.
+
+Example:
+
+```yaml
+SSOConfig:
+  Default:
+    Accounts:
+      072668187369:
+        Roles:
+          AssumeRoleAdmin:
+            Via: "arn:aws:iam::647310151462:role/sandbox-05-assumeroleadmin"
+```
+
+Will allow a user to assume the non-AWS Identity Center role
+`aws:iam::072668187369:roles/AssumeRoleAdmin` via the AWS Identity Center managed
+role `arn:aws:iam::647310151462:role/sandbox-05-assumeroleadmin`.
+
+Note: The [aws-sso console](https://github.com/synfinatic/aws-sso-cli/issues/1205) command
+is not supported for roles accessed using the `Via` feature.
+
 ##### SourceIdentity
 
 An [optional string](

--- a/internal/sso/awssso.go
+++ b/internal/sso/awssso.go
@@ -401,7 +401,7 @@ func (as *AWSSSO) GetRoleCredentials(accountId int64, role string) (storage.Role
 	// is the role defined in the config file?
 	configRole, err := as.SSOConfig.GetRole(accountId, role)
 	if err != nil {
-		log.Debug("SSOConfig.GetRole()", "error", err.Error())
+		log.Debug("SSOConfig.GetRole()", "error", err.Error(), "config", as.SSOConfig)
 	}
 
 	// If not in config OR config does not require doing a Via

--- a/internal/sso/roles.go
+++ b/internal/sso/roles.go
@@ -435,6 +435,18 @@ func (r *AWSRoleFlat) GetEnvVarTags(s *Settings) map[string]string {
 	return ret
 }
 
+// AwsRole converts the AWSRoleFlat to an AWSRole
+func (r *AWSRoleFlat) AwsRole() *AWSRole {
+	return &AWSRole{
+		Arn:           r.Arn,
+		DefaultRegion: r.DefaultRegion,
+		Expires:       r.ExpiresEpoch,
+		Profile:       r.Profile,
+		Tags:          r.Tags,
+		Via:           r.Via,
+	}
+}
+
 // HasPrefix determines if the given field starts with the value
 // Tags, Expires and ExpiresEpoch are invalid
 func (r *AWSRoleFlat) HasPrefix(field, prefix string) (bool, error) {

--- a/internal/sso/roles_test.go
+++ b/internal/sso/roles_test.go
@@ -341,6 +341,30 @@ func TestRoleFlatExpiresIn(t *testing.T) {
 	assert.Equal(t, "4m", x)
 }
 
+func TestRoleFlatAwsRole(t *testing.T) {
+	f := &AWSRoleFlat{
+		Arn:           "arn:aws:iam::123456789012:role/foobar",
+		DefaultRegion: "us-east-1",
+		ExpiresEpoch:  923452345,
+		Profile:       "foobar",
+		Tags: map[string]string{
+			"Foo": "bar",
+		},
+		Via: "arn:aws:iam::123456789012:role/foobarSource",
+	}
+	x := f.AwsRole()
+	assert.Equal(t, AWSRole{
+		Arn:           "arn:aws:iam::123456789012:role/foobar",
+		DefaultRegion: "us-east-1",
+		Expires:       923452345,
+		Profile:       "foobar",
+		Tags: map[string]string{
+			"Foo": "bar",
+		},
+		Via: "arn:aws:iam::123456789012:role/foobarSource",
+	}, *x)
+}
+
 // profile functions
 func TestEmptyString(t *testing.T) {
 	assert.True(t, emptyString(""))

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -184,7 +184,7 @@ func TimeRemain(expires int64, space bool) (string, error) {
 	return s, nil
 }
 
-// AccountIdToString returns a string version of AWS AccountID
+// AccountIdToString returns a string version of AWS AccountID with leading zeroes
 func AccountIdToString(a int64) (string, error) {
 	if a < 0 || a > MAX_AWS_ACCOUNTID {
 		return "", fmt.Errorf("invalid AWS AccountId: %d", a)


### PR DESCRIPTION
- Fixes getting API creds for role chaining.
- Getting an AWS Console (`aws-sso console`) is not working

Refs: #1202, #1087