### PR TITLE
[Feature] Add support for specifying SSO instance via `-S/--sso` flag for `aws-sso-profile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 * Add support for `ansi-osc52` copying of URLs into clipboard #1070
 * `--url-action` now supports auto-complete
-* `aws-sso-profile` shell helper now supports `-S`/`--sso` flag to specify SSO instance
+* `aws-sso-profile` shell helper now supports `-S`/`--sso` flag to specify SSO instance [#1264](https://github.com/synfinatic/aws-sso-cli/pull/1264)
 
 ### Bugs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 * Add support for `ansi-osc52` copying of URLs into clipboard #1070
 * `--url-action` now supports auto-complete
+* `aws-sso-profile` shell helper now supports `-S`/`--sso` flag to specify SSO instance
 
 ### Bugs
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -485,6 +485,21 @@ This shell command enables you to assume an AWS SSO role by the profile name
 _in the current shell and with auto-complete functionality_.  Basically it is a
 wrapper around `eval $(aws-sso eval --profile XXXX)` but with auto-complete.
 
+**Usage:**
+
+```bash
+# Using the default SSO instance
+aws-sso-profile <profile-name>
+
+# Using a specific SSO instance (v2.1.0+)
+aws-sso-profile -S <sso-instance> <profile-name>
+aws-sso-profile --sso <sso-instance> <profile-name>
+```
+
+The `-S` or `--sso` flag allows you to specify which SSO instance to use when you
+have multiple SSO configurations. This is particularly useful when working with
+multiple AWS organizations or when the profile name exists in multiple SSO instances.
+
 This command will export the same [environment variables](#managed-variables)
 as the [eval](#eval) command.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -497,8 +497,7 @@ aws-sso-profile --sso <sso-instance> <profile-name>
 ```
 
 The `-S` or `--sso` flag allows you to specify which SSO instance to use when you
-have multiple SSO configurations. This is particularly useful when working with
-multiple AWS organizations or when the profile name exists in multiple SSO instances.
+have multiple SSO configurations.
 
 This command will export the same [environment variables](#managed-variables)
 as the [eval](#eval) command.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -119,6 +119,19 @@ allows you to easily assume a role in your current shell with auto-complete
 generated AWS Profile names as defined by the [ProfileFormat](
 config.md#profileformat) config variable.
 
+```bash
+# Basic usage with the default SSO instance
+aws-sso-profile MyProfile
+
+# Using a specific SSO instance (v2.1.0+)
+aws-sso-profile -S Production MyProfile
+aws-sso-profile --sso Production MyProfile
+```
+
+The `-S` or `--sso` flag allows you to specify which SSO instance to use when you
+have multiple SSO configurations. This is particularly useful when working with
+multiple AWS organizations.
+
 The latter (`aws-sso-clear`), clears all the environment variables
 installed by `aws-sso-profile`.
 

--- a/internal/helper/aws-sso.fish
+++ b/internal/helper/aws-sso.fish
@@ -10,18 +10,54 @@ complete -f -c aws-sso -a "(__complete_aws-sso)"
 function aws-sso-profile
   set --local _args (string split -- ' ' $AWS_SSO_HELPER_ARGS)
   set -q AWS_SSO_HELPER_ARGS; or set --local _args -L error
+  set --local _sso ""
+  set --local _profile ""
+  set --local _remaining_args
+  
   if [ -n "$AWS_PROFILE" ]
       echo "Unable to assume a role while AWS_PROFILE is set"
       return 1
   end
 
-  if [ -z "$argv[1]" ]
-      echo "Usage: aws-sso-profile <profile>"
+  # Parse arguments
+  set --local i 1
+  while [ $i -le (count $argv) ]
+      switch $argv[$i]
+          case -S --sso
+              set i (math $i + 1)
+              if [ $i -gt (count $argv) ]
+                  echo "Error: -S/--sso requires an argument"
+                  return 1
+              end
+              set _sso $argv[$i]
+          case '-*'
+              echo "Unknown option: $argv[$i]"
+              echo "Usage: aws-sso-profile [-S|--sso <sso-instance>] <profile>"
+              return 1
+          case '*'
+              if [ -z "$_profile" ]
+                  set _profile $argv[$i]
+              else
+                  echo "Error: Multiple profiles specified"
+                  return 1
+              end
+      end
+      set i (math $i + 1)
+  end
+
+  if [ -z "$_profile" ]
+      echo "Usage: aws-sso-profile [-S|--sso <sso-instance>] <profile>"
       return 1
   end
 
-  eval $({{ .Executable }} $_args eval -p $argv[1])
-  if [ "$AWS_SSO_PROFILE" != "$1" ]
+  # Build and execute the eval command with optional SSO flag
+  if [ -n "$_sso" ]
+      eval $({{ .Executable }} $_args -S $_sso eval -p $_profile)
+  else
+      eval $({{ .Executable }} $_args eval -p $_profile)
+  end
+  
+  if [ "$AWS_SSO_PROFILE" != "$_profile" ]
       return 1
   end
 end

--- a/internal/helper/zshrc.sh
+++ b/internal/helper/zshrc.sh
@@ -16,18 +16,56 @@ __aws_sso_profile_complete() {
 
 aws-sso-profile() {
     local _args=${AWS_SSO_HELPER_ARGS:- -L error}
+    local _sso=""
+    local _profile=""
+    
     if [ -n "$AWS_PROFILE" ]; then
         echo "Unable to assume a role while AWS_PROFILE is set"
         return 1
     fi
 
-    if [ -z "$1" ]; then
-        echo "Usage: aws-sso-profile <profile>"
+    # Parse arguments
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -S|--sso)
+                shift
+                if [ -z "$1" ]; then
+                    echo "Error: -S/--sso requires an argument"
+                    return 1
+                fi
+                _sso="$1"
+                shift
+                ;;
+            -*)
+                echo "Unknown option: $1"
+                echo "Usage: aws-sso-profile [-S|--sso <sso-instance>] <profile>"
+                return 1
+                ;;
+            *)
+                if [ -z "$_profile" ]; then
+                    _profile="$1"
+                else
+                    echo "Error: Multiple profiles specified"
+                    return 1
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    if [ -z "$_profile" ]; then
+        echo "Usage: aws-sso-profile [-S|--sso <sso-instance>] <profile>"
         return 1
     fi
 
-    eval $({{ .Executable }} ${=_args} eval -p "$1")
-    if [ "$AWS_SSO_PROFILE" != "$1" ]; then
+    # Build and execute the eval command with optional SSO flag
+    if [ -n "$_sso" ]; then
+        eval $({{ .Executable }} ${=_args} -S "$_sso" eval -p "$_profile")
+    else
+        eval $({{ .Executable }} ${=_args} eval -p "$_profile")
+    fi
+    
+    if [ "$AWS_SSO_PROFILE" != "$_profile" ]; then
         return 1
     fi
 }


### PR DESCRIPTION
This pull request adds support for specifying an SSO instance when using the `aws-sso-profile` shell helper, making it easier to work with multiple AWS SSO configurations. 

The feature is available via the new `-S`/`--sso` flag, and usage instructions have been updated in the documentation. 

### Example usage

```sh
# Usage
aws-sso-profile
Usage: aws-sso-profile [-S|--sso <sso-instance>] <profile>

# Basic usage with the default SSO instance
aws-sso-profile MyProfile

# Using a specific SSO instance (v2.1.0+)
aws-sso-profile -S Production MyProfile
aws-sso-profile --sso Production MyProfile
```

## Related

- #1241 

## Changes:

* Added support for the `-S`/`--sso` flag to the `aws-sso-profile` shell helper, allowing users to specify an SSO instance when assuming a profile. This enables seamless use with multiple AWS organizations or duplicate profile names. (`internal/helper/bash_profile.sh`, `internal/helper/zshrc.sh`, `internal/helper/aws-sso.fish`) [[1]](diffhunk://#diff-9b1a6f794e721122e2f11581cf0e16d3f66934863198c247d493b08f769abecaR14-R63) [[2]](diffhunk://#diff-036290c0ca498e1a6562e39ddca3da433f42d8f8c648f3f8e06a020ff83cc129R19-R68) [[3]](diffhunk://#diff-a7529c1293439af8fcc1d6b0c03b1c47534cbe08b8e922c86eaf5804bb6d9e3eR13-R60)

## Documentation:

* Updated `docs/commands.md` and `docs/quickstart.md` with usage examples and explanations for the new `-S`/`--sso` flag, clarifying its benefits and how to use it. [[1]](diffhunk://#diff-e2c7369e0995500500b1f573c0efb5d7a018c94e443bac87948f3caecd7e905eR488-R502) [[2]](diffhunk://#diff-988a5392cf907f7c5728b8ac90445facc7f835f3c00375764ec99769dcde2d5aR122-R134)

## Changelog:

* Added a changelog entry describing the new `-S`/`--sso` flag support in the `aws-sso-profile` helper.