### PR TITLE
Fix set AWS_REGION alongside AWS_DEFAULT_REGION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bugs
 
+* Fix `$AWS_REGION` not set by `eval`/`exec` despite being documented #1277
 * Fix bugs parsing AccountId's with leading zero's on the command line #1366
 
 ## [v2.2.2] - 2026-05-17

--- a/cmd/aws-sso/exec_cmd.go
+++ b/cmd/aws-sso/exec_cmd.go
@@ -35,7 +35,7 @@ type ExecCmd struct {
 	AccountId  AccountID `kong:"name='account',short='A',help='AWS AccountID of role to assume',env='AWS_SSO_ACCOUNT_ID',predictor='accountId'"`
 	Role       string    `kong:"short='R',help='Name of AWS Role to assume',env='AWS_SSO_ROLE_NAME',predictor='role'"`
 	Profile    string    `kong:"short='p',help='Name of AWS Profile to assume',predictor='profile'"`
-	NoRegion   bool      `kong:"short='n',help='Do not set AWS_DEFAULT_REGION from config.yaml'"`
+	NoRegion   bool      `kong:"short='n',help='Do not set AWS_DEFAULT_REGION/AWS_REGION from config.yaml'"`
 	STSRefresh bool      `kong:"help='Force refresh of STS Token Credentials'"`
 
 	// Exec Params
@@ -103,6 +103,21 @@ func execCmd(ctx *RunContext, accountid int64, role string) error {
 	return cmd.Run()
 }
 
+// setRegionVars populates region-related env vars in shellVars. When region is
+// non-empty it sets AWS_DEFAULT_REGION, AWS_REGION and the sentinel
+// AWS_SSO_DEFAULT_REGION to that value. When empty it clears the sentinel so
+// the region is no longer treated as aws-sso-managed.
+func setRegionVars(shellVars map[string]string, region string) {
+	if len(region) > 0 {
+		shellVars["AWS_DEFAULT_REGION"] = region
+		shellVars["AWS_REGION"] = region
+		shellVars["AWS_SSO_DEFAULT_REGION"] = region
+	} else {
+		// we no longer manage the region
+		shellVars["AWS_SSO_DEFAULT_REGION"] = ""
+	}
+}
+
 func execShellEnvs(ctx *RunContext, accountid int64, role, region string) map[string]string {
 	var err error
 	credsPtr := GetRoleCredentials(ctx, AwsSSO, ctx.Cli.Exec.STSRefresh, accountid, role)
@@ -120,13 +135,7 @@ func execShellEnvs(ctx *RunContext, accountid int64, role, region string) map[st
 		"AWS_SSO":                    ssoName,
 	}
 
-	if len(region) > 0 {
-		shellVars["AWS_DEFAULT_REGION"] = region
-		shellVars["AWS_SSO_DEFAULT_REGION"] = region
-	} else {
-		// we no longer manage the region
-		shellVars["AWS_SSO_DEFAULT_REGION"] = ""
-	}
+	setRegionVars(shellVars, region)
 
 	// Set the AWS_SSO_PROFILE env var using our template
 	cache := ctx.Settings.Cache.GetSSO()

--- a/cmd/aws-sso/exec_cmd_test.go
+++ b/cmd/aws-sso/exec_cmd_test.go
@@ -1,0 +1,43 @@
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2026 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetRegionVars(t *testing.T) {
+	t.Run("sets AWS_DEFAULT_REGION, AWS_REGION and sentinel when region is non-empty", func(t *testing.T) {
+		shellVars := map[string]string{}
+		setRegionVars(shellVars, "us-east-1")
+		assert.Equal(t, "us-east-1", shellVars["AWS_DEFAULT_REGION"])
+		assert.Equal(t, "us-east-1", shellVars["AWS_REGION"])
+		assert.Equal(t, "us-east-1", shellVars["AWS_SSO_DEFAULT_REGION"])
+	})
+
+	t.Run("clears sentinel and leaves region vars absent when region is empty", func(t *testing.T) {
+		shellVars := map[string]string{}
+		setRegionVars(shellVars, "")
+		assert.NotContains(t, shellVars, "AWS_DEFAULT_REGION")
+		assert.NotContains(t, shellVars, "AWS_REGION")
+		assert.Equal(t, "", shellVars["AWS_SSO_DEFAULT_REGION"])
+	})
+}


### PR DESCRIPTION
## Problem

PR #1336 was supposed to fix #1277 by managing `$AWS_REGION` alongside
`$AWS_DEFAULT_REGION`, but the fix was incomplete. The unset path
(`eval --clear`) and the guard in `GetDefaultRegion` were both updated to
handle `$AWS_REGION`, and the docs were updated to say both variables are
managed — but `execShellEnvs` (the function that actually **sets** env vars for
`eval`/`exec`/`aws-sso-profile`) was never updated to include `AWS_REGION`.

Reproduction:
```
aws-sso-profile dev:admin
printenv | grep AWS_REGION   # empty — only AWS_DEFAULT_REGION is set
dotnet test ...               # fails — .NET SDK only reads AWS_REGION
```

## Changes

**`cmd/aws-sso/exec_cmd.go`**

- Extracted the region-assignment block from `execShellEnvs` into a new
  `setRegionVars(shellVars map[string]string, region string)` helper.
- `setRegionVars` now sets `AWS_REGION` alongside `AWS_DEFAULT_REGION` and
  `AWS_SSO_DEFAULT_REGION` when a region is configured.
- Updated the `--no-region` / `-n` flag help text to mention `AWS_REGION`.

**`cmd/aws-sso/exec_cmd_test.go`** *(new file)*

- Added `TestSetRegionVars` covering both cases:
  - non-empty region → all three vars (`AWS_DEFAULT_REGION`, `AWS_REGION`,
    `AWS_SSO_DEFAULT_REGION`) are set to the configured value
  - empty region → only the sentinel `AWS_SSO_DEFAULT_REGION` is cleared

## No other changes required

| Component | Status |
|---|---|
| Unset on `eval --clear` (`eval_cmd.go`) | ✅ already unsets `AWS_REGION` |
| Don't override user-set region (`settings.go`) | ✅ already reads `AWS_REGION` as fallback |
| Docs (`FAQ.md`, `config.md`) | ✅ already describe both vars being managed |
