### PR TITLE
fix: spelling mistake in logline

### DIFF
--- a/cmd/aws-sso/login_cmd.go
+++ b/cmd/aws-sso/login_cmd.go
@@ -97,7 +97,7 @@ func doAuth(ctx *RunContext) {
 		}
 
 		if added > 0 || deleted > 0 {
-			log.Info("Updated cache", "added", added, "deletd", deleted)
+			log.Info("Updated cache", "added", added, "deleted", deleted)
 		}
 
 		if err = ctx.Settings.Cache.Save(true); err != nil {


### PR DESCRIPTION
This pull request fixes a minor typo in a log message in the `doAuth` function. The log key `"deletd"` was corrected to `"deleted"`.