### PR TITLE
Manage AWS_REGION

### DIFF
--- a/cmd/aws-sso/eval_cmd.go
+++ b/cmd/aws-sso/eval_cmd.go
@@ -35,7 +35,7 @@ type EvalCmd struct {
 	Profile   string `kong:"short='p',help='Name of AWS Profile to assume',predictor='profile'"`
 
 	Clear    bool   `kong:"short='c',help='Generate \"unset XXXX\" commands to clear environment'"`
-	NoRegion bool   `kong:"short='n',help='Do not set/clear AWS_DEFAULT_REGION from config.yaml'"`
+	NoRegion bool   `kong:"short='n',help='Do not set/clear AWS_DEFAULT_REGION/AWS_REGION from config.yaml'"`
 	Refresh  bool   `kong:"short='r',help='Refresh current IAM credentials'"`
 	EnvArn   string `kong:"hidden,env='AWS_SSO_ROLE_ARN'"` // used for refresh
 }
@@ -126,11 +126,15 @@ func unsetEnvVars(ctx *RunContext) error {
 
 	// clear the region if
 	// 1. User did not specify --no-region AND
-	// 2. The AWS_DEFAULT_REGION is managed by us (tracks AWS_SSO_DEFAULT_REGION)
+	// 2. The AWS_DEFAULT_REGION/AWS_REGION is managed by us (tracks AWS_SSO_DEFAULT_REGION)
 	if !ctx.Cli.Eval.NoRegion && os.Getenv("AWS_DEFAULT_REGION") == os.Getenv("AWS_SSO_DEFAULT_REGION") {
 		envs = append(envs, "AWS_DEFAULT_REGION")
+		envs = append(envs, "AWS_REGION")
 		envs = append(envs, "AWS_SSO_DEFAULT_REGION")
 	} else if os.Getenv("AWS_DEFAULT_REGION") != os.Getenv("AWS_SSO_DEFAULT_REGION") {
+		// clear the tracking variable if we don't match
+		envs = append(envs, "AWS_SSO_DEFAULT_REGION")
+	} else if os.Getenv("AWS_REGION") != os.Getenv("AWS_SSO_DEFAULT_REGION") {
 		// clear the tracking variable if we don't match
 		envs = append(envs, "AWS_SSO_DEFAULT_REGION")
 	}

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -87,26 +87,27 @@ source_profile = NameOfAwsSsoCliProfile
 And generate the necessary AWS SSO CLI profile entries via
 [aws-sso config-profiles](commands.md#config-profiles) command.
 
-### How does AWS SSO CLI manage the $AWS\_DEFAULT\_REGION?
+### How does AWS SSO CLI manage the $AWS\_DEFAULT\_REGION / $AWS\_REGION?
 
-AWS SSO will leave the `$AWS_DEFAULT_REGION` environment variable alone
+AWS SSO will leave the `$AWS_DEFAULT_REGION` and `$AWS_REGION` environment variables alone
 unless the following are all true:
 
-* The `$AWS_DEFAULT_REGION` is not already defined in your shell
+* The `$AWS_DEFAULT_REGION` and `$AWS_REGION` is not already defined in your shell
 * You have specified the region in the `config.yaml` via `DefaultRegion`
 * You have not set the `--no-region` flag on the CLI
-* If `$AWS_SSO_DEFAULT_REGION` is set, does it match `$AWS_DEFAULT_REGION?`
+* If `$AWS_SSO_DEFAULT_REGION` is set, does it match `$AWS_DEFAULT_REGION` or `$AWS_REGION`?
 
-If the above are true, then AWS SSO will define both:
+If the above are true, then AWS SSO will define:
 
+* `$AWS_REGION`
 * `$AWS_DEFAULT_REGION`
 * `$AWS_SSO_DEFAULT_REGION`
 
 to the default region as defined by `config.yaml`.  If the user changes
 roles and the two variables are set to the same region, then AWS SSO will
 update the region.   If the user ever overrides the `$AWS_DEFAULT_REGION`
-value or deletes the `$AWS_SSO_DEFAULT_REGION` then AWS SSO will no longer
-manage the variable.
+or `$AWS_REGION` value or deletes the `$AWS_SSO_DEFAULT_REGION` then AWS
+SSO will no longer manage the variable.
 
 <!-- https://github.com/synfinatic/aws-sso-cli/issues/166 -->
 ![graph](https://user-images.githubusercontent.com/1075352/143502947-1465f68f-0ef5-4de7-a997-ea716facc637.png)

--- a/docs/config.md
+++ b/docs/config.md
@@ -130,8 +130,8 @@ The `SSORegion` is required.
 ### DefaultRegion
 
 The `DefaultRegion` allows you to define a value for the `$AWS_DEFAULT_REGION`
-when switching to a role.  Note that, aws-sso will NEVER change an existing
-`$AWS_DEFAULT_REGION` set by the user.
+and `$AWS_REGION` when switching to a role.  Note that, aws-sso will NEVER change an existing
+`$AWS_DEFAULT_REGION` or `$AWS_REGION` set by the user.
 
 `DefaultRegion` can be specified at the following levels and the first match is
 selected (most specific to most generic):

--- a/internal/sso/settings.go
+++ b/internal/sso/settings.go
@@ -94,10 +94,13 @@ func (s *Settings) GetDefaultRegion(id int64, roleName string, noRegion bool) st
 	}
 
 	currentRegion := os.Getenv("AWS_DEFAULT_REGION")
+	if len(currentRegion) == 0 {
+		currentRegion = os.Getenv("AWS_REGION")
+	}
 	ssoManagedRegion := os.Getenv("AWS_SSO_DEFAULT_REGION")
 
 	if len(currentRegion) > 0 && currentRegion != ssoManagedRegion {
-		log.Debug("Will not override current AWS_DEFAULT_REGION", "region", currentRegion)
+		log.Debug("Will not override current AWS_DEFAULT_REGION/AWS_REGION", "region", currentRegion)
 		return ""
 	}
 

--- a/internal/sso/settings_test.go
+++ b/internal/sso/settings_test.go
@@ -235,6 +235,7 @@ func (suite *SettingsTestSuite) TestSave() {
 
 func clearEnv() {
 	os.Setenv("AWS_DEFAULT_REGION", "")
+	os.Setenv("AWS_REGION", "")
 	os.Setenv("AWS_SSO_DEFAULT_REGION", "")
 }
 
@@ -253,6 +254,12 @@ func (suite *SettingsTestSuite) TestGetDefaultRegion() {
 	assert.Equal(t, "", suite.settings.GetDefaultRegion(833365043586, "AWSAdministratorAccess:", true))
 
 	os.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+	assert.Equal(t, "", suite.settings.GetDefaultRegion(258234615182, "AWSAdministratorAccess", false))
+	assert.Equal(t, "", suite.settings.GetDefaultRegion(258234615182, "LimitedAccess", false))
+	assert.Equal(t, "", suite.settings.GetDefaultRegion(833365043586, "AWSAdministratorAccess:", false))
+
+	clearEnv()
+	os.Setenv("AWS_REGION", "us-east-1")
 	assert.Equal(t, "", suite.settings.GetDefaultRegion(258234615182, "AWSAdministratorAccess", false))
 	assert.Equal(t, "", suite.settings.GetDefaultRegion(258234615182, "LimitedAccess", false))
 	assert.Equal(t, "", suite.settings.GetDefaultRegion(833365043586, "AWSAdministratorAccess:", false))


### PR DESCRIPTION
AWS has decided that AWS_REGION is the new hotness and replacing AWS_DEFAULT_REGION.  So we should support it.

Fixes: #1277