### PR TITLE
Padded zero accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Bugs
+
+* Fix bugs parsing AccountId's with leading zero's on the command line #1366
+
 ## [v2.2.2] - 2026-05-17
 
 ### Bugs

--- a/cmd/aws-sso/console_cmd.go
+++ b/cmd/aws-sso/console_cmd.go
@@ -49,10 +49,10 @@ type ConsoleCmd struct {
 	STSRefresh bool   `kong:"help='Force refresh of STS Token Credentials'"`
 	UrlAction  string `kong:"short='u',help='How to handle URLs [clip|exec|open|print|printurl|granted-containers|open-url-in-container|ansi-osc52] (default: open)',predictor='urlAction'"`
 
-	Arn       string `kong:"short='a',help='ARN of role to assume',env='AWS_SSO_ROLE_ARN',predictor='arn'"`
-	AccountId int64  `kong:"name='account',short='A',help='AWS AccountID of role to assume',env='AWS_SSO_ACCOUNT_ID',predictor='accountId'"`
-	Role      string `kong:"short='R',help='Name of AWS Role to assume',env='AWS_SSO_ROLE_NAME',predictor='role'"`
-	Profile   string `kong:"short='p',help='Name of AWS Profile to assume',predictor='profile'"`
+	Arn       string    `kong:"short='a',help='ARN of role to assume',env='AWS_SSO_ROLE_ARN',predictor='arn'"`
+	AccountId AccountID `kong:"name='account',short='A',help='AWS AccountID of role to assume',env='AWS_SSO_ACCOUNT_ID',predictor='accountId'"`
+	Role      string    `kong:"short='R',help='Name of AWS Role to assume',env='AWS_SSO_ROLE_NAME',predictor='role'"`
+	Profile   string    `kong:"short='p',help='Name of AWS Profile to assume',predictor='profile'"`
 
 	AccessKeyId     string `kong:"env='AWS_ACCESS_KEY_ID',hidden"`
 	SecretAccessKey string `kong:"env='AWS_SECRET_ACCESS_KEY',hidden"`
@@ -81,7 +81,7 @@ func (cc *ConsoleCmd) Run(ctx *RunContext) error {
 	}
 
 	// Check our CLI args
-	sci := NewSelectCliArgs(ctx.Cli.Console.Arn, ctx.Cli.Console.AccountId, ctx.Cli.Console.Role, ctx.Cli.Console.Profile)
+	sci := NewSelectCliArgs(ctx.Cli.Console.Arn, int64(ctx.Cli.Console.AccountId), ctx.Cli.Console.Role, ctx.Cli.Console.Profile)
 	if err := sci.Update(ctx); err == nil {
 		// successful lookup?
 		return openConsole(ctx, sci.AccountId, sci.RoleName)

--- a/cmd/aws-sso/ecs_client_cmd.go
+++ b/cmd/aws-sso/ecs_client_cmd.go
@@ -33,11 +33,11 @@ import (
 
 type EcsLoadCmd struct {
 	// AWS Params
-	Arn        string `kong:"short='a',help='ARN of role to load',env='AWS_SSO_ROLE_ARN',predictor='arn'"`
-	AccountId  int64  `kong:"name='account',short='A',help='AWS AccountID of role to load',env='AWS_SSO_ACCOUNT_ID',predictor='accountId',xor='account'"`
-	Role       string `kong:"short='R',help='Name of AWS Role to load',env='AWS_SSO_ROLE_NAME',predictor='role',xor='role'"`
-	Profile    string `kong:"short='p',help='Name of AWS Profile to load',predictor='profile',xor='account,role'"`
-	STSRefresh bool   `kong:"help='Force refresh of STS Token Credentials'"`
+	Arn        string    `kong:"short='a',help='ARN of role to load',env='AWS_SSO_ROLE_ARN',predictor='arn'"`
+	AccountId  AccountID `kong:"name='account',short='A',help='AWS AccountID of role to load',env='AWS_SSO_ACCOUNT_ID',predictor='accountId',xor='account'"`
+	Role       string    `kong:"short='R',help='Name of AWS Role to load',env='AWS_SSO_ROLE_NAME',predictor='role',xor='role'"`
+	Profile    string    `kong:"short='p',help='Name of AWS Profile to load',predictor='profile',xor='account,role'"`
+	STSRefresh bool      `kong:"help='Force refresh of STS Token Credentials'"`
 
 	// Other params
 	Server  string `kong:"help='Endpoint of aws-sso ECS Server',env='AWS_SSO_ECS_SERVER',default='localhost:4144'"`
@@ -51,7 +51,7 @@ func (e EcsLoadCmd) AfterApply(runCtx *RunContext) error {
 }
 
 func (cc *EcsLoadCmd) Run(ctx *RunContext) error {
-	sci := NewSelectCliArgs(ctx.Cli.Ecs.Load.Arn, ctx.Cli.Ecs.Load.AccountId, ctx.Cli.Ecs.Load.Role, ctx.Cli.Ecs.Load.Profile)
+	sci := NewSelectCliArgs(ctx.Cli.Ecs.Load.Arn, int64(ctx.Cli.Ecs.Load.AccountId), ctx.Cli.Ecs.Load.Role, ctx.Cli.Ecs.Load.Profile)
 	if err := sci.Update(ctx); err == nil {
 		// successful lookup?
 		return ecsLoadCmd(ctx, sci.AccountId, sci.RoleName)

--- a/cmd/aws-sso/eval_cmd.go
+++ b/cmd/aws-sso/eval_cmd.go
@@ -29,10 +29,10 @@ import (
 
 type EvalCmd struct {
 	// AWS Params
-	Arn       string `kong:"short='a',help='ARN of role to assume',predictor='arn'"`
-	AccountId int64  `kong:"name='account',short='A',help='AWS AccountID of role to assume',predictor='accountId'"`
-	Role      string `kong:"short='R',help='Name of AWS Role to assume',predictor='role'"`
-	Profile   string `kong:"short='p',help='Name of AWS Profile to assume',predictor='profile'"`
+	Arn       string    `kong:"short='a',help='ARN of role to assume',predictor='arn'"`
+	AccountId AccountID `kong:"name='account',short='A',help='AWS AccountID of role to assume',predictor='accountId'"`
+	Role      string    `kong:"short='R',help='Name of AWS Role to assume',predictor='role'"`
+	Profile   string    `kong:"short='p',help='Name of AWS Profile to assume',predictor='profile'"`
 
 	Clear    bool   `kong:"short='c',help='Generate \"unset XXXX\" commands to clear environment'"`
 	NoRegion bool   `kong:"short='n',help='Do not set/clear AWS_DEFAULT_REGION/AWS_REGION from config.yaml'"`
@@ -83,10 +83,10 @@ func (cc *EvalCmd) Run(ctx *RunContext) error {
 		if err != nil {
 			return err
 		}
-	} else if ctx.Cli.Eval.Role != "" && ctx.Cli.Eval.AccountId > 0 {
-		// if CLI args are speecified, use that
+	} else if ctx.Cli.Eval.Role != "" && ctx.Cli.Eval.AccountId != 0 {
+		// if CLI args are specified, use that
+		accountid = int64(ctx.Cli.Eval.AccountId)
 		role = ctx.Cli.Eval.Role
-		accountid = ctx.Cli.Eval.AccountId
 	} else {
 		return fmt.Errorf("please specify --refresh, --clear, --arn, or --account and --role")
 	}

--- a/cmd/aws-sso/exec_cmd.go
+++ b/cmd/aws-sso/exec_cmd.go
@@ -31,12 +31,12 @@ import (
 
 type ExecCmd struct {
 	// AWS Params
-	Arn        string `kong:"short='a',help='ARN of role to assume',env='AWS_SSO_ROLE_ARN',predictor='arn'"`
-	AccountId  int64  `kong:"name='account',short='A',help='AWS AccountID of role to assume',env='AWS_SSO_ACCOUNT_ID',predictor='accountId'"`
-	Role       string `kong:"short='R',help='Name of AWS Role to assume',env='AWS_SSO_ROLE_NAME',predictor='role'"`
-	Profile    string `kong:"short='p',help='Name of AWS Profile to assume',predictor='profile'"`
-	NoRegion   bool   `kong:"short='n',help='Do not set AWS_DEFAULT_REGION from config.yaml'"`
-	STSRefresh bool   `kong:"help='Force refresh of STS Token Credentials'"`
+	Arn        string    `kong:"short='a',help='ARN of role to assume',env='AWS_SSO_ROLE_ARN',predictor='arn'"`
+	AccountId  AccountID `kong:"name='account',short='A',help='AWS AccountID of role to assume',env='AWS_SSO_ACCOUNT_ID',predictor='accountId'"`
+	Role       string    `kong:"short='R',help='Name of AWS Role to assume',env='AWS_SSO_ROLE_NAME',predictor='role'"`
+	Profile    string    `kong:"short='p',help='Name of AWS Profile to assume',predictor='profile'"`
+	NoRegion   bool      `kong:"short='n',help='Do not set AWS_DEFAULT_REGION from config.yaml'"`
+	STSRefresh bool      `kong:"help='Force refresh of STS Token Credentials'"`
 
 	// Exec Params
 	Cmd  string   `kong:"arg,optional,name='command',help='Command to execute',env='SHELL'"`
@@ -65,7 +65,7 @@ func (cc *ExecCmd) Run(ctx *RunContext) error {
 		}
 	}
 
-	sci := NewSelectCliArgs(ctx.Cli.Exec.Arn, ctx.Cli.Exec.AccountId, ctx.Cli.Exec.Role, ctx.Cli.Exec.Profile)
+	sci := NewSelectCliArgs(ctx.Cli.Exec.Arn, int64(ctx.Cli.Exec.AccountId), ctx.Cli.Exec.Role, ctx.Cli.Exec.Profile)
 	if err := sci.Update(ctx); err == nil {
 		// successful lookup?
 		return execCmd(ctx, sci.AccountId, sci.RoleName)

--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -49,6 +49,19 @@ var VALID_LOG_LEVELS = []string{"error", "warn", "info", "debug", "trace"}
 
 var AwsSSO *ssoauth.AWSSSO // global
 
+// AccountID is a custom type that safely parses AWS account IDs from strings with leading zeros.
+type AccountID int64
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface for Kong.
+func (a *AccountID) UnmarshalText(text []byte) error {
+	parsed, err := awsparse.AccountIdToInt64(string(text))
+	if err != nil {
+		return fmt.Errorf("invalid account ID: %s", string(text))
+	}
+	*a = AccountID(parsed)
+	return nil
+}
+
 type CommandAuth int
 
 const (

--- a/cmd/aws-sso/tags_cmd.go
+++ b/cmd/aws-sso/tags_cmd.go
@@ -26,8 +26,8 @@ import (
 )
 
 type TagsCmd struct {
-	AccountId int64  `kong:"name='account',short='A',help='Filter results based on AWS AccountID'"`
-	Role      string `kong:"short='R',help='Filter results based on AWS Role Name'"`
+	AccountId AccountID `kong:"name='account',short='A',help='Filter results based on AWS AccountID'"`
+	Role      string    `kong:"short='R',help='Filter results based on AWS Role Name'"`
 }
 
 // AfterApply determines if SSO auth token is required
@@ -39,6 +39,8 @@ func (t TagsCmd) AfterApply(runCtx *RunContext) error {
 func (cc *TagsCmd) Run(ctx *RunContext) error {
 	set := ctx.Settings
 	cache := ctx.Settings.Cache.GetSSO()
+	accountId := int64(ctx.Cli.Tags.AccountId)
+
 	s, err := ctx.Settings.GetSelectedSSO(ctx.Cli.SSO)
 	if err != nil {
 		return err
@@ -55,7 +57,7 @@ func (cc *TagsCmd) Run(ctx *RunContext) error {
 
 	// If user has specified an account (or account + role) then limit
 	if ctx.Cli.Tags.AccountId != 0 {
-		for _, fRole := range cache.Roles.GetAccountRoles(ctx.Cli.Tags.AccountId) {
+		for _, fRole := range cache.Roles.GetAccountRoles(accountId) {
 			if ctx.Cli.Tags.Role == "" {
 				roles = append(roles, fRole)
 			} else {


### PR DESCRIPTION
use Kong Mapper interface to parse AccountId as a string that converts into an int64

Fixes: #1366