### PR TITLE
fix: restore device_code RegisterClient grant types broken in 2.2.x

### DIFF
--- a/internal/sso/auth/awssso_auth.go
+++ b/internal/sso/auth/awssso_auth.go
@@ -57,8 +57,8 @@ func (as *AWSSSO) ValidAuthToken() bool {
 	// have "refresh_token" and must re-register to get a refresh-capable token.
 	clientData := storage.RegisterClientData{}
 	if err := as.store.GetRegisterClientData(as.StoreKey(), &clientData); err == nil {
-		if !clientData.SupportsAuthorizationCode() || !clientData.SupportsRefreshToken() {
-			// always add refresh token support, even if we are using device_code
+		if as.getAuthWorkflow() == oidc.AuthWorkflowPKCE &&
+			(!clientData.SupportsAuthorizationCode() || !clientData.SupportsRefreshToken()) {
 			log.Debug("client registration lacks necessary grant types; forcing new registration", "storeKey", as.StoreKey())
 			err = as.store.DeleteRegisterClientData(as.StoreKey())
 			if err != nil {
@@ -304,16 +304,11 @@ func (as *AWSSSO) getAuthWorkflow() oidc.AuthWorkflow {
 // on the AuthWorkflow.
 func (as *AWSSSO) GrantTypes() []storage.GrantType {
 	log.Debug("GrantTypes()", "authWorkflow", as.getAuthWorkflow())
-	// for now we always return both grant types.
-	return []storage.GrantType{storage.GrantTypeAuthorizationCode, storage.GrantTypeDeviceCode, storage.GrantTypeRefreshToken}
-	/*
-		if as.getAuthWorkflow() == oidc.AuthWorkflowDeviceCode {
-			// Device code flow uses device_code to get the initial token; also include
-			// authorization_code so subsequent calls can renew without re-authenticating.
-		}
-		// Default code flow only needs authorization_code support.
-		return []storage.GrantType{storage.GrantTypeAuthorizationCode}
-	*/
+	if as.getAuthWorkflow() == oidc.AuthWorkflowDeviceCode {
+		// device_code flow: match pre-2.2.0 behaviour — AWS SSO rejects authorization_code here
+		return []storage.GrantType{storage.GrantTypeRefreshToken}
+	}
+	return []storage.GrantType{storage.GrantTypeAuthorizationCode, storage.GrantTypeRefreshToken}
 }
 
 func (as *AWSSSO) authGrantTypes() []string {


### PR DESCRIPTION
## Summary

Fixes #1359

In 2.2.x, \`GrantTypes()\` unconditionally returns \`[authorization_code, device_code, refresh_token]\` for all auth workflows. AWS SSO rejects this combination for \`device_code\` \`RegisterClient\` calls with \`InvalidScopeException\`, breaking headless users who cannot use PKCE (browser and CLI on different machines).

The bug may have been difficult to catch in testing — upgrading from 2.1.0 with an existing cached client registration causes 2.2.x to reuse the old registration for the first login. The \`InvalidScopeException\` only surfaces after the cache is cleared and a fresh \`RegisterClient\` is required.

## Changes

**\`internal/sso/auth/awssso_auth.go\`**

**Fix 1 — \`GrantTypes()\`**: For \`device_code\` workflow, return only \`[refresh_token]\`, matching pre-2.2.0 behaviour that AWS SSO accepts. PKCE continues to use \`[authorization_code, refresh_token]\`.

**Fix 2 — \`ValidAuthToken()\`**: Previously forced re-registration if the cached client registration lacked \`authorization_code\` or \`refresh_token]\`, even for \`device_code\` workflow. This caused \`list\`, \`eval\`, and other commands to silently fail after a successful login. Now only enforces PKCE-specific grant type requirements when the workflow is actually PKCE.

## Testing

Tested against one native AWS IAM Identity Center instance with \`AuthWorkflow: device_code\`. Fresh cache, full login and role cache population confirmed working.

\`\`\`
DEBUG GrantTypes() authWorkflow=device_code
DEBUG authGrantTypes() grantTypes=[refresh_token]
DEBUG Created OIDC device code storeKey=... expires=600
...
INFO  Updated cache added=45 deleted=0
\`\`\`