### PR TITLE
fix: correct 'which to' -> 'wish to' typo in docs/config.md

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -206,7 +206,7 @@ Some special tags:
 
 #### Roles
 
-The `Roles` block is optional, except for roles you which to assume via role chaining.
+The `Roles` block is optional, except for roles you wish to assume via role chaining.
 
 ##### Profile
 


### PR DESCRIPTION
Fixes documentation typo in docs/config.md line 209.

The sentence 'except for roles you which to assume' should be 'except for roles you wish to assume'.

Simple 1-word fix: 'which' → 'wish'.