### PR TITLE
feat(internal/config): support both `.yml` and `.yaml` suffixes when loading the config file

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,7 +27,8 @@ import (
 
 const (
 	OLD_CONFIG_DIR      = "~/.aws-sso"
-	CONFIG_FILE         = "%s/config.yaml"
+	CONFIG_FILE_YAML    = "%s/config.yaml"
+	CONFIG_FILE_YML     = "%s/config.yml"
 	JSON_STORE_FILE     = "%s/store.json"
 	INSECURE_CACHE_FILE = "%s/cache.json"
 )
@@ -59,9 +60,22 @@ func ConfigDir(expand bool) string {
 	return path
 }
 
-// ConfigFile returns the path to the config file
+// ConfigFile returns the path to the config file, prioritizing .yaml, then .yml
 func ConfigFile(expand bool) string {
-	return fmt.Sprintf(CONFIG_FILE, ConfigDir(expand))
+	dir := ConfigDir(expand)
+	yamlPath := fmt.Sprintf(CONFIG_FILE_YAML, dir)
+	ymlPath := fmt.Sprintf(CONFIG_FILE_YML, dir)
+
+	// Check for existence of .yaml file first
+	if _, err := os.Stat(yamlPath); err == nil {
+		return yamlPath
+	}
+	// If not, check for existence of .yml file
+	if _, err := os.Stat(ymlPath); err == nil {
+		return ymlPath
+	}
+	// If neither exist, default to .yaml path
+	return yamlPath
 }
 
 // JsonStoreFile returns the path to the JSON store file

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -50,6 +50,41 @@ func TestConfigFile(t *testing.T) {
 	assert.Equal(t, "~/.aws-sso/config.yaml", ConfigFile(false))
 }
 
+func TestConfigFile_Prioritization(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "aws-sso-test")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Save & override relevant env for isolation
+	origXDG := os.Getenv("XDG_CONFIG_HOME")
+	defer os.Setenv("XDG_CONFIG_HOME", origXDG)
+	os.Unsetenv("XDG_CONFIG_HOME")
+
+	origHome := os.Getenv("HOME")
+	defer os.Setenv("HOME", origHome)
+	assert.NoError(t, os.Setenv("HOME", tempDir))
+
+	// Phase 1: Neither config.yaml nor config.yml exist
+	expected := fmt.Sprintf("%s/.config/aws-sso/config.yaml", tempDir)
+	assert.Equal(t, expected, ConfigFile(true))
+
+	// Phase 2: Only .yml exists
+	_ = os.MkdirAll(fmt.Sprintf("%s/.config/aws-sso", tempDir), 0755)
+	ymlPath := fmt.Sprintf("%s/.config/aws-sso/config.yml", tempDir)
+	assert.NoError(t, os.WriteFile(ymlPath, []byte("yml: true"), 0644))
+	assert.Equal(t, ymlPath, ConfigFile(true))
+
+	// Phase 3: Only .yaml exists
+	os.Remove(ymlPath)
+	yamlPath := fmt.Sprintf("%s/.config/aws-sso/config.yaml", tempDir)
+	assert.NoError(t, os.WriteFile(yamlPath, []byte("yaml: true"), 0644))
+	assert.Equal(t, yamlPath, ConfigFile(true))
+
+	// Phase 4: Both .yaml and .yml exist, should pick .yaml
+	assert.NoError(t, os.WriteFile(ymlPath, []byte("yml: true"), 0644))
+	assert.Equal(t, yamlPath, ConfigFile(true))
+}
+
 func TestJsonStoreFile(t *testing.T) {
 	tempHome, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)


### PR DESCRIPTION
**Why?**

It's a common mistake when people set up their config file and supporting both suffixes will improve the UX a lot.

**What?**
This pull request updates the configuration file handling in the `internal/config` package to support both `.yaml` and `.yml` file extensions, with a prioritization mechanism. It also introduces tests to validate the prioritization logic.

### Configuration file handling updates:
* [`internal/config/config.go`](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL30-R31): Added support for both `.yaml` and `.yml` configuration file extensions by introducing `CONFIG_FILE_YAML` and `CONFIG_FILE_YML` constants. Updated the `ConfigFile` function to prioritize `.yaml` over `.yml` if both exist. If neither exists, `.yaml` is used as the default. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL30-R31) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL62-R78)

### Testing enhancements:
* [`internal/config/config_test.go`](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R53-R87): Added a new test, `TestConfigFile_Prioritization`, to verify the prioritization logic for `.yaml` and `.yml` files. The test covers scenarios where neither file exists, only one exists, or both exist.