### PR TITLE
Fix AuthUrlAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 <!-- markdownlint-disable MD024 -->
 # AWS SSO CLI Changelog
 
-## [Unreleased] - 2025-XX-XX
+## [v2.0.3] - 2025-05-29
+
+### Bugs
+
+* Fix regression for `aws-sso login` no longer honoring `AuthUrlAction` #1230
 
 ### Changes
 
@@ -829,7 +833,9 @@
 
 Initial release
 
-[Unreleased]: https://github.com/synfinatic/aws-sso-cli/compare/v2.0.2...main
+<!-- markdownlint-disable-next-line MD053 -->
+[Unreleased]: https://github.com/synfinatic/aws-sso-cli/compare/v2.0.3...main
+[v2.0.3]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v2.0.3
 [v2.0.2]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v2.0.2
 [v2.0.1]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v2.0.1
 [v2.0.0]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v2.0.0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT_VERSION        := 2.0.2
+PROJECT_VERSION        := 2.0.3
 DOCKER_REPO            := synfinatic
 PROJECT_NAME           := aws-sso
 DOCKER_PROJECT_NAME    := aws-sso-cli-ecs-server

--- a/cmd/aws-sso/login_cmd.go
+++ b/cmd/aws-sso/login_cmd.go
@@ -63,12 +63,17 @@ func doAuth(ctx *RunContext) {
 		return
 	}
 
-	action, err := url.NewAction(ctx.Cli.Login.UrlAction)
-	if err != nil {
-		log.Fatal("Invalid --url-action", "action", ctx.Cli.Login.UrlAction)
-	}
-	if action == "" {
-		action = ctx.Settings.UrlAction
+	var err error
+	action := ctx.Settings.UrlAction // global default
+	if len(ctx.Cli.Login.UrlAction) > 0 {
+		// CLI override
+		action, err = url.NewAction(ctx.Cli.Login.UrlAction)
+		if err != nil {
+			log.Fatal("Invalid --url-action", "action", ctx.Cli.Login.UrlAction)
+		}
+	} else if AwsSSO.SSOConfig.AuthUrlAction != url.Undef {
+		// Auth specific override
+		action = AwsSSO.SSOConfig.AuthUrlAction
 	}
 	err = AwsSSO.Authenticate(action, ctx.Settings.Browser)
 	if err != nil {

--- a/internal/sso/awssso_auth.go
+++ b/internal/sso/awssso_auth.go
@@ -73,11 +73,7 @@ func (as *AWSSSO) Authenticate(urlAction url.Action, browser string) error {
 	log.Trace("Authenticate", "urlAction", urlAction, "browser", browser)
 	// cache urlAction and browser for subsequent calls if necessary
 	// if action is still undefined, use the default action which is defined inside NewHandleUrl()
-	if urlAction != url.Undef {
-		as.urlAction = urlAction
-	} else if as.SSOConfig.AuthUrlAction != url.Undef {
-		as.urlAction = as.SSOConfig.AuthUrlAction
-	}
+	as.urlAction = urlAction
 
 	if browser != "" {
 		as.browser = browser

--- a/internal/sso/awssso_auth_test.go
+++ b/internal/sso/awssso_auth_test.go
@@ -335,8 +335,7 @@ func TestAuthenticate(t *testing.T) {
 	assert.NoError(t, err)
 
 	// verify no override of CLI when not set
-	as.SSOConfig.AuthUrlAction = url.Print
-	err = as.Authenticate(url.Undef, "fake-browser")
+	err = as.Authenticate(url.Print, "fake-browser")
 	assert.NoError(t, err)
 
 	defer func() {


### PR DESCRIPTION
Fixes a regression in v2.0.2 where `AuthUrlAction` was no longer honored.

Fixes: #1230