### PR TITLE
docs: fix role chaining typo in config guide

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -206,7 +206,7 @@ Some special tags:
 
 #### Roles
 
-The `Roles` block is optional, except for roles you which to assume via role chaining.
+The `Roles` block is optional, except for roles you wish to assume via role chaining.
 
 ##### Profile
 


### PR DESCRIPTION
## Summary
- correct "which" to "wish" in the role-chaining sentence in `docs/config.md`

## Validation
- verified the updated sentence in `docs/config.md` now reads naturally and no stale `which to assume via role chaining` text remains in the repo

Closes #1376