### PR TITLE
Fix console command for Role Chaining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 * Fix clearing ENV vars under Windows Powershell #1244
 * Fix docs around correct naming of `--level` flag #1240
+* Fix console command for Via/AssumeRole roles #1205
 
 ## [v2.0.3] - 2025-05-29
 

--- a/internal/sso/awssso.go
+++ b/internal/sso/awssso.go
@@ -473,7 +473,7 @@ func (as *AWSSSO) GetRoleCredentials(accountId int64, role string) (storage.Role
 	previousRole := fmt.Sprintf("%s@%s", creds.RoleName, previousAccount)
 
 	input := sts.AssumeRoleInput{
-		//		DurationSeconds: aws.Int64(900),
+		// DurationSeconds: aws.Int32(900),
 		RoleArn:         aws.String(utils.MakeRoleARN(accountId, role)),
 		RoleSessionName: aws.String(previousRole),
 	}
@@ -497,6 +497,7 @@ func (as *AWSSSO) GetRoleCredentials(accountId int64, role string) (storage.Role
 		SecretAccessKey: aws.ToString(output.Credentials.SecretAccessKey),
 		SessionToken:    aws.ToString(output.Credentials.SessionToken),
 		Expiration:      aws.ToTime(output.Credentials.Expiration).UnixMilli(),
+		RoleChaining:    true, // we used AssumeRole to get these creds
 	}
 	return ret, nil
 }

--- a/internal/sso/awssso_test.go
+++ b/internal/sso/awssso_test.go
@@ -726,6 +726,7 @@ func TestGetRoleCredentials(t *testing.T) {
 	assert.Equal(t, int64(42), creds.Expiration)
 	assert.Equal(t, "secret-access-key", creds.SecretAccessKey)
 	assert.Equal(t, "session-token", creds.SessionToken)
+	assert.False(t, creds.RoleChaining)
 
 	_, err = as.GetRoleCredentials(int64(1111111), "FooBar")
 	assert.Error(t, err)

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -83,7 +83,8 @@ type RoleCredentials struct { // Cache
 	AccessKeyId     string `json:"accessKeyId"`
 	SecretAccessKey string `json:"secretAccessKey"`
 	SessionToken    string `json:"sessionToken"`
-	Expiration      int64  `json:"expiration"` // not in seconds, but millisec
+	Expiration      int64  `json:"expiration"`   // not in seconds, but millisec
+	RoleChaining    bool   `json:"roleChaining"` // true if we used AssumeRole to get these creds
 }
 
 // RoleArn returns the ARN for the role


### PR DESCRIPTION
You can't specify the SessionDuration when we do RoleChaining for the console command because it will fail

Fixes: #1205