### PR TITLE
fix `setup profiles` forced re-auth

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,6 +28,15 @@
             "mode": "auto",
             "program": "${workspaceFolder}/cmd/aws-sso/",
             "args": ["ecs", "server"]
+        },
+
+        {
+            "name": "setup profiles",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/aws-sso/",
+            "args": ["setup", "profiles", "--diff" ]
         }
     ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # AWS SSO CLI Changelog
 
+## [Unreleased] - 2025-XX-XX
+
+### Bugs
+
+ * Fix forced re-auth with `aws-sso setup profiles` #1210
+
+### Changes
+
+ * `aws-sso setup profiles` Now uses your existing cache if not expired and refreshes only if necessary
+ * `aws-sso setup profiles` Now requires users to be logged in
+
 ## [v2.0.0] - 2025-05-10
 
 ### Bugs

--- a/cmd/aws-sso/cache_cmd.go
+++ b/cmd/aws-sso/cache_cmd.go
@@ -63,7 +63,7 @@ func (cc *CacheCmd) Run(ctx *RunContext) error {
 		// should we update our config??
 		if !ctx.Cli.Cache.NoConfigCheck && ctx.Settings.AutoConfigCheck {
 			if ctx.Settings.ConfigProfilesUrlAction != url.ConfigProfilesUndef {
-				err := awsconfig.UpdateAwsConfig(ctx.Settings, "", true, false)
+				err := awsconfig.UpdateAwsConfig(ssoName, ctx.Settings, "", true, false)
 				if err != nil {
 					log.Error("Unable to auto-update aws config file", "error", err.Error())
 				}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -334,16 +334,16 @@ _automatically refresh_.  This means, if you do not have a valid AWS SSO token,
 you will be prompted to authentiate via your SSO provider and subsequent
 requests to obtain new IAM STS credentials will automatically happen as needed.
 
-**Note:** You should run this command any time your list of AWS roles changes
-in order to update the `~/.aws/config` file or enable [AutoConfigCheck](
-config.md#autoconfigcheck).
+**Note:** You should run this command _after_ [aws-sso cache](#cache) any time 
+your list of AWS roles changes in order to update the `~/.aws/config` file 
+or enable [AutoConfigCheck](config.md#autoconfigcheck).
 
 **Note:** It is important that you do _NOT_ remove the `# BEGIN_AWS_SSO_CLI` and
 `# END_AWS_SSO_CLI` lines from your config file!  These markers are used to track
 which profiles are managed by AWS SSO CLI.
 
-**Note:** This command does not honor the `--sso` option as it operates on all
-of the configured AWS SSO instances in the `~/.aws-sso/config.yaml` file.
+**Note:** This command does not auto-refresh the list of cached roles, so if they
+have recently changed you should run `aws-sso cache` first.
 
 ---
 

--- a/internal/awsconfig/config.go
+++ b/internal/awsconfig/config.go
@@ -48,8 +48,8 @@ func AwsConfigFile(cfile string) string {
 var stdout = os.Stdout
 
 // PrintAwsConfig just prints what our new AWS config file block would look like
-func PrintAwsConfig(s *sso.Settings) error {
-	profiles, err := getProfileMap(s)
+func PrintAwsConfig(ssoName string, s *sso.Settings) error {
+	profiles, err := getProfileMap(ssoName, s)
 	if err != nil {
 		return err
 	}
@@ -64,8 +64,8 @@ func PrintAwsConfig(s *sso.Settings) error {
 
 // UpdateAwsConfig updates our AWS config file, optionally presenting a diff for
 // review or possibly making the change without prompting
-func UpdateAwsConfig(s *sso.Settings, cfile string, diff, force bool) error {
-	profiles, err := getProfileMap(s)
+func UpdateAwsConfig(ssoName string, s *sso.Settings, cfile string, diff, force bool) error {
+	profiles, err := getProfileMap(ssoName, s)
 	if err != nil {
 		return err
 	}
@@ -81,8 +81,8 @@ func UpdateAwsConfig(s *sso.Settings, cfile string, diff, force bool) error {
 }
 
 // getProfileMap returns our validated sso.ProfileMap
-func getProfileMap(s *sso.Settings) (*sso.ProfileMap, error) {
-	profiles, err := s.GetAllProfiles()
+func getProfileMap(ssoName string, s *sso.Settings) (*sso.ProfileMap, error) {
+	profiles, err := s.GetSSOProfiles(ssoName)
 	if err != nil {
 		return profiles, err
 	}

--- a/internal/awsconfig/config_test.go
+++ b/internal/awsconfig/config_test.go
@@ -67,11 +67,17 @@ func TestGetProfileMap(t *testing.T) {
 		},
 	}
 
-	profiles, err := getProfileMap(s)
-	p := *profiles
+	profiles, err := getProfileMap("Default", s)
 	assert.NoError(t, err)
+	p := *profiles
 	assert.Equal(t, 1, len(p))
 	assert.Equal(t, 2, len(p["Default"]))
+
+	// Check when the SSO name is not available we should get an empty map
+	profiles, err = getProfileMap("NotAvailable", s)
+	assert.NoError(t, err)
+	p = *profiles
+	assert.Equal(t, 0, len(p))
 
 	// now fail
 	s.Cache.SSO["Other"] = &sso.SSOCache{
@@ -89,7 +95,7 @@ func TestGetProfileMap(t *testing.T) {
 			},
 		},
 	}
-	_, err = getProfileMap(s)
+	_, err = getProfileMap("Default", s)
 	assert.Error(t, err)
 }
 
@@ -125,7 +131,7 @@ func TestPrintAwsConfig(t *testing.T) {
 	fname := stdout.Name()
 	defer os.Remove(fname)
 
-	err = PrintAwsConfig(s)
+	err = PrintAwsConfig("Default", s)
 	assert.NoError(t, err)
 
 	_, err = stdout.Seek(0, 0)
@@ -158,7 +164,7 @@ func TestPrintAwsConfig(t *testing.T) {
 		},
 	}
 
-	err = PrintAwsConfig(s)
+	err = PrintAwsConfig("Default", s)
 	assert.Error(t, err)
 }
 
@@ -194,7 +200,7 @@ func TestUpdateAwsConfig(t *testing.T) {
 	defer os.Remove(fname)
 	cfile.Close()
 
-	err = UpdateAwsConfig(s, fname, false, true)
+	err = UpdateAwsConfig("Default", s, fname, false, true)
 	assert.NoError(t, err)
 
 	cfile, err = os.Open(fname)
@@ -226,6 +232,6 @@ func TestUpdateAwsConfig(t *testing.T) {
 		},
 	}
 
-	err = UpdateAwsConfig(s, fname, false, true)
+	err = UpdateAwsConfig("Default", s, fname, false, true)
 	assert.Error(t, err)
 }

--- a/internal/sso/cache.go
+++ b/internal/sso/cache.go
@@ -56,6 +56,23 @@ type Cache struct {
 	refreshed       bool                 // track if we have run Refresh() since this is expensive
 }
 
+func (c *Cache) GetSSOByName(name string) *SSOCache {
+	if v, ok := c.SSO[name]; ok {
+		return v
+	}
+	// else, init a new one
+	c.SSO[name] = &SSOCache{
+		name:       c.ssoName,
+		LastUpdate: 0,
+		History:    []string{},
+		Roles: &Roles{
+			Accounts: map[int64]*AWSAccount{},
+			ssoName:  c.ssoName,
+		},
+	}
+	return c.SSO[name]
+}
+
 func OpenCache(f string, s *Settings) (*Cache, error) {
 	cache := Cache{
 		settings:        s,

--- a/internal/sso/cache_test.go
+++ b/internal/sso/cache_test.go
@@ -592,6 +592,38 @@ func (suite *CacheTestSuite) TestPruneSSO() {
 	assert.NotContains(t, c.SSO, "Invalid")
 }
 
+func (suite *CacheTestSuite) TestGetSSOByName() {
+	t := suite.T()
+
+	c := &Cache{
+		SSO: map[string]*SSOCache{
+			"Primary": {
+				name: "Primary",
+			},
+			"Secondary": {
+				name: "NotSecondary",
+			},
+			"Invalid": {},
+		},
+	}
+
+	cache := c.GetSSOByName("Primary")
+	assert.NotNil(t, cache)
+	assert.Equal(t, "Primary", cache.name)
+
+	cache = c.GetSSOByName("Secondary")
+	assert.NotNil(t, cache)
+	assert.Equal(t, "NotSecondary", cache.name)
+
+	cache = c.GetSSOByName("Invalid")
+	assert.NotNil(t, cache)
+	assert.Empty(t, cache.name)
+
+	cache = c.GetSSOByName("Missing")
+	assert.NotNil(t, cache)
+	assert.Empty(t, cache.name)
+}
+
 func (suite *CacheTestSuite) TestAddConfigRoles() {
 	t := suite.T()
 

--- a/internal/sso/settings_test.go
+++ b/internal/sso/settings_test.go
@@ -345,6 +345,17 @@ func (suite *SettingsTestSuite) TestSetOverrides() {
 	assert.Equal(t, 10, s.Threads)
 }
 
+func (suite *SettingsTestSuite) TestGetSSOProfiles() {
+	t := suite.T()
+
+	profiles, err := suite.settings.GetSSOProfiles("Default")
+	assert.NoError(t, err)
+	assert.NotNil(t, profiles)
+	assert.Equal(t, 1, len(*profiles))
+	assert.Contains(t, *profiles, "Default")
+	assert.NotContains(t, *profiles, "Another")
+}
+
 func TestCreatedAt(t *testing.T) {
 	s := Settings{
 		configFile: "/dev/null/invalid",


### PR DESCRIPTION
- setup profiles command now uses your cache and validates it has not expired.
- if cache has expired, it will refresh without prompting you to login or fail if you have not logged in
- fixes bug where non-default SSO instances were empty


Fixes: #1210