### PR TITLE
Support device_code or authorization_code, not both

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v2.2.2] - 2026-05-17
+
+### Bugs
+
+* Force device registration with device_code or authorization_code, not both #1359
+
 ## [v2.2.1] - 2026-05-16
 
 ### Bugs
@@ -889,7 +895,8 @@
 Initial release
 
 <!-- markdownlint-disable-next-line MD053 -->
-[Unreleased]: https://github.com/synfinatic/aws-sso-cli/compare/v2.2.1...main
+[Unreleased]: https://github.com/synfinatic/aws-sso-cli/compare/v2.2.2...main
+[v2.2.2]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v2.2.2
 [v2.2.1]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v2.2.1
 [v2.2.0]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v2.2.0
 [v2.1.0]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v2.1.0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT_VERSION        := 2.2.1
+PROJECT_VERSION        := 2.2.2
 DOCKER_REPO            := synfinatic
 PROJECT_NAME           := aws-sso
 DOCKER_PROJECT_NAME    := aws-sso-cli-ecs-server

--- a/internal/sso/auth/awssso_auth.go
+++ b/internal/sso/auth/awssso_auth.go
@@ -34,14 +34,12 @@ import (
 )
 
 const (
-	DEFAULT_AUTH_COLOR = "blue"
-	DEFAULT_AUTH_ICON  = "fingerprint"
-	VERIFY_MSG         = "\n\tVerify this code in your browser: %s\n"
-)
-
-const (
-	awsSSOClientName = "aws-sso-cli"
-	awsSSOClientType = "public"
+	DEFAULT_AUTH_COLOR       = "blue"
+	DEFAULT_AUTH_ICON        = "fingerprint"
+	VERIFY_MSG               = "\n\tVerify this code in your browser: %s\n"
+	SSO_ACCOUNT_ACCESS_SCOPE = "sso:account:access"
+	awsSSOClientName         = "aws-sso-cli"
+	awsSSOClientType         = "public"
 	// The default values for ODIC defined in:
 	// https://tools.ietf.org/html/draft-ietf-oauth-device-flow-15#section-3.5
 	SLOW_DOWN_SEC  = 5
@@ -57,14 +55,16 @@ func (as *AWSSSO) ValidAuthToken() bool {
 	// have "refresh_token" and must re-register to get a refresh-capable token.
 	clientData := storage.RegisterClientData{}
 	if err := as.store.GetRegisterClientData(as.StoreKey(), &clientData); err == nil {
-		if !clientData.SupportsAuthorizationCode() || !clientData.SupportsRefreshToken() {
-			// always add refresh token support, even if we are using device_code
-			log.Debug("client registration lacks necessary grant types; forcing new registration", "storeKey", as.StoreKey())
-			err = as.store.DeleteRegisterClientData(as.StoreKey())
-			if err != nil {
-				log.Error("unable to delete RegisterClientData from secure store", "storeKey", as.StoreKey(), "error", err.Error())
+		for _, gt := range as.GrantTypes() {
+			if !clientData.SupportsGrantType(gt) {
+				log.Debug("client registration lacks necessary grant types; forcing new registration",
+					"storeKey", as.StoreKey(), "missingGrantType", gt)
+				err = as.store.DeleteRegisterClientData(as.StoreKey())
+				if err != nil {
+					log.Error("unable to delete RegisterClientData from secure store", "storeKey", as.StoreKey(), "error", err.Error())
+				}
+				return false
 			}
-			return false
 		}
 	}
 
@@ -163,8 +163,9 @@ func (as *AWSSSO) reauthenticate() error {
 	case oidc.AuthWorkflowPKCE:
 		return as.reauthenticatePKCE()
 	default:
-		return fmt.Errorf("unsupported auth workflow: %s", as.getAuthWorkflow())
+		log.Fatal("unsupported auth workflow", "workflow", as.getAuthWorkflow())
 	}
+	return nil
 }
 
 // registerClient does the needful to talk to AWS or read our cache to get the
@@ -188,7 +189,7 @@ func (as *AWSSSO) registerClient(force bool) error {
 		IssuerUrl:  as.StartUrl,
 	}
 	if as.getAuthWorkflow() == oidc.AuthWorkflowPKCE {
-		input.Scopes = []string{"sso:account:access"}
+		input.Scopes = []string{SSO_ACCOUNT_ACCESS_SCOPE}
 		input.RedirectUris = []string{as.pkceRedirectURIBase()}
 	}
 	resp, err := as.oidcClient.RegisterClient(context.TODO(), input)
@@ -304,16 +305,15 @@ func (as *AWSSSO) getAuthWorkflow() oidc.AuthWorkflow {
 // on the AuthWorkflow.
 func (as *AWSSSO) GrantTypes() []storage.GrantType {
 	log.Debug("GrantTypes()", "authWorkflow", as.getAuthWorkflow())
-	// for now we always return both grant types.
-	return []storage.GrantType{storage.GrantTypeAuthorizationCode, storage.GrantTypeDeviceCode, storage.GrantTypeRefreshToken}
-	/*
-		if as.getAuthWorkflow() == oidc.AuthWorkflowDeviceCode {
-			// Device code flow uses device_code to get the initial token; also include
-			// authorization_code so subsequent calls can renew without re-authenticating.
-		}
-		// Default code flow only needs authorization_code support.
-		return []storage.GrantType{storage.GrantTypeAuthorizationCode}
-	*/
+	switch as.getAuthWorkflow() {
+	case oidc.AuthWorkflowDeviceCode:
+		return []storage.GrantType{storage.GrantTypeDeviceCode, storage.GrantTypeRefreshToken}
+	case oidc.AuthWorkflowPKCE:
+		return []storage.GrantType{storage.GrantTypeAuthorizationCode, storage.GrantTypeRefreshToken}
+	default:
+		log.Fatal("unsupported auth workflow", "workflow", as.getAuthWorkflow())
+	}
+	return nil
 }
 
 func (as *AWSSSO) authGrantTypes() []string {
@@ -395,7 +395,7 @@ func (as *AWSSSO) reauthenticatePKCE() error {
 		AuthorizationEndpoint: as.pkceAuthorizationEndpoint(),
 		ClientID:              as.ClientData.ClientId,
 		RedirectURI:           redirectURI,
-		Scopes:                []string{"sso:account:access"},
+		Scopes:                []string{SSO_ACCOUNT_ACCESS_SCOPE},
 	})
 	if err != nil {
 		return fmt.Errorf("unable to start pkce authorization with AWS SSO: %w", err)

--- a/internal/sso/auth/awssso_auth_test.go
+++ b/internal/sso/auth/awssso_auth_test.go
@@ -107,13 +107,13 @@ func TestStoreKey(t *testing.T) {
 func TestAuthWorkflowSelection(t *testing.T) {
 	as := &AWSSSO{}
 	assert.Equal(t, as.getAuthWorkflow(), oidc.AuthWorkflowPKCE)
-	assert.Equal(t, as.authGrantTypes(), []string{string(storage.GrantTypeAuthorizationCode), string(storage.GrantTypeDeviceCode), string(storage.GrantTypeRefreshToken)})
-	assert.Equal(t, as.GrantTypes(), []storage.GrantType{storage.GrantTypeAuthorizationCode, storage.GrantTypeDeviceCode, storage.GrantTypeRefreshToken})
+	assert.Equal(t, as.authGrantTypes(), []string{string(storage.GrantTypeAuthorizationCode), string(storage.GrantTypeRefreshToken)})
+	assert.Equal(t, as.GrantTypes(), []storage.GrantType{storage.GrantTypeAuthorizationCode, storage.GrantTypeRefreshToken})
 
 	as.SSOConfig = &ssoconfig.SSOConfig{AuthWorkflow: oidc.AuthWorkflowDeviceCode}
 	assert.Equal(t, as.getAuthWorkflow(), oidc.AuthWorkflowDeviceCode)
-	assert.Equal(t, as.authGrantTypes(), []string{string(storage.GrantTypeAuthorizationCode), string(storage.GrantTypeDeviceCode), string(storage.GrantTypeRefreshToken)})
-	assert.Equal(t, as.GrantTypes(), []storage.GrantType{storage.GrantTypeAuthorizationCode, storage.GrantTypeDeviceCode, storage.GrantTypeRefreshToken})
+	assert.Equal(t, as.authGrantTypes(), []string{string(storage.GrantTypeDeviceCode), string(storage.GrantTypeRefreshToken)})
+	assert.Equal(t, as.GrantTypes(), []storage.GrantType{storage.GrantTypeDeviceCode, storage.GrantTypeRefreshToken})
 }
 
 func TestAuthenticateSteps(t *testing.T) {
@@ -362,24 +362,26 @@ func TestAuthenticate(t *testing.T) {
 	_ = as.Authenticate(uri.Undef, "fake-browser")
 }
 
-func TestValidAuthToken(t *testing.T) {
+func authTokenSetup(t *testing.T, workflow oidc.AuthWorkflow) (as *AWSSSO, key string, jstore storage.SecureStorage) {
 	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
-	jstore, err := storage.OpenJsonStore(tfile.Name())
+	jstore, err = storage.OpenJsonStore(tfile.Name())
 	assert.NoError(t, err)
 
-	defer os.Remove(tfile.Name())
+	t.Cleanup(func() {
+		_ = os.Remove(tfile.Name()) // nolint:gosec
+	})
 
 	// Use a mock oidcClient that always fails the refresh so that expired-token
 	// test cases correctly return false without panicking on a nil pointer.
-	as := &AWSSSO{
+	as = &AWSSSO{
 		SsoRegion:  "us-west-1",
 		StartUrl:   "https://testing.awsapps.com/start",
 		store:      jstore,
 		oidcClient: &mockOIDCClient{exchangeRefreshErr: fmt.Errorf("test: refresh not available")},
 		SSOConfig: &ssoconfig.SSOConfig{
-			AuthWorkflow: oidc.AuthWorkflowDeviceCode,
+			AuthWorkflow: workflow,
 		},
 	}
 
@@ -391,7 +393,7 @@ func TestValidAuthToken(t *testing.T) {
 		RefreshToken: "refresh_token",
 		TokenType:    "token_type",
 	}
-	key := as.StoreKey()
+	key = as.StoreKey()
 	err = jstore.SaveCreateTokenResponse(key, token)
 	assert.NoError(t, err)
 	assert.False(t, as.ValidAuthToken())
@@ -405,6 +407,12 @@ func TestValidAuthToken(t *testing.T) {
 	token.ExpiresAt = 99999999999
 	err = jstore.SaveCreateTokenResponse(key, token)
 	assert.NoError(t, err)
+	return as, key, jstore
+}
+
+func TestValidAuthTokenPKCE(t *testing.T) { // nolint:dupl
+	var err error
+	as, key, jstore := authTokenSetup(t, oidc.AuthWorkflowPKCE)
 
 	// ValidAuthToken requires a stored RegisterClientData with both
 	// authorization_code and refresh_token grant type support.
@@ -417,6 +425,43 @@ func TestValidAuthToken(t *testing.T) {
 	err = jstore.SaveRegisterClientData(key, clientData)
 	assert.NoError(t, err)
 	assert.True(t, as.ValidAuthToken())
+
+	clientData.GrantTypes = []storage.GrantType{storage.GrantTypeDeviceCode, storage.GrantTypeRefreshToken}
+	err = jstore.SaveRegisterClientData(key, clientData)
+	assert.NoError(t, err)
+	assert.False(t, as.ValidAuthToken())
+
+	clientData.GrantTypes = []storage.GrantType{storage.GrantTypeAuthorizationCode}
+	err = jstore.SaveRegisterClientData(key, clientData)
+	assert.NoError(t, err)
+	assert.False(t, as.ValidAuthToken())
+}
+
+func TestValidAuthTokenDeviceCode(t *testing.T) { // nolint:dupl
+	var err error
+	as, key, jstore := authTokenSetup(t, oidc.AuthWorkflowDeviceCode)
+
+	// ValidAuthToken requires a stored RegisterClientData with both
+	// device_code and refresh_token grant type support.
+	clientData := storage.RegisterClientData{
+		ClientId:              "test-client-id",
+		ClientSecret:          "test-client-secret",
+		ClientSecretExpiresAt: 99999999999,
+		GrantTypes:            []storage.GrantType{storage.GrantTypeDeviceCode, storage.GrantTypeRefreshToken},
+	}
+	err = jstore.SaveRegisterClientData(key, clientData)
+	assert.NoError(t, err)
+	assert.True(t, as.ValidAuthToken())
+
+	clientData.GrantTypes = []storage.GrantType{storage.GrantTypeAuthorizationCode, storage.GrantTypeRefreshToken}
+	err = jstore.SaveRegisterClientData(key, clientData)
+	assert.NoError(t, err)
+	assert.False(t, as.ValidAuthToken())
+
+	clientData.GrantTypes = []storage.GrantType{storage.GrantTypeDeviceCode}
+	err = jstore.SaveRegisterClientData(key, clientData)
+	assert.NoError(t, err)
+	assert.False(t, as.ValidAuthToken())
 }
 
 func TestAuthenticateFailure(t *testing.T) {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -74,37 +74,37 @@ func (r *RegisterClientData) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// SupportsAuthorizationCode returns true if the registration includes the
-// "authorization_code" grant type.
-func (r *RegisterClientData) SupportsAuthorizationCode() bool {
-	for _, gt := range r.GrantTypes {
-		if gt == GrantTypeAuthorizationCode {
+func (r *RegisterClientData) SupportsGrantType(gt GrantType) bool {
+	if len(r.GrantTypes) > 2 {
+		// Hack to deal with v2.2.0/2.2.1 bug where we supported all 3 grant types
+		// but some AWS SSO configs did not like authorization_code + device_code together
+		// see: https://github.com/synfinatic/aws-sso-cli/issues/1359
+		return false
+	}
+	for _, g := range r.GrantTypes {
+		if g == gt {
 			return true
 		}
 	}
 	return false
+}
+
+// SupportsAuthorizationCode returns true if the registration includes the
+// "authorization_code" grant type.
+func (r *RegisterClientData) SupportsAuthorizationCode() bool {
+	return r.SupportsGrantType(GrantTypeAuthorizationCode)
 }
 
 // SupportsRefreshToken returns true if the registration includes the
 // "refresh_token" grant type.
 func (r *RegisterClientData) SupportsRefreshToken() bool {
-	for _, gt := range r.GrantTypes {
-		if gt == GrantTypeRefreshToken {
-			return true
-		}
-	}
-	return false
+	return r.SupportsGrantType(GrantTypeRefreshToken)
 }
 
 // SupportsDeviceCode returns true if the registration includes the
 // "device_code" grant type.
 func (r *RegisterClientData) SupportsDeviceCode() bool {
-	for _, gt := range r.GrantTypes {
-		if gt == GrantTypeDeviceCode {
-			return true
-		}
-	}
-	return false
+	return r.SupportsGrantType(GrantTypeDeviceCode)
 }
 
 // Expired returns true if it has expired or will in the next hour

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -85,6 +85,19 @@ func TestRegisterClientDataUnmarshalJSON(t *testing.T) {
 	assert.True(t, r3.SupportsAuthorizationCode())
 }
 
+func TestSupportsGrantType(t *testing.T) {
+	r := &RegisterClientData{
+		GrantTypes: []GrantType{GrantTypeDeviceCode, GrantTypeRefreshToken},
+	}
+	assert.True(t, r.SupportsGrantType(GrantTypeDeviceCode))
+	assert.True(t, r.SupportsGrantType(GrantTypeRefreshToken))
+	assert.False(t, r.SupportsGrantType(GrantTypeAuthorizationCode))
+
+	// adding the 3rd type should always return false
+	r.GrantTypes = append(r.GrantTypes, GrantTypeAuthorizationCode)
+	assert.False(t, r.SupportsGrantType(GrantTypeAuthorizationCode))
+}
+
 func TestRegisterClientDataSupportsAuthorizationCode(t *testing.T) {
 	r := &RegisterClientData{}
 	assert.False(t, r.SupportsAuthorizationCode())


### PR DESCRIPTION
Apparently some AWS SSO instances throw an API error if the client tries to register using both device_code and authorization_code.

This change forces the client to always register one or the other + refresh_token support. Existing clients which have support for all 3 will be re-registed with 2.

Fixes: #1359