### PR TITLE
Fix device auth post PKCE / refresh tokens

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -47,14 +47,15 @@ configuration option.
 
 ### Should I use `AuthWorkflow: device_code` or `AuthWorkflow: pkce`?
 
-Most users should start with `AuthWorkflow: pkce` because it is now the
-default. `aws-sso` opens the authorization URL, starts a temporary loopback
+Most users should start with `AuthWorkflow: pkce` because it is faster and more secure.
+With PKCE `aws-sso` opens the authorization URL in your browser, starts a temporary loopback
 listener on `127.0.0.1`, validates the returned `state`, and exchanges the code
 for tokens automatically.
 
 `AuthWorkflow: device_code` is **not recommended** — its short verification
 code is not bound to the initiating session, making it vulnerable to
-device code phishing and requires more human involvement.
+[device code phishing](https://blog.christophetd.fr/pkce-aws-sso/)
+and requires more human involvement.
 
 However, `device_code` is the correct choice for remote or headless environments where
 `aws-sso` does not run on the same machine as the browser, since PKCE relies

--- a/internal/sso/auth/awssso_auth.go
+++ b/internal/sso/auth/awssso_auth.go
@@ -51,6 +51,21 @@ const (
 // ValidAuthToken returns true if we have a valid AWS SSO authentication token
 // or false if we need to authenticate.
 func (as *AWSSSO) ValidAuthToken() bool {
+	log.Trace("ValidAuthToken()", "storeKey", as.StoreKey())
+	// First verify the stored registration supports refresh tokens. Old
+	// registrations (or those written before GrantTypes was persisted) won't
+	// have "refresh_token" and must re-register to get a refresh-capable token.
+	clientData := storage.RegisterClientData{}
+	if err := as.store.GetRegisterClientData(as.StoreKey(), &clientData); err != nil || !clientData.SupportsAuthorizationCode() {
+		// always add refresh token support, even if we are using device_code
+		log.Debug("Cached SSO registration lacks PKCE authorization_code support. Forcing device authentication...")
+		err = as.store.DeleteRegisterClientData(as.StoreKey())
+		if err != nil {
+			log.Error("unable to delete RegisterClientData from secure store", "storeKey", as.StoreKey(), "error", err.Error())
+		}
+		return false
+	}
+
 	// check our cache
 	token := storage.CreateTokenResponse{}
 	err := as.store.GetCreateTokenResponse(as.StoreKey(), &token)
@@ -59,6 +74,7 @@ func (as *AWSSSO) ValidAuthToken() bool {
 		return false
 	}
 
+	// happy path
 	if !token.Expired() {
 		as.tokenLock.Lock()
 		as.Token = token
@@ -127,7 +143,7 @@ func (as *AWSSSO) registerClient(force bool) error {
 		log.Trace("Checking cache for RegisterClientData", "storeKey", as.StoreKey())
 		err := as.store.GetRegisterClientData(as.StoreKey(), &as.ClientData)
 		if err == nil && !as.ClientData.Expired() {
-			log.Debug("Using RegisterClient cache", "storeKey", as.StoreKey())
+			log.Debug("Using RegisterClient from secure store", "storeKey", as.StoreKey())
 			return nil
 		}
 	}
@@ -150,6 +166,9 @@ func (as *AWSSSO) registerClient(force bool) error {
 	log.Trace("Registered new client with AWS SSO", "ClientId", resp.ClientId, "ClientSecretExpiresAt", resp.ClientSecretExpiresAt)
 
 	as.ClientData = resp
+	// AWS does not echo back the grant types we registered with, so we record
+	// them ourselves so ValidAuthToken() can check for refresh_token support.
+	as.ClientData.GrantTypes = as.GrantTypes()
 	log.Trace("SaveRegisterClientData start", "storeKey", as.StoreKey())
 	err = as.store.SaveRegisterClientData(as.StoreKey(), as.ClientData)
 	if err != nil {
@@ -216,7 +235,7 @@ func (as *AWSSSO) createToken() error {
 			ClientID:     as.ClientData.ClientId,
 			ClientSecret: as.ClientData.ClientSecret,
 			DeviceCode:   as.DeviceAuth.DeviceCode,
-			GrantType:    oidc.GrantTypeDeviceCode,
+			GrantType:    storage.GrantTypeDeviceCode,
 		},
 		RetryInterval: retryInterval,
 		SlowDown:      slowDown,
@@ -239,6 +258,8 @@ func (as *AWSSSO) saveToken(token storage.CreateTokenResponse) error {
 	return nil
 }
 
+// getAuthWorkflow returns the AuthWorkflow to use for this AWSSSO instance, defaulting
+// to PKCE if not set.
 func (as *AWSSSO) getAuthWorkflow() oidc.AuthWorkflow {
 	if as.SSOConfig == nil {
 		return oidc.AuthWorkflowPKCE
@@ -246,11 +267,29 @@ func (as *AWSSSO) getAuthWorkflow() oidc.AuthWorkflow {
 	return as.SSOConfig.AuthWorkflow.OrDefault()
 }
 
+// GrantTypes returns the list of GrantTypes to request in our OIDC client registration, based
+// on the AuthWorkflow.
+func (as *AWSSSO) GrantTypes() []storage.GrantType {
+	log.Debug("GrantTypes()", "authWorkflow", as.getAuthWorkflow())
+	// for now we always return both grant types.
+	return []storage.GrantType{storage.GrantTypeAuthorizationCode, storage.GrantTypeDeviceCode}
+	/*
+		if as.getAuthWorkflow() == oidc.AuthWorkflowDeviceCode {
+			// Device code flow uses device_code to get the initial token; also include
+			// authorization_code so subsequent calls can renew without re-authenticating.
+		}
+		// Default code flow only needs authorization_code support.
+		return []storage.GrantType{storage.GrantTypeAuthorizationCode}
+	*/
+}
+
 func (as *AWSSSO) authGrantTypes() []string {
-	if as.getAuthWorkflow() == oidc.AuthWorkflowPKCE {
-		return []string{"refresh_token", oidc.GrantTypeAuthorizationCode}
+	grantTypes := []string{}
+	for _, gt := range as.GrantTypes() {
+		grantTypes = append(grantTypes, string(gt))
 	}
-	return []string{"refresh_token"}
+	log.Debug("authGrantTypes()", "grantTypes", grantTypes)
+	return grantTypes
 }
 
 // pkceRedirectURIBase is used in RegisterClient (no port, no path per RFC 8252 §7.3)

--- a/internal/sso/auth/awssso_auth_test.go
+++ b/internal/sso/auth/awssso_auth_test.go
@@ -106,12 +106,14 @@ func TestStoreKey(t *testing.T) {
 
 func TestAuthWorkflowSelection(t *testing.T) {
 	as := &AWSSSO{}
-	assert.Equal(t, oidc.AuthWorkflowPKCE, as.getAuthWorkflow())
-	assert.Equal(t, []string{"refresh_token", oidc.GrantTypeAuthorizationCode}, as.authGrantTypes())
+	assert.Equal(t, as.getAuthWorkflow(), oidc.AuthWorkflowPKCE)
+	assert.Equal(t, as.authGrantTypes(), []string{string(storage.GrantTypeAuthorizationCode), string(storage.GrantTypeDeviceCode)})
+	assert.Equal(t, as.GrantTypes(), []storage.GrantType{storage.GrantTypeAuthorizationCode, storage.GrantTypeDeviceCode})
 
 	as.SSOConfig = &ssoconfig.SSOConfig{AuthWorkflow: oidc.AuthWorkflowDeviceCode}
-	assert.Equal(t, oidc.AuthWorkflowDeviceCode, as.getAuthWorkflow())
-	assert.Equal(t, []string{"refresh_token"}, as.authGrantTypes())
+	assert.Equal(t, as.getAuthWorkflow(), oidc.AuthWorkflowDeviceCode)
+	assert.Equal(t, as.authGrantTypes(), []string{string(storage.GrantTypeAuthorizationCode), string(storage.GrantTypeDeviceCode)})
+	assert.Equal(t, as.GrantTypes(), []storage.GrantType{storage.GrantTypeAuthorizationCode, storage.GrantTypeDeviceCode})
 }
 
 func TestAuthenticateSteps(t *testing.T) {
@@ -320,6 +322,7 @@ func TestAuthenticate(t *testing.T) {
 		},
 	})
 
+	as.ValidAuthToken()
 	assert.False(t, as.ValidAuthToken())
 
 	err = as.Authenticate("print", "fake-browser")
@@ -398,6 +401,16 @@ func TestValidAuthToken(t *testing.T) {
 	token.ExpiresIn = int32(^int(0) >> 1)
 	token.ExpiresAt = 99999999999
 	err = jstore.SaveCreateTokenResponse(key, token)
+	assert.NoError(t, err)
+
+	// ValidAuthToken also requires a stored RegisterClientData with refresh_token support.
+	clientData := storage.RegisterClientData{
+		ClientId:              "test-client-id",
+		ClientSecret:          "test-client-secret",
+		ClientSecretExpiresAt: 99999999999,
+		GrantTypes:            []storage.GrantType{storage.GrantTypeAuthorizationCode},
+	}
+	err = jstore.SaveRegisterClientData(key, clientData)
 	assert.NoError(t, err)
 	assert.True(t, as.ValidAuthToken())
 }
@@ -861,7 +874,7 @@ func TestRegisterClientPKCE(t *testing.T) {
 		in := mock.registerClientInputs[0]
 		assert.Equal(t, []string{"sso:account:access"}, in.Scopes)
 		assert.Equal(t, []string{"http://127.0.0.1"}, in.RedirectUris)
-		assert.Contains(t, in.GrantTypes, oidc.GrantTypeAuthorizationCode)
+		assert.Contains(t, in.GrantTypes, string(storage.GrantTypeAuthorizationCode))
 	}
 }
 

--- a/internal/sso/oidc/client.go
+++ b/internal/sso/oidc/client.go
@@ -74,7 +74,7 @@ func (c *AWSClient) CreateToken(ctx context.Context, in CreateTokenInput) (stora
 	input := &ssooidc.CreateTokenInput{
 		ClientId:     aws.String(in.ClientID),
 		ClientSecret: aws.String(in.ClientSecret),
-		GrantType:    aws.String(in.GrantType),
+		GrantType:    aws.String(string(in.GrantType)),
 	}
 	if in.DeviceCode != "" {
 		input.DeviceCode = aws.String(in.DeviceCode)

--- a/internal/sso/oidc/pkce.go
+++ b/internal/sso/oidc/pkce.go
@@ -92,7 +92,7 @@ func (c *AWSClient) ExchangePKCEAuthCode(ctx context.Context, in ExchangePKCEAut
 	return c.CreateToken(ctx, CreateTokenInput{
 		ClientID:     in.ClientID,
 		ClientSecret: in.ClientSecret,
-		GrantType:    GrantTypeAuthorizationCode,
+		GrantType:    storage.GrantTypeAuthorizationCode,
 		Code:         in.Code,
 		CodeVerifier: in.CodeVerifier,
 		RedirectURI:  in.RedirectURI,

--- a/internal/sso/oidc/pkce_test.go
+++ b/internal/sso/oidc/pkce_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
 	"github.com/stretchr/testify/assert"
+	"github.com/synfinatic/aws-sso-cli/internal/storage"
 )
 
 func TestStartPKCEAuthCodeFlow(t *testing.T) {
@@ -120,7 +121,7 @@ func TestExchangePKCEAuthCode(t *testing.T) {
 		assert.Equal(t, "access-token", out.AccessToken)
 		if assert.Len(t, api.createTokenInputs, 1) {
 			in := api.createTokenInputs[0]
-			assert.Equal(t, GrantTypeAuthorizationCode, aws.ToString(in.GrantType))
+			assert.Equal(t, string(storage.GrantTypeAuthorizationCode), aws.ToString(in.GrantType))
 			assert.Equal(t, "auth-code", aws.ToString(in.Code))
 			assert.Equal(t, "pkce-verifier", aws.ToString(in.CodeVerifier))
 			assert.Equal(t, "http://localhost:12345/callback", aws.ToString(in.RedirectUri))

--- a/internal/sso/oidc/types.go
+++ b/internal/sso/oidc/types.go
@@ -29,8 +29,6 @@ type Client interface {
 }
 
 const (
-	GrantTypeDeviceCode         = "urn:ietf:params:oauth:grant-type:device_code"
-	GrantTypeAuthorizationCode  = "authorization_code"
 	PKCECodeChallengeMethodS256 = "S256"
 
 	defaultCodeVerifierBytes = 48
@@ -86,7 +84,7 @@ type StartDeviceAuthorizationInput struct {
 type CreateTokenInput struct {
 	ClientID     string
 	ClientSecret string // nolint:gosec
-	GrantType    string
+	GrantType    storage.GrantType
 	DeviceCode   string
 	Code         string
 	CodeVerifier string

--- a/internal/storage/json_store_test.go
+++ b/internal/storage/json_store_test.go
@@ -100,6 +100,7 @@ func (s *JsonStoreTestSuite) TestRegisterClientData() {
 		ClientIdIssuedAt:      1629947379,
 		ClientSecret:          "not a real secret",
 		ClientSecretExpiresAt: 1637723379,
+		GrantTypes:            []GrantType{GrantTypeDeviceCode},
 	}
 	assert.Equal(t, rcdTest, rcd)
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -20,6 +20,7 @@ package storage
 
 import (
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"reflect"
@@ -37,14 +38,51 @@ func init() {
 	log = logger.GetLogger()
 }
 
+type GrantType string
+
+const (
+	GrantTypeDeviceCode        GrantType = "urn:ietf:params:oauth:grant-type:device_code"
+	GrantTypeAuthorizationCode GrantType = "authorization_code" // aka PKCE
+	GrantTypeRefreshToken      GrantType = "refresh_token"      // unused
+)
+
 // this struct should be cached for long term if possible
 type RegisterClientData struct {
-	AuthorizationEndpoint string `json:"authorizationEndpoint,omitempty"`
-	ClientId              string `json:"clientId"`
-	ClientIdIssuedAt      int64  `json:"clientIdIssuedAt"`
-	ClientSecret          string `json:"clientSecret"` // nolint:gosec
-	ClientSecretExpiresAt int64  `json:"clientSecretExpiresAt"`
-	TokenEndpoint         string `json:"tokenEndpoint,omitempty"`
+	AuthorizationEndpoint string      `json:"authorizationEndpoint,omitempty"`
+	ClientId              string      `json:"clientId"`
+	ClientIdIssuedAt      int64       `json:"clientIdIssuedAt"`
+	ClientSecret          string      `json:"clientSecret"` // nolint:gosec
+	ClientSecretExpiresAt int64       `json:"clientSecretExpiresAt"`
+	TokenEndpoint         string      `json:"tokenEndpoint,omitempty"`
+	GrantTypes            []GrantType `json:"grantTypes,omitempty"`
+}
+
+// UnmarshalJSON implements json.Unmarshaler. If GrantTypes is absent or empty
+// in stored JSON (written by older versions of aws-sso-cli), it defaults to
+// ["device_code"] — which does NOT include "authorization_code", so stale
+// registrations will trigger a transparent one-time re-auth.
+func (r *RegisterClientData) UnmarshalJSON(b []byte) error {
+	type plain RegisterClientData // break recursion
+	var tmp plain
+	if err := json.Unmarshal(b, &tmp); err != nil {
+		return err
+	}
+	*r = RegisterClientData(tmp)
+	if len(r.GrantTypes) == 0 {
+		r.GrantTypes = []GrantType{GrantTypeDeviceCode}
+	}
+	return nil
+}
+
+// SupportsAuthorizationCode returns true if the registration includes the
+// "authorization_code" grant type.
+func (r *RegisterClientData) SupportsAuthorizationCode() bool {
+	for _, gt := range r.GrantTypes {
+		if gt == GrantTypeAuthorizationCode {
+			return true
+		}
+	}
+	return false
 }
 
 // Expired returns true if it has expired or will in the next hour

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -19,6 +19,7 @@ package storage
  */
 
 import (
+	"encoding/json"
 	"os"
 	"testing"
 	"time"
@@ -60,6 +61,42 @@ func TestRegisterClientDataExpired(t *testing.T) {
 
 	tr.ClientSecretExpiresAt = time.Now().Unix() + 60*60 + 1
 	assert.False(t, tr.Expired())
+}
+
+func TestRegisterClientDataUnmarshalJSON(t *testing.T) {
+	// Old JSON with no grantTypes field should default to ["authorization_code"]
+	old := []byte(`{"clientId":"cid","clientIdIssuedAt":0,"clientSecret":"sec","clientSecretExpiresAt":9999999999}`)
+	var r RegisterClientData
+	assert.NoError(t, json.Unmarshal(old, &r))
+	assert.Equal(t, []GrantType{GrantTypeDeviceCode}, r.GrantTypes)
+	assert.False(t, r.SupportsAuthorizationCode())
+
+	// Explicit empty array should also get the default
+	empty := []byte(`{"clientId":"cid","clientIdIssuedAt":0,"clientSecret":"sec","clientSecretExpiresAt":9999999999,"grantTypes":[]}`)
+	var r2 RegisterClientData
+	assert.NoError(t, json.Unmarshal(empty, &r2))
+	assert.Equal(t, []GrantType{GrantTypeDeviceCode}, r2.GrantTypes)
+	assert.False(t, r2.SupportsAuthorizationCode())
+
+	// JSON with refresh_token present
+	withRefresh := []byte(`{"clientId":"cid","clientIdIssuedAt":0,"clientSecret":"sec","clientSecretExpiresAt":9999999999,"grantTypes":["refresh_token","authorization_code"]}`)
+	var r3 RegisterClientData
+	assert.NoError(t, json.Unmarshal(withRefresh, &r3))
+	assert.True(t, r3.SupportsAuthorizationCode())
+}
+
+func TestRegisterClientDataSupportsAuthorizationCode(t *testing.T) {
+	r := &RegisterClientData{}
+	assert.False(t, r.SupportsAuthorizationCode())
+
+	r.GrantTypes = []GrantType{GrantTypeAuthorizationCode}
+	assert.True(t, r.SupportsAuthorizationCode())
+
+	r.GrantTypes = []GrantType{GrantTypeDeviceCode}
+	assert.False(t, r.SupportsAuthorizationCode())
+
+	r.GrantTypes = []GrantType{GrantTypeDeviceCode, GrantTypeAuthorizationCode}
+	assert.True(t, r.SupportsAuthorizationCode())
 }
 
 func TestRoleCredentialsExpired(t *testing.T) {


### PR DESCRIPTION
Basically the grant type supported in the device auth was only for the old token and we need to force a device auth refresh, else the user will get an authorizied error after upgrading to 2.2.x+