### PR TITLE
Fix UniqueCheck to only validate profiles within the requested SSO

### DIFF
--- a/internal/awsconfig/config_test.go
+++ b/internal/awsconfig/config_test.go
@@ -79,7 +79,8 @@ func TestGetProfileMap(t *testing.T) {
 	p = *profiles
 	assert.Equal(t, 0, len(p))
 
-	// now fail
+	// Profiles from a different SSO with the same name should not cause
+	// a duplicate error, since UniqueCheck only checks the requested SSO
 	s.Cache.SSO["Other"] = &sso.SSOCache{
 		Roles: &sso.Roles{
 			Accounts: map[int64]*sso.AWSAccount{
@@ -96,7 +97,7 @@ func TestGetProfileMap(t *testing.T) {
 		},
 	}
 	_, err = getProfileMap("Default", s)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func TestPrintAwsConfig(t *testing.T) {
@@ -215,7 +216,8 @@ func TestUpdateAwsConfig(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile(`# BEGIN_AWS_SSO_CLI`), string(buf))
 	assert.Regexp(t, regexp.MustCompile(`# END_AWS_SSO_CLI`), string(buf))
 
-	// now fail
+	// Profiles from a different SSO with the same name should not cause
+	// a duplicate error, since UniqueCheck only checks the requested SSO
 	s.Cache.SSO["Other"] = &sso.SSOCache{
 		Roles: &sso.Roles{
 			Accounts: map[int64]*sso.AWSAccount{
@@ -233,5 +235,5 @@ func TestUpdateAwsConfig(t *testing.T) {
 	}
 
 	err = UpdateAwsConfig("Default", s, fname, false, true)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }

--- a/internal/sso/settings.go
+++ b/internal/sso/settings.go
@@ -504,22 +504,22 @@ func (s *Settings) GetSSOProfiles(ssoName string) (*ProfileMap, error) {
 	return &profiles, nil
 }
 
-// UniqueCheck verifies that all of the profiles are unique
+// UniqueCheck verifies that all of the profiles are unique.
+// Only checks profiles that are actually in the ProfileMap rather than
+// iterating over all cached SSO instances, which could produce false
+// duplicates when the ProfileFormat includes {{ .SSO }}.
 func (p *ProfileMap) UniqueCheck(s *Settings) error {
 	profileUniqueCheck := map[string][]string{} // ProfileName() => Arn
 
-	for ssoName, sso := range s.Cache.SSO {
-		for _, role := range sso.Roles.GetAllRoles() {
-			profile, err := role.ProfileName(s)
-			if err != nil {
-				return err
-			}
+	for ssoName, roles := range *p {
+		for arn, config := range roles {
+			profile := config.Profile
 
 			if match, duplicate := profileUniqueCheck[profile]; duplicate {
 				return fmt.Errorf("duplicate profile name '%s' for:\n%s: %s\n%s: %s",
-					profile, match[0], match[1], ssoName, role.Arn)
+					profile, match[0], match[1], ssoName, arn)
 			}
-			profileUniqueCheck[profile] = []string{ssoName, role.Arn}
+			profileUniqueCheck[profile] = []string{ssoName, arn}
 		}
 	}
 

--- a/internal/sso/settings.go
+++ b/internal/sso/settings.go
@@ -497,22 +497,22 @@ func (s *Settings) GetSSOProfiles(ssoName string) (*ProfileMap, error) {
 	return &profiles, nil
 }
 
-// UniqueCheck verifies that all of the profiles are unique
+// UniqueCheck verifies that all of the profiles are unique.
+// Only checks profiles that are actually in the ProfileMap rather than
+// iterating over all cached SSO instances, which could produce false
+// duplicates when the ProfileFormat includes {{ .SSO }}.
 func (p *ProfileMap) UniqueCheck(s *Settings) error {
 	profileUniqueCheck := map[string][]string{} // ProfileName() => Arn
 
-	for ssoName, sso := range s.Cache.SSO {
-		for _, role := range sso.Roles.GetAllRoles() {
-			profile, err := role.ProfileName(s)
-			if err != nil {
-				return err
-			}
+	for ssoName, roles := range *p {
+		for arn, config := range roles {
+			profile := config.Profile
 
 			if match, duplicate := profileUniqueCheck[profile]; duplicate {
 				return fmt.Errorf("duplicate profile name '%s' for:\n%s: %s\n%s: %s",
-					profile, match[0], match[1], ssoName, role.Arn)
+					profile, match[0], match[1], ssoName, arn)
 			}
-			profileUniqueCheck[profile] = []string{ssoName, role.Arn}
+			profileUniqueCheck[profile] = []string{ssoName, arn}
 		}
 	}
 

--- a/internal/sso/settings_test.go
+++ b/internal/sso/settings_test.go
@@ -301,19 +301,21 @@ func (suite *SettingsTestSuite) TestGetAllProfiles() {
 	assert.False(t, profiles.IsDuplicate("testing"))
 	assert.True(t, profiles.IsDuplicate("Log archive/AWSAdministratorAccess"))
 
+	// UniqueCheck detects duplicates in the ProfileMap itself
+	dupProfiles := ProfileMap{
+		"sso1": map[string]ProfileConfig{
+			"arn:aws:iam::111111111111:role/Admin": {Profile: "same-profile", Sso: "sso1"},
+		},
+		"sso2": map[string]ProfileConfig{
+			"arn:aws:iam::222222222222:role/Admin": {Profile: "same-profile", Sso: "sso2"},
+		},
+	}
+	assert.Error(t, dupProfiles.UniqueCheck(suite.settings))
+
 	oldFormat := suite.settings.ProfileFormat
-	// generates duplicates
-	suite.settings.ProfileFormat = "{{ .AccountId }}"
-	assert.Error(t, profiles.UniqueCheck(suite.settings))
-
-	// unable to generate a profile
-	suite.settings.ProfileFormat = "{{ .UniqueCheckFailure }}"
-	assert.Error(t, profiles.UniqueCheck(suite.settings))
-
 	suite.settings.ProfileFormat = "{{ .GetAllProfilesFailure }}"
 	_, err = suite.settings.GetAllProfiles()
 	assert.Error(t, err)
-
 	suite.settings.ProfileFormat = oldFormat
 }
 

--- a/internal/sso/settings_test.go
+++ b/internal/sso/settings_test.go
@@ -299,19 +299,21 @@ func (suite *SettingsTestSuite) TestGetAllProfiles() {
 	assert.False(t, profiles.IsDuplicate("testing"))
 	assert.True(t, profiles.IsDuplicate("Log archive/AWSAdministratorAccess"))
 
+	// UniqueCheck detects duplicates in the ProfileMap itself
+	dupProfiles := ProfileMap{
+		"sso1": map[string]ProfileConfig{
+			"arn:aws:iam::111111111111:role/Admin": {Profile: "same-profile", Sso: "sso1"},
+		},
+		"sso2": map[string]ProfileConfig{
+			"arn:aws:iam::222222222222:role/Admin": {Profile: "same-profile", Sso: "sso2"},
+		},
+	}
+	assert.Error(t, dupProfiles.UniqueCheck(suite.settings))
+
 	oldFormat := suite.settings.ProfileFormat
-	// generates duplicates
-	suite.settings.ProfileFormat = "{{ .AccountId }}"
-	assert.Error(t, profiles.UniqueCheck(suite.settings))
-
-	// unable to generate a profile
-	suite.settings.ProfileFormat = "{{ .UniqueCheckFailure }}"
-	assert.Error(t, profiles.UniqueCheck(suite.settings))
-
 	suite.settings.ProfileFormat = "{{ .GetAllProfilesFailure }}"
 	_, err = suite.settings.GetAllProfiles()
 	assert.Error(t, err)
-
 	suite.settings.ProfileFormat = oldFormat
 }
 


### PR DESCRIPTION
## Summary

- `ProfileMap.UniqueCheck()` was iterating over all cached SSO instances (`s.Cache.SSO`) instead of only the profiles actually contained in the `ProfileMap`
- This caused false "duplicate profile name" errors when multiple SSO instances had accounts with the same alias and role name, even when the `ProfileFormat` included `{{ .SSO }}` which would produce unique profile names per SSO instance
- Fixed by checking uniqueness against the already-generated profiles in the `ProfileMap` rather than re-deriving them from all cached SSOs

## Reproduction

AWS Organizations commonly have accounts with identical names across different organizations — e.g. `Organisation`, `Log Archive`, `Audit`, or `Security`. When a user has multiple SSO instances configured and these accounts share the same role (e.g. `AdministratorAccess` or `ReadOnly`), running:

    aws-sso setup profiles -S my-sso

Produces a false duplicate error like:

    FATAL duplicate profile name ':Organisation:AdministratorAccess' for:
    sso-a: arn:aws:iam::111111111111:role/AdministratorAccess
    sso-b: arn:aws:iam::222222222222:role/AdministratorAccess

Even though the `ProfileFormat` `{{ .SSO }}:...` should generate distinct names like `sso-a:Organisation:AdministratorAccess` vs `sso-b:Organisation:AdministratorAccess`.

The root cause is twofold:
1. `UniqueCheck` iterated over all cached SSOs, not just the one being generated
2. Because `Roles.ssoName` was not set for the other SSO instances, `{{ .SSO }}` resolved to an empty string, making the profiles appear identical

## Test plan

- [x] Updated tests in `internal/sso/settings_test.go` to validate duplicate detection within the ProfileMap
- [x] Updated tests in `internal/awsconfig/config_test.go` to reflect that cross-SSO profiles should not conflict
- [x] All existing tests pass (`go test ./internal/...`)