### PR TITLE
aws-sso eval -c no longer requires a logged in session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
  * Fix ignoring `--url-action` when passed in on CLI
  * `aws-sso list` should never force authentication #1219
+ * `aws-sso-clear` now no longer requires user to be logged in #1224
 
 ## [v2.0.1] - 2025-05-16
 

--- a/cmd/aws-sso/eval_cmd.go
+++ b/cmd/aws-sso/eval_cmd.go
@@ -42,7 +42,11 @@ type EvalCmd struct {
 
 // AfterApply determines if SSO auth token is required
 func (e EvalCmd) AfterApply(runCtx *RunContext) error {
-	runCtx.Auth = AUTH_REQUIRED
+	if !runCtx.Cli.Eval.Clear {
+		runCtx.Auth = AUTH_REQUIRED
+	} else {
+		runCtx.Auth = AUTH_SKIP
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fixes: #1224