### PR TITLE
fix: exit cleanly on SIGINT even when blocked in keyring/D-Bus calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Bugs
+
+* Fix zombie processes holding storage.lock after SIGINT #1379
+
 ### Changes
 
 * Add unit tests for cmd/aws-sso

--- a/cmd/aws-sso/login_cmd.go
+++ b/cmd/aws-sso/login_cmd.go
@@ -52,7 +52,7 @@ func checkAuth(ctx *RunContext) bool {
 		AwsSSO = ssoauth.NewAWSSSO(s, ctx.Store)
 	}
 
-	return AwsSSO.ValidAuthToken()
+	return AwsSSO.ValidAuthToken(ctx.Ctx)
 }
 
 // doAuth creates a singleton AWSSO object post authentication
@@ -75,7 +75,7 @@ func doAuth(ctx *RunContext) {
 		// Auth specific override
 		action = AwsSSO.SSOConfig.AuthUrlAction
 	}
-	err = AwsSSO.Authenticate(action, ctx.Settings.Browser)
+	err = AwsSSO.Authenticate(ctx.Ctx, action, ctx.Settings.Browser)
 	if err != nil {
 		log.Fatal("Unable to authenticate", "error", err.Error())
 	}

--- a/cmd/aws-sso/logout_cmd.go
+++ b/cmd/aws-sso/logout_cmd.go
@@ -41,7 +41,7 @@ func (cc *LogoutCmd) Run(ctx *RunContext) error {
 	awssso := ssoauth.NewAWSSSO(s, ctx.Store)
 
 	flushSts(ctx, awssso)
-	return awssso.Logout() // invalidate our AccessToken
+	return awssso.Logout(ctx.Ctx) // invalidate our AccessToken
 }
 
 // flushSts flushes our IAM STS Role credentials from the secure store
@@ -49,7 +49,7 @@ func flushSts(ctx *RunContext, awssso *ssoauth.AWSSSO) {
 	cache := ctx.Settings.Cache.GetSSO()
 	for _, role := range cache.Roles.GetAllRoles() {
 		if !role.IsExpired() {
-			if err := ctx.Store.DeleteRoleCredentials(role.Arn); err != nil {
+			if err := ctx.Store.DeleteRoleCredentials(ctx.Ctx, role.Arn); err != nil {
 				log.Error("Unable to delete STS token", "arn", role.Arn)
 			}
 		}

--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -19,11 +19,14 @@ package main
  */
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
 	"slices"
 	"strings"
+	"syscall"
 
 	"github.com/alecthomas/kong"
 
@@ -77,6 +80,7 @@ type RunContext struct {
 	Settings *sso.Settings // unified config & cache
 	Store    storage.SecureStorage
 	Auth     CommandAuth
+	Ctx      context.Context
 }
 
 const (
@@ -161,11 +165,22 @@ type CLI struct {
 }
 
 func main() {
+	appCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	// Exit on first signal even when blocked inside a keyring/D-Bus call.
+	// The OS then releases all fcntl locks held by this process.
+	go func() {
+		<-appCtx.Done()
+		os.Exit(1)
+	}()
+
 	cli := CLI{}
 	var err error
 	runCtx := RunContext{
 		Cli:  &cli,
 		Auth: AUTH_UNKNOWN,
+		Ctx:  appCtx,
 	}
 
 	override := parseArgs(&runCtx)
@@ -251,7 +266,7 @@ func loadSecureStore(ctx *RunContext) {
 		if err != nil {
 			log.Fatal("Unable to create SecureStore", "error", err.Error())
 		}
-		ctx.Store, err = storage.OpenKeyring(cfg)
+		ctx.Store, err = storage.OpenKeyring(ctx.Ctx, cfg)
 		if err != nil {
 			log.Fatal("Unable to open SecureStore", "file", ctx.Settings.SecureStore, "error", err.Error())
 		}
@@ -378,7 +393,7 @@ func GetRoleCredentials(ctx *RunContext, awssso *ssoauth.AWSSSO, refreshSTS bool
 	log.Debug("Retrieved role credentials from AWS SSO")
 
 	// Cache our creds
-	if err := ctx.Store.SaveRoleCredentials(arn, creds); err != nil {
+	if err := ctx.Store.SaveRoleCredentials(ctx.Ctx, arn, creds); err != nil {
 		log.Warn("Unable to cache role credentials in secure store", "error", err.Error())
 	}
 

--- a/cmd/aws-sso/main_test.go
+++ b/cmd/aws-sso/main_test.go
@@ -1,9 +1,14 @@
 package main
 
 import (
+	"context"
+	"os"
+	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAccountIDUnmarshalText(t *testing.T) {
@@ -51,6 +56,29 @@ func TestAccountIDUnmarshalText(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSignalExitGoroutine verifies that cancelling the signal context causes os.Exit(1).
+// It uses a subprocess so os.Exit doesn't terminate the test runner.
+func TestSignalExitGoroutine(t *testing.T) {
+	if os.Getenv("TEST_SIGNAL_EXIT_SUBPROCESS") == "1" {
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			<-ctx.Done()
+			os.Exit(1)
+		}()
+		cancel()
+		time.Sleep(time.Second) // should not reach here
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestSignalExitGoroutine", "-test.v") //nolint:gosec
+	cmd.Env = append(os.Environ(), "TEST_SIGNAL_EXIT_SUBPROCESS=1")
+	err := cmd.Run()
+	require.Error(t, err)
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 1, exitErr.ExitCode())
 }
 
 func TestLogLevelTypeValidate(t *testing.T) {

--- a/cmd/aws-sso/setup_cmd.go
+++ b/cmd/aws-sso/setup_cmd.go
@@ -50,7 +50,7 @@ func (e EcsAuthCmd) AfterApply(runCtx *RunContext) error {
 func (cc *EcsAuthCmd) Run(ctx *RunContext) error {
 	// Delete the token
 	if ctx.Cli.Setup.Ecs.Auth.Delete {
-		return ctx.Store.DeleteEcsBearerToken()
+		return ctx.Store.DeleteEcsBearerToken(ctx.Ctx)
 	}
 
 	// Or store the token in the SecureStore
@@ -60,7 +60,7 @@ func (cc *EcsAuthCmd) Run(ctx *RunContext) error {
 	if strings.HasPrefix(ctx.Cli.Setup.Ecs.Auth.BearerToken, "Bearer ") {
 		return fmt.Errorf("token should not start with 'Bearer '")
 	}
-	return ctx.Store.SaveEcsBearerToken(ctx.Cli.Setup.Ecs.Auth.BearerToken)
+	return ctx.Store.SaveEcsBearerToken(ctx.Ctx, ctx.Cli.Setup.Ecs.Auth.BearerToken)
 }
 
 type EcsSSLCmd struct {
@@ -79,7 +79,7 @@ func (e EcsSSLCmd) AfterApply(runCtx *RunContext) error {
 
 func (cc *EcsSSLCmd) Run(ctx *RunContext) error {
 	if ctx.Cli.Setup.Ecs.SSL.Delete {
-		return ctx.Store.DeleteEcsSslKeyPair()
+		return ctx.Store.DeleteEcsSslKeyPair(ctx.Ctx)
 	} else if ctx.Cli.Setup.Ecs.SSL.Print {
 		cert, err := ctx.Store.GetEcsSslCert()
 		if err != nil {
@@ -113,5 +113,5 @@ func (cc *EcsSSLCmd) Run(ctx *RunContext) error {
 		}
 	}
 
-	return ctx.Store.SaveEcsSslKeyPair(privateKey, certChain)
+	return ctx.Store.SaveEcsSslKeyPair(ctx.Ctx, privateKey, certChain)
 }

--- a/internal/sso/auth/awssso.go
+++ b/internal/sso/auth/awssso.go
@@ -197,7 +197,7 @@ func (as *AWSSSO) ListAccounts(input *awssso.ListAccountsInput) (*awssso.ListAcc
 				log.Warn("AccessToken Unauthorized Error; forcing re-authentication")
 				log.Debug("AccessToken Unauthorized Error; refreshing", "error", err.Error())
 
-				if err2 := as.reauthenticate(); err2 != nil {
+				if err2 := as.reauthenticate(context.Background()); err2 != nil {
 					// fail hard now
 					return output, err2
 				}
@@ -235,7 +235,7 @@ func (as *AWSSSO) ListAccountRoles(input *awssso.ListAccountRolesInput) (*awssso
 				log.Warn("AccessToken Unauthorized Error; forcing re-authentication")
 				log.Debug("AccessToken Unauthorized Error; refreshing", "error", err.Error())
 
-				if err = as.reauthenticate(); err != nil {
+				if err = as.reauthenticate(context.Background()); err != nil {
 					// fail hard now
 					panic(fmt.Sprintf("Unexpected auth failure: %s", err.Error()))
 				}

--- a/internal/sso/auth/awssso_auth.go
+++ b/internal/sso/auth/awssso_auth.go
@@ -49,7 +49,7 @@ const (
 
 // ValidAuthToken returns true if we have a valid AWS SSO authentication token
 // or false if we need to authenticate.
-func (as *AWSSSO) ValidAuthToken() bool {
+func (as *AWSSSO) ValidAuthToken(ctx context.Context) bool {
 	log.Trace("ValidAuthToken()", "storeKey", as.StoreKey())
 	// First verify the stored registration supports refresh tokens. Old
 	// registrations (or those written before GrantTypes was persisted) won't
@@ -60,7 +60,7 @@ func (as *AWSSSO) ValidAuthToken() bool {
 			if !clientData.SupportsGrantType(gt) {
 				log.Debug("client registration lacks necessary grant types; forcing new registration",
 					"storeKey", as.StoreKey(), "missingGrantType", gt)
-				err = as.store.DeleteRegisterClientData(as.StoreKey())
+				err = as.store.DeleteRegisterClientData(ctx, as.StoreKey())
 				if err != nil {
 					log.Error("unable to delete RegisterClientData from secure store", "storeKey", as.StoreKey(), "error", err.Error())
 				}
@@ -95,7 +95,7 @@ func (as *AWSSSO) ValidAuthToken() bool {
 
 	// Attempt a silent renewal using the stored refresh token before
 	// falling back to a full browser-based re-authentication.
-	if token.RefreshToken != "" && as.tryRefreshToken(token, clientData) {
+	if token.RefreshToken != "" && as.tryRefreshToken(ctx, token, clientData) {
 		return true
 	}
 	return false
@@ -105,9 +105,9 @@ func (as *AWSSSO) ValidAuthToken() bool {
 // the stored refresh token.  It saves the new token and returns true on
 // success, or logs and returns false so the caller can fall back to a full
 // re-authentication flow.
-func (as *AWSSSO) tryRefreshToken(expiredToken storage.CreateTokenResponse, clientData storage.RegisterClientData) bool {
+func (as *AWSSSO) tryRefreshToken(ctx context.Context, expiredToken storage.CreateTokenResponse, clientData storage.RegisterClientData) bool {
 	log.Debug("Attempting silent token refresh", "storeKey", as.StoreKey())
-	newToken, err := as.oidcClient.ExchangeRefreshToken(context.Background(), oidc.ExchangeRefreshTokenInput{
+	newToken, err := as.oidcClient.ExchangeRefreshToken(ctx, oidc.ExchangeRefreshTokenInput{
 		ClientID:     clientData.ClientId,
 		ClientSecret: clientData.ClientSecret,
 		RefreshToken: expiredToken.RefreshToken,
@@ -120,14 +120,14 @@ func (as *AWSSSO) tryRefreshToken(expiredToken storage.CreateTokenResponse, clie
 		// AWS may choose not to return a new refresh token; if so, reuse the old one.
 		newToken.RefreshToken = expiredToken.RefreshToken
 	}
-	_ = as.saveToken(newToken)
+	_ = as.saveToken(ctx, newToken)
 	log.Debug("Token successfully refreshed", "storeKey", as.StoreKey())
 	return true
 }
 
 // Authenticate retrieves an AWS SSO AccessToken from our cache or by
 // making the necessary AWS SSO calls.
-func (as *AWSSSO) Authenticate(urlAction uri.Action, browser string) error {
+func (as *AWSSSO) Authenticate(ctx context.Context, urlAction uri.Action, browser string) error {
 	log.Trace("Authenticate", "urlAction", urlAction, "browser", browser)
 	// cache urlAction and browser for subsequent calls if necessary
 	// if action is still undefined, use the default action which is defined inside NewHandleUrl()
@@ -137,7 +137,7 @@ func (as *AWSSSO) Authenticate(urlAction uri.Action, browser string) error {
 		as.browser = browser
 	}
 
-	return as.reauthenticate()
+	return as.reauthenticate(ctx)
 }
 
 // StoreKey returns the key in the cache for this AWSSSO instance
@@ -146,13 +146,13 @@ func (as *AWSSSO) StoreKey() string {
 }
 
 // reauthenticate talks to AWS SSO to generate a new AWS SSO AccessToken
-func (as *AWSSSO) reauthenticate() error {
+func (as *AWSSSO) reauthenticate(ctx context.Context) error {
 	// This should only be happening one at a time!
 	as.authenticateLock.Lock()
 	defer as.authenticateLock.Unlock()
 
 	log.Trace("reauthenticate()", "storeKey", as.StoreKey())
-	err := as.registerClient(false)
+	err := as.registerClient(ctx, false)
 	if err != nil {
 		return fmt.Errorf("unable to register client with AWS SSO: %w", err)
 	}
@@ -160,9 +160,9 @@ func (as *AWSSSO) reauthenticate() error {
 
 	switch as.getAuthWorkflow() {
 	case oidc.AuthWorkflowDeviceCode:
-		return as.reauthenticateDeviceCode()
+		return as.reauthenticateDeviceCode(ctx)
 	case oidc.AuthWorkflowPKCE:
-		return as.reauthenticatePKCE()
+		return as.reauthenticatePKCE(ctx)
 	default:
 		log.Fatal("unsupported auth workflow", "workflow", as.getAuthWorkflow())
 	}
@@ -171,7 +171,7 @@ func (as *AWSSSO) reauthenticate() error {
 
 // registerClient does the needful to talk to AWS or read our cache to get the
 // RegisterClientData for later steps and saves it to our secret store
-func (as *AWSSSO) registerClient(force bool) error {
+func (as *AWSSSO) registerClient(ctx context.Context, force bool) error {
 	log.Trace("registerClient()")
 	if !force {
 		log.Trace("Checking cache for RegisterClientData", "storeKey", as.StoreKey())
@@ -193,7 +193,7 @@ func (as *AWSSSO) registerClient(force bool) error {
 		input.Scopes = []string{SSO_ACCOUNT_ACCESS_SCOPE}
 		input.RedirectUris = []string{as.pkceRedirectURIBase()}
 	}
-	resp, err := as.oidcClient.RegisterClient(context.TODO(), input)
+	resp, err := as.oidcClient.RegisterClient(ctx, input)
 	if err != nil {
 		return err
 	}
@@ -204,7 +204,7 @@ func (as *AWSSSO) registerClient(force bool) error {
 	// them ourselves so ValidAuthToken() can check for refresh_token support.
 	as.ClientData.GrantTypes = as.GrantTypes()
 	log.Trace("SaveRegisterClientData start", "storeKey", as.StoreKey())
-	err = as.store.SaveRegisterClientData(as.StoreKey(), as.ClientData)
+	err = as.store.SaveRegisterClientData(ctx, as.StoreKey(), as.ClientData)
 	if err != nil {
 		log.Error("unable to save RegisterClientData", "storeKey", as.StoreKey(), "error", err.Error())
 	}
@@ -214,9 +214,9 @@ func (as *AWSSSO) registerClient(force bool) error {
 
 // startDeviceAuthorization makes the call to AWS to initiate the OIDC auth
 // to the SSO provider.
-func (as *AWSSSO) startDeviceAuthorization() error {
+func (as *AWSSSO) startDeviceAuthorization(ctx context.Context) error {
 	log.Trace("startDeviceAuthorization()", "storeKey", as.StoreKey())
-	resp, err := as.oidcClient.StartDeviceAuthorization(context.TODO(), oidc.StartDeviceAuthorizationInput{
+	resp, err := as.oidcClient.StartDeviceAuthorization(ctx, oidc.StartDeviceAuthorizationInput{
 		StartURL:     as.StartUrl,
 		ClientID:     as.ClientData.ClientId,
 		ClientSecret: as.ClientData.ClientSecret,
@@ -256,7 +256,7 @@ func (as *AWSSSO) getDeviceAuthInfo() (DeviceAuthInfo, error) {
 
 // createToken blocks until we have a new SSO AccessToken and saves it
 // to our secret store
-func (as *AWSSSO) createToken() error {
+func (as *AWSSSO) createToken(ctx context.Context) error {
 	log.Trace("createToken()")
 	var slowDown = SLOW_DOWN_SEC * time.Second
 	var retryInterval = RETRY_INTERVAL * time.Second
@@ -274,20 +274,20 @@ func (as *AWSSSO) createToken() error {
 		RetryInterval: retryInterval,
 		SlowDown:      slowDown,
 	}
-	token, err := as.oidcClient.PollDeviceCodeToken(context.TODO(), input)
+	token, err := as.oidcClient.PollDeviceCodeToken(ctx, input)
 	if err != nil {
 		return err
 	}
 
-	return as.saveToken(token)
+	return as.saveToken(ctx, token)
 }
 
-func (as *AWSSSO) saveToken(token storage.CreateTokenResponse) error {
+func (as *AWSSSO) saveToken(ctx context.Context, token storage.CreateTokenResponse) error {
 	as.tokenLock.Lock()
 	as.Token = token
 	as.tokenLock.Unlock()
 	// use the local variable directly to avoid a lock gap
-	if err := as.store.SaveCreateTokenResponse(as.StoreKey(), token); err != nil {
+	if err := as.store.SaveCreateTokenResponse(ctx, as.StoreKey(), token); err != nil {
 		log.Error("unable to save CreateTokenResponse", "error", err.Error())
 	}
 	return nil
@@ -351,16 +351,16 @@ func (as *AWSSSO) pkceAuthorizationEndpoint() string {
 	return fmt.Sprintf("https://oidc.%s.amazonaws.com/authorize", as.SsoRegion)
 }
 
-func (as *AWSSSO) reauthenticateDeviceCode() error {
-	err := as.startDeviceAuthorization()
+func (as *AWSSSO) reauthenticateDeviceCode(ctx context.Context) error {
+	err := as.startDeviceAuthorization(ctx)
 	log.Trace("<- reauthenticate()")
 	if err != nil {
 		log.Debug("startDeviceAuthorization failed.  Forcing refresh of registerClient")
 		// startDeviceAuthorization can fail if our cached registerClient token is invalid
-		if err = as.registerClient(true); err != nil {
+		if err = as.registerClient(ctx, true); err != nil {
 			return fmt.Errorf("unable to register client with AWS SSO: %w", err)
 		}
-		if err = as.startDeviceAuthorization(); err != nil {
+		if err = as.startDeviceAuthorization(ctx); err != nil {
 			return fmt.Errorf("unable to start device authorization with AWS SSO: %w", err)
 		}
 	}
@@ -380,7 +380,7 @@ func (as *AWSSSO) reauthenticateDeviceCode() error {
 
 	log.Info("Waiting for SSO authentication...")
 
-	err = as.createToken()
+	err = as.createToken(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to create new AWS SSO token: %w", err)
 	}
@@ -388,7 +388,7 @@ func (as *AWSSSO) reauthenticateDeviceCode() error {
 	return nil
 }
 
-func (as *AWSSSO) reauthenticatePKCE() error {
+func (as *AWSSSO) reauthenticatePKCE(ctx context.Context) error {
 	// Find a free loopback port for the callback listener. RFC 8252 §7.3 recommends
 	// any available port rather than a fixed one to avoid bind conflicts.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -399,7 +399,7 @@ func (as *AWSSSO) reauthenticatePKCE() error {
 	_ = ln.Close()
 	redirectURI := fmt.Sprintf("http://127.0.0.1:%d", port)
 
-	flow, err := as.oidcClient.StartPKCEAuthCodeFlow(context.Background(), oidc.StartPKCEAuthCodeInput{
+	flow, err := as.oidcClient.StartPKCEAuthCodeFlow(ctx, oidc.StartPKCEAuthCodeInput{
 		AuthorizationEndpoint: as.pkceAuthorizationEndpoint(),
 		ClientID:              as.ClientData.ClientId,
 		RedirectURI:           redirectURI,
@@ -416,10 +416,10 @@ func (as *AWSSSO) reauthenticatePKCE() error {
 	}
 
 	// Give the user up to 5 minutes to complete the browser login.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	pkceCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
-	callback, err := as.oidcClient.WaitForPKCECallback(ctx, oidc.WaitForPKCECallbackInput{
+	callback, err := as.oidcClient.WaitForPKCECallback(pkceCtx, oidc.WaitForPKCECallbackInput{
 		RedirectURI:   redirectURI,
 		ExpectedState: flow.State,
 	})
@@ -434,16 +434,16 @@ func (as *AWSSSO) reauthenticatePKCE() error {
 		CodeVerifier: flow.CodeVerifier,
 		RedirectURI:  redirectURI,
 	}
-	token, err := as.oidcClient.ExchangePKCEAuthCode(context.TODO(), input)
+	token, err := as.oidcClient.ExchangePKCEAuthCode(ctx, input)
 	if err != nil {
 		return fmt.Errorf("unable to exchange pkce authorization code: %w", err)
 	}
 
-	return as.saveToken(token)
+	return as.saveToken(ctx, token)
 }
 
 // Logout performs an SSO logout with AWS and invalidates our SSO session
-func (as *AWSSSO) Logout() error {
+func (as *AWSSSO) Logout(ctx context.Context) error {
 	token := as.Token.AccessToken
 
 	if token == "" {
@@ -455,7 +455,7 @@ func (as *AWSSSO) Logout() error {
 		token = tr.AccessToken
 
 		// delete the value from the store so we don't think we have a valid token
-		if err := as.store.DeleteCreateTokenResponse(as.key); err != nil {
+		if err := as.store.DeleteCreateTokenResponse(ctx, as.key); err != nil {
 			log.Error("unable to delete AccessToken from secure store", "error", err.Error())
 		}
 	}
@@ -465,6 +465,6 @@ func (as *AWSSSO) Logout() error {
 	}
 
 	// do the needful
-	_, err := as.sso.Logout(context.TODO(), input)
+	_, err := as.sso.Logout(ctx, input)
 	return err
 }

--- a/internal/sso/auth/awssso_auth_test.go
+++ b/internal/sso/auth/awssso_auth_test.go
@@ -205,14 +205,14 @@ func TestAuthenticateSteps(t *testing.T) {
 		},
 	})
 
-	err = as.registerClient(false)
+	err = as.registerClient(context.Background(), false)
 	assert.NoError(t, err)
 	assert.Equal(t, "this-is-my-client-id", as.ClientData.ClientId)
 	assert.Equal(t, "this-is-my-client-secret", as.ClientData.ClientSecret)
 	assert.Equal(t, int64(42), as.ClientData.ClientIdIssuedAt)
 	assert.Equal(t, int64(4200), as.ClientData.ClientSecretExpiresAt)
 
-	err = as.startDeviceAuthorization()
+	err = as.startDeviceAuthorization(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, "device-code", as.DeviceAuth.DeviceCode)
 	assert.Equal(t, "user-code", as.DeviceAuth.UserCode)
@@ -221,7 +221,7 @@ func TestAuthenticateSteps(t *testing.T) {
 	assert.Equal(t, int32(42), as.DeviceAuth.ExpiresIn)
 	assert.Equal(t, int32(5), as.DeviceAuth.Interval)
 
-	err = as.createToken()
+	err = as.createToken(context.Background())
 	assert.NoError(t, err)
 	assert.Equal(t, "access-token", as.Token.AccessToken)
 	assert.Equal(t, int32(42), as.Token.ExpiresIn)
@@ -356,12 +356,12 @@ func TestAuthenticate(t *testing.T) {
 		},
 	})
 
-	as.ValidAuthToken()
-	assert.False(t, as.ValidAuthToken())
+	as.ValidAuthToken(context.Background())
+	assert.False(t, as.ValidAuthToken(context.Background()))
 
-	err = as.Authenticate("print", "fake-browser")
+	err = as.Authenticate(context.Background(), "print", "fake-browser")
 	assert.NoError(t, err)
-	assert.True(t, as.ValidAuthToken())
+	assert.True(t, as.ValidAuthToken(context.Background()))
 	assert.Equal(t, "access-token", as.Token.AccessToken)
 	assert.Equal(t, int32(expires), as.Token.ExpiresIn) // #nosec
 	assert.Equal(t, "id-token", as.Token.IdToken)
@@ -369,7 +369,7 @@ func TestAuthenticate(t *testing.T) {
 	assert.Equal(t, "token-type", as.Token.TokenType)
 
 	// We should now have a valid auth token
-	assert.True(t, as.ValidAuthToken())
+	assert.True(t, as.ValidAuthToken(context.Background()))
 	assert.Equal(t, "access-token", as.Token.AccessToken)
 	assert.Equal(t, int32(expires), as.Token.ExpiresIn) // #nosec
 	assert.Equal(t, "id-token", as.Token.IdToken)
@@ -378,11 +378,11 @@ func TestAuthenticate(t *testing.T) {
 
 	// verify CLI override
 	as.SSOConfig.AuthUrlAction = "invalid"
-	err = as.Authenticate("print", "fake-browser")
+	err = as.Authenticate(context.Background(), "print", "fake-browser")
 	assert.NoError(t, err)
 
 	// verify no override of CLI when not set
-	err = as.Authenticate(uri.Print, "fake-browser")
+	err = as.Authenticate(context.Background(), uri.Print, "fake-browser")
 	assert.NoError(t, err)
 
 	defer func() {
@@ -393,7 +393,7 @@ func TestAuthenticate(t *testing.T) {
 
 	// we can't exec with bad config
 	as.SSOConfig.AuthUrlAction = uri.Exec
-	_ = as.Authenticate(uri.Undef, "fake-browser")
+	_ = as.Authenticate(context.Background(), uri.Undef, "fake-browser")
 }
 
 func authTokenSetup(t *testing.T, workflow oidc.AuthWorkflow) (as *AWSSSO, key string, jstore storage.SecureStorage) {
@@ -428,18 +428,18 @@ func authTokenSetup(t *testing.T, workflow oidc.AuthWorkflow) (as *AWSSSO, key s
 		TokenType:    "token_type",
 	}
 	key = as.StoreKey()
-	err = jstore.SaveCreateTokenResponse(key, token)
+	err = jstore.SaveCreateTokenResponse(context.Background(), key, token)
 	assert.NoError(t, err)
-	assert.False(t, as.ValidAuthToken())
+	assert.False(t, as.ValidAuthToken(context.Background()))
 
 	token.ExpiresAt = 99999
-	err = jstore.SaveCreateTokenResponse(key, token)
+	err = jstore.SaveCreateTokenResponse(context.Background(), key, token)
 	assert.NoError(t, err)
-	assert.False(t, as.ValidAuthToken())
+	assert.False(t, as.ValidAuthToken(context.Background()))
 
 	token.ExpiresIn = int32(^int(0) >> 1)
 	token.ExpiresAt = 99999999999
-	err = jstore.SaveCreateTokenResponse(key, token)
+	err = jstore.SaveCreateTokenResponse(context.Background(), key, token)
 	assert.NoError(t, err)
 	return as, key, jstore
 }
@@ -456,19 +456,19 @@ func TestValidAuthTokenPKCE(t *testing.T) { // nolint:dupl
 		ClientSecretExpiresAt: 99999999999,
 		GrantTypes:            []storage.GrantType{storage.GrantTypeAuthorizationCode, storage.GrantTypeRefreshToken},
 	}
-	err = jstore.SaveRegisterClientData(key, clientData)
+	err = jstore.SaveRegisterClientData(context.Background(), key, clientData)
 	assert.NoError(t, err)
-	assert.True(t, as.ValidAuthToken())
+	assert.True(t, as.ValidAuthToken(context.Background()))
 
 	clientData.GrantTypes = []storage.GrantType{storage.GrantTypeDeviceCode, storage.GrantTypeRefreshToken}
-	err = jstore.SaveRegisterClientData(key, clientData)
+	err = jstore.SaveRegisterClientData(context.Background(), key, clientData)
 	assert.NoError(t, err)
-	assert.False(t, as.ValidAuthToken())
+	assert.False(t, as.ValidAuthToken(context.Background()))
 
 	clientData.GrantTypes = []storage.GrantType{storage.GrantTypeAuthorizationCode}
-	err = jstore.SaveRegisterClientData(key, clientData)
+	err = jstore.SaveRegisterClientData(context.Background(), key, clientData)
 	assert.NoError(t, err)
-	assert.False(t, as.ValidAuthToken())
+	assert.False(t, as.ValidAuthToken(context.Background()))
 }
 
 func TestValidAuthTokenDeviceCode(t *testing.T) { // nolint:dupl
@@ -483,19 +483,19 @@ func TestValidAuthTokenDeviceCode(t *testing.T) { // nolint:dupl
 		ClientSecretExpiresAt: 99999999999,
 		GrantTypes:            []storage.GrantType{storage.GrantTypeDeviceCode, storage.GrantTypeRefreshToken},
 	}
-	err = jstore.SaveRegisterClientData(key, clientData)
+	err = jstore.SaveRegisterClientData(context.Background(), key, clientData)
 	assert.NoError(t, err)
-	assert.True(t, as.ValidAuthToken())
+	assert.True(t, as.ValidAuthToken(context.Background()))
 
 	clientData.GrantTypes = []storage.GrantType{storage.GrantTypeAuthorizationCode, storage.GrantTypeRefreshToken}
-	err = jstore.SaveRegisterClientData(key, clientData)
+	err = jstore.SaveRegisterClientData(context.Background(), key, clientData)
 	assert.NoError(t, err)
-	assert.False(t, as.ValidAuthToken())
+	assert.False(t, as.ValidAuthToken(context.Background()))
 
 	clientData.GrantTypes = []storage.GrantType{storage.GrantTypeDeviceCode}
-	err = jstore.SaveRegisterClientData(key, clientData)
+	err = jstore.SaveRegisterClientData(context.Background(), key, clientData)
 	assert.NoError(t, err)
-	assert.False(t, as.ValidAuthToken())
+	assert.False(t, as.ValidAuthToken(context.Background()))
 }
 
 func TestAuthenticateFailure(t *testing.T) {
@@ -656,19 +656,19 @@ func TestAuthenticateFailure(t *testing.T) {
 		},
 	})
 
-	err = as.Authenticate("print", "fake-browser")
+	err = as.Authenticate(context.Background(), "print", "fake-browser")
 	assert.Contains(t, err.Error(), "unable to register client with AWS SSO")
 
-	err = as.Authenticate("print", "fake-browser")
+	err = as.Authenticate(context.Background(), "print", "fake-browser")
 	assert.Contains(t, err.Error(), "unable to start device authorization")
 
-	err = as.Authenticate("print", "fake-browser")
+	err = as.Authenticate(context.Background(), "print", "fake-browser")
 	assert.Contains(t, err.Error(), "createToken:")
 
-	err = as.Authenticate("print", "fake-browser")
+	err = as.Authenticate(context.Background(), "print", "fake-browser")
 	assert.Contains(t, err.Error(), "no valid verification url")
 
-	err = as.Authenticate("invalid", "fake-browser")
+	err = as.Authenticate(context.Background(), "invalid", "fake-browser")
 	assert.Contains(t, err.Error(), "unsupported Open action")
 }
 
@@ -729,7 +729,7 @@ func TestReauthenticate(t *testing.T) {
 		},
 	})
 
-	err = as.reauthenticate()
+	err = as.reauthenticate(context.Background())
 	assert.Contains(t, err.Error(), "unable to exec")
 }
 
@@ -769,7 +769,7 @@ func TestLogout(t *testing.T) {
 		},
 	}
 
-	err = as.Logout()
+	err = as.Logout(context.Background())
 	assert.NoError(t, err)
 	tr := storage.CreateTokenResponse{}
 	assert.Error(t, as.store.GetCreateTokenResponse(as.key, &tr))
@@ -784,10 +784,10 @@ func TestLogout(t *testing.T) {
 		},
 	}
 
-	err = as.Logout()
+	err = as.Logout(context.Background())
 	assert.Error(t, err)
 
-	err = jstore.SaveCreateTokenResponse("primary", storage.CreateTokenResponse{
+	err = jstore.SaveCreateTokenResponse(context.Background(), "primary", storage.CreateTokenResponse{
 		AccessToken:  "access-token",
 		ExpiresIn:    42,
 		ExpiresAt:    time.Now().Add(duration).Unix(),
@@ -796,7 +796,7 @@ func TestLogout(t *testing.T) {
 		TokenType:    "token-type",
 	})
 	assert.NoError(t, err)
-	err = as.Logout()
+	err = as.Logout(context.Background())
 	assert.NoError(t, err)
 	err = jstore.GetCreateTokenResponse("primary", &storage.CreateTokenResponse{})
 	assert.Error(t, err)
@@ -918,7 +918,7 @@ func TestSaveToken(t *testing.T) {
 		TokenType:    "Bearer",
 	}
 
-	err = as.saveToken(token)
+	err = as.saveToken(context.Background(), token)
 	assert.NoError(t, err)
 	assert.Equal(t, token.AccessToken, as.Token.AccessToken)
 	assert.Equal(t, token.IdToken, as.Token.IdToken)
@@ -957,7 +957,7 @@ func TestRegisterClientPKCE(t *testing.T) {
 		SSOConfig:  &ssoconfig.SSOConfig{AuthWorkflow: oidc.AuthWorkflowPKCE},
 	}
 
-	err = as.registerClient(true)
+	err = as.registerClient(context.Background(), true)
 	assert.NoError(t, err)
 	assert.Equal(t, "pkce-client-id", as.ClientData.ClientId)
 
@@ -1008,7 +1008,7 @@ func TestReauthenticatePKCE(t *testing.T) {
 			SSOConfig:  &ssoconfig.SSOConfig{AuthWorkflow: oidc.AuthWorkflowPKCE},
 		}
 
-		err = as.reauthenticatePKCE()
+		err = as.reauthenticatePKCE(context.Background())
 		assert.NoError(t, err)
 		assert.Equal(t, "pkce-access-token", as.Token.AccessToken)
 		assert.Equal(t, "pkce-id-token", as.Token.IdToken)
@@ -1049,7 +1049,7 @@ func TestReauthenticatePKCE(t *testing.T) {
 			SSOConfig:  &ssoconfig.SSOConfig{AuthWorkflow: oidc.AuthWorkflowPKCE},
 		}
 
-		err = as.reauthenticatePKCE()
+		err = as.reauthenticatePKCE(context.Background())
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unable to start pkce authorization")
 		assert.Contains(t, err.Error(), "pkce start failed")
@@ -1081,7 +1081,7 @@ func TestReauthenticatePKCE(t *testing.T) {
 			SSOConfig:  &ssoconfig.SSOConfig{AuthWorkflow: oidc.AuthWorkflowPKCE},
 		}
 
-		err = as.reauthenticatePKCE()
+		err = as.reauthenticatePKCE(context.Background())
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unable to receive pkce callback")
 		assert.Contains(t, err.Error(), "callback timed out")
@@ -1114,7 +1114,7 @@ func TestReauthenticatePKCE(t *testing.T) {
 			SSOConfig:  &ssoconfig.SSOConfig{AuthWorkflow: oidc.AuthWorkflowPKCE},
 		}
 
-		err = as.reauthenticatePKCE()
+		err = as.reauthenticatePKCE(context.Background())
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unable to exchange pkce authorization code")
 		assert.Contains(t, err.Error(), "token exchange failed")
@@ -1159,7 +1159,7 @@ func TestTryRefreshToken(t *testing.T) {
 			oidcClient: mock,
 		}
 
-		ok := as.tryRefreshToken(expiredToken, clientData)
+		ok := as.tryRefreshToken(context.Background(), expiredToken, clientData)
 		assert.True(t, ok)
 		assert.Equal(t, "new-access-token", as.Token.AccessToken)
 		assert.Equal(t, "new-refresh-token", as.Token.RefreshToken)
@@ -1197,7 +1197,7 @@ func TestTryRefreshToken(t *testing.T) {
 			oidcClient: mock,
 		}
 
-		ok := as.tryRefreshToken(expiredToken, clientData)
+		ok := as.tryRefreshToken(context.Background(), expiredToken, clientData)
 		assert.False(t, ok)
 		// Token in memory should be unchanged (zero value)
 		assert.Equal(t, "", as.Token.AccessToken)
@@ -1238,7 +1238,7 @@ func TestValidAuthTokenRefresh(t *testing.T) {
 			ClientSecretExpiresAt: time.Now().Add(time.Hour).Unix(),
 			GrantTypes:            []storage.GrantType{storage.GrantTypeAuthorizationCode, storage.GrantTypeRefreshToken},
 		}
-		err = jstore.SaveRegisterClientData(as.StoreKey(), clientData)
+		err = jstore.SaveRegisterClientData(context.Background(), as.StoreKey(), clientData)
 		assert.NoError(t, err)
 
 		// Save an expired token that has a refresh token
@@ -1247,16 +1247,16 @@ func TestValidAuthTokenRefresh(t *testing.T) {
 			ExpiresAt:    1, // expired
 			RefreshToken: "stored-refresh-token",
 		}
-		err = jstore.SaveCreateTokenResponse(as.StoreKey(), expiredToken)
+		err = jstore.SaveCreateTokenResponse(context.Background(), as.StoreKey(), expiredToken)
 		assert.NoError(t, err)
 
 		// ValidAuthToken should silently refresh and return true
-		assert.True(t, as.ValidAuthToken())
+		assert.True(t, as.ValidAuthToken(context.Background()))
 		assert.Equal(t, "refreshed-access-token", as.Token.AccessToken)
 		assert.Equal(t, "new-refresh-token", as.Token.RefreshToken)
 
 		// The new token must be persisted so the next call also succeeds
-		assert.True(t, as.ValidAuthToken())
+		assert.True(t, as.ValidAuthToken(context.Background()))
 		assert.Len(t, mock.exchangeRefreshInputs, 1) // only refreshed once
 	})
 
@@ -1285,7 +1285,7 @@ func TestValidAuthTokenRefresh(t *testing.T) {
 			ClientSecretExpiresAt: time.Now().Add(time.Hour).Unix(),
 			GrantTypes:            []storage.GrantType{storage.GrantTypeAuthorizationCode, storage.GrantTypeRefreshToken},
 		}
-		err = jstore.SaveRegisterClientData(as.StoreKey(), clientData)
+		err = jstore.SaveRegisterClientData(context.Background(), as.StoreKey(), clientData)
 		assert.NoError(t, err)
 
 		expiredToken := storage.CreateTokenResponse{
@@ -1293,10 +1293,10 @@ func TestValidAuthTokenRefresh(t *testing.T) {
 			ExpiresAt:    1,
 			RefreshToken: "bad-refresh-token",
 		}
-		err = jstore.SaveCreateTokenResponse(as.StoreKey(), expiredToken)
+		err = jstore.SaveCreateTokenResponse(context.Background(), as.StoreKey(), expiredToken)
 		assert.NoError(t, err)
 
-		assert.False(t, as.ValidAuthToken())
+		assert.False(t, as.ValidAuthToken(context.Background()))
 		assert.Equal(t, "", as.Token.AccessToken)
 	})
 
@@ -1323,7 +1323,7 @@ func TestValidAuthTokenRefresh(t *testing.T) {
 			ClientSecretExpiresAt: time.Now().Add(time.Hour).Unix(),
 			GrantTypes:            []storage.GrantType{storage.GrantTypeAuthorizationCode, storage.GrantTypeRefreshToken},
 		}
-		err = jstore.SaveRegisterClientData(as.StoreKey(), clientData)
+		err = jstore.SaveRegisterClientData(context.Background(), as.StoreKey(), clientData)
 		assert.NoError(t, err)
 
 		expiredToken := storage.CreateTokenResponse{
@@ -1331,10 +1331,10 @@ func TestValidAuthTokenRefresh(t *testing.T) {
 			ExpiresAt:    1,
 			RefreshToken: "", // no refresh token
 		}
-		err = jstore.SaveCreateTokenResponse(as.StoreKey(), expiredToken)
+		err = jstore.SaveCreateTokenResponse(context.Background(), as.StoreKey(), expiredToken)
 		assert.NoError(t, err)
 
-		assert.False(t, as.ValidAuthToken())
+		assert.False(t, as.ValidAuthToken(context.Background()))
 		// ExchangeRefreshToken should never have been called
 		assert.Len(t, mock.exchangeRefreshInputs, 0)
 	})

--- a/internal/sso/auth/interfaces.go
+++ b/internal/sso/auth/interfaces.go
@@ -19,6 +19,8 @@ package auth
  */
 
 import (
+	"context"
+
 	ssoconfig "github.com/synfinatic/aws-sso-cli/internal/sso/config"
 	"github.com/synfinatic/aws-sso-cli/internal/uri"
 )
@@ -26,9 +28,9 @@ import (
 // Authenticator is the interface that wraps AWS SSO authentication operations.
 // *AWSSSO satisfies this interface.
 type Authenticator interface {
-	Authenticate(urlAction uri.Action, browser string) error
-	ValidAuthToken() bool
-	Logout() error
+	Authenticate(ctx context.Context, urlAction uri.Action, browser string) error
+	ValidAuthToken(ctx context.Context) bool
+	Logout(ctx context.Context) error
 }
 
 // Compile-time assertions that *AWSSSO satisfies both interfaces.

--- a/internal/storage/flock.go
+++ b/internal/storage/flock.go
@@ -19,6 +19,7 @@ package storage
  */
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -55,8 +56,22 @@ func FlockBlockerReset() {
 	sleeper.Reset()
 }
 
-// Implments fslock.Blocker
+// FlockBlocker implements fslock.Blocker with exponential backoff.
 func FlockBlocker() error {
 	time.Sleep(sleeper.Duration())
 	return nil
+}
+
+// FlockBlockerWithCtx returns an fslock.Blocker that stops if ctx is cancelled.
+// Wrap ctx with context.WithTimeout before calling to enforce a lock-wait deadline.
+func FlockBlockerWithCtx(ctx context.Context) func() error {
+	return func() error {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("storage lock wait cancelled: %w", ctx.Err())
+		default:
+		}
+		time.Sleep(sleeper.Duration())
+		return nil
+	}
 }

--- a/internal/storage/flock_test.go
+++ b/internal/storage/flock_test.go
@@ -19,10 +19,12 @@ package storage
  */
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/synfinatic/aws-sso-cli/internal/config"
@@ -42,4 +44,31 @@ func TestFlockFile(t *testing.T) {
 func TestFlockBlocker(t *testing.T) {
 	FlockBlockerReset()
 	assert.NoError(t, FlockBlocker())
+}
+
+func TestFlockBlockerWithCtx(t *testing.T) {
+	t.Run("active context returns nil", func(t *testing.T) {
+		FlockBlockerReset()
+		blocker := FlockBlockerWithCtx(context.Background())
+		assert.NoError(t, blocker())
+	})
+
+	t.Run("cancelled context returns error wrapping context.Canceled", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		blocker := FlockBlockerWithCtx(ctx)
+		err := blocker()
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("expired deadline returns error wrapping context.DeadlineExceeded", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		defer cancel()
+		time.Sleep(5 * time.Millisecond)
+		blocker := FlockBlockerWithCtx(ctx)
+		err := blocker()
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+	})
 }

--- a/internal/storage/json_store.go
+++ b/internal/storage/json_store.go
@@ -19,6 +19,7 @@ package storage
  */
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -88,7 +89,7 @@ func (jc *JsonStore) save() error {
 }
 
 // SaveRegisterClientData saves the RegisterClientData in our JSON store
-func (jc *JsonStore) SaveRegisterClientData(key string, client RegisterClientData) error {
+func (jc *JsonStore) SaveRegisterClientData(_ context.Context, key string, client RegisterClientData) error {
 	jc.RegisterClient[key] = client
 	return jc.save()
 }
@@ -104,13 +105,13 @@ func (jc *JsonStore) GetRegisterClientData(key string, client *RegisterClientDat
 }
 
 // DeleteRegisterClientData deletes the RegisterClientData from the JSON store
-func (jc *JsonStore) DeleteRegisterClientData(key string) error {
+func (jc *JsonStore) DeleteRegisterClientData(_ context.Context, key string) error {
 	delete(jc.RegisterClient, key)
 	return jc.save()
 }
 
 // SaveCreateTokenResponse stores the token in the json file
-func (jc *JsonStore) SaveCreateTokenResponse(key string, token CreateTokenResponse) error {
+func (jc *JsonStore) SaveCreateTokenResponse(_ context.Context, key string, token CreateTokenResponse) error {
 	jc.CreateTokenResponse[key] = token
 	return jc.save()
 }
@@ -126,13 +127,13 @@ func (jc *JsonStore) GetCreateTokenResponse(key string, token *CreateTokenRespon
 }
 
 // DeleteCreateTokenResponse deletes the token from the json file
-func (jc *JsonStore) DeleteCreateTokenResponse(key string) error {
+func (jc *JsonStore) DeleteCreateTokenResponse(_ context.Context, key string) error {
 	delete(jc.CreateTokenResponse, key)
 	return jc.save()
 }
 
 // SaveRoleCredentials stores the token in the json file
-func (jc *JsonStore) SaveRoleCredentials(arn string, token RoleCredentials) error {
+func (jc *JsonStore) SaveRoleCredentials(_ context.Context, arn string, token RoleCredentials) error {
 	jc.RoleCredentials[arn] = token
 	return jc.save()
 }
@@ -148,13 +149,13 @@ func (jc *JsonStore) GetRoleCredentials(arn string, token *RoleCredentials) erro
 }
 
 // DeleteRoleCredentials deletes the token from the json file
-func (jc *JsonStore) DeleteRoleCredentials(arn string) error {
+func (jc *JsonStore) DeleteRoleCredentials(_ context.Context, arn string) error {
 	delete(jc.RoleCredentials, arn)
 	return jc.save()
 }
 
 // SaveStaticCredentials stores the token in the json file
-func (jc *JsonStore) SaveStaticCredentials(arn string, creds StaticCredentials) error {
+func (jc *JsonStore) SaveStaticCredentials(_ context.Context, arn string, creds StaticCredentials) error {
 	jc.StaticCredentials[arn] = creds
 	return jc.save()
 }
@@ -170,7 +171,7 @@ func (jc *JsonStore) GetStaticCredentials(arn string, creds *StaticCredentials) 
 }
 
 // DeleteStaticCredentials deletes the StaticCredentials from the json file
-func (jc *JsonStore) DeleteStaticCredentials(arn string) error {
+func (jc *JsonStore) DeleteStaticCredentials(_ context.Context, arn string) error {
 	if _, ok := jc.StaticCredentials[arn]; !ok {
 		// return error if key doesn't exist
 		return fmt.Errorf("no StaticCredentials for ARN: %s", arn)
@@ -192,7 +193,7 @@ func (jc *JsonStore) ListStaticCredentials() []string {
 }
 
 // SaveEcsBearerToken stores the token in the json file
-func (jc *JsonStore) SaveEcsBearerToken(token string) error {
+func (jc *JsonStore) SaveEcsBearerToken(_ context.Context, token string) error {
 	jc.EcsBearerToken = token
 	return jc.save()
 }
@@ -203,13 +204,13 @@ func (jc *JsonStore) GetEcsBearerToken() (string, error) {
 }
 
 // DeleteEcsBearerToken deletes the token from the json file
-func (jc *JsonStore) DeleteEcsBearerToken() error {
+func (jc *JsonStore) DeleteEcsBearerToken(_ context.Context) error {
 	jc.EcsBearerToken = ""
 	return jc.save()
 }
 
 // SaveEcsSslKeyPair stores the SSL private key and certificate chain in the json file
-func (jc *JsonStore) SaveEcsSslKeyPair(privateKey, certChain []byte) error {
+func (jc *JsonStore) SaveEcsSslKeyPair(_ context.Context, privateKey, certChain []byte) error {
 	if err := ValidateSSLCertificate(certChain); err != nil {
 		return err
 	}
@@ -233,7 +234,7 @@ func (jc *JsonStore) GetEcsSslKey() (string, error) {
 }
 
 // DeleteEcsSslKeyPair deletes the SSL private key and certificate chain from the json file
-func (jc *JsonStore) DeleteEcsSslKeyPair() error {
+func (jc *JsonStore) DeleteEcsSslKeyPair(_ context.Context) error {
 	jc.EcsPrivateKey = ""
 	jc.EcsCertChain = ""
 	return jc.save()

--- a/internal/storage/json_store_test.go
+++ b/internal/storage/json_store_test.go
@@ -19,6 +19,7 @@ package storage
  */
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -104,18 +105,18 @@ func (s *JsonStoreTestSuite) TestRegisterClientData() {
 	}
 	assert.Equal(t, rcdTest, rcd)
 
-	err = s.json.SaveRegisterClientData(key, rcd)
+	err = s.json.SaveRegisterClientData(context.Background(), key, rcd)
 	assert.Nil(t, err)
 	assert.Equal(t, rcdTest, rcd)
 
-	err = s.json.DeleteRegisterClientData(key)
+	err = s.json.DeleteRegisterClientData(context.Background(), key)
 	assert.Nil(t, err)
 
 	err = s.json.GetRegisterClientData(key, &rcd)
 	assert.NotNil(t, err)
 }
 
-func (s *JsonStoreTestSuite) TestRoleCredentials() {
+func (s *JsonStoreTestSuite) TestRoleCredentials() { //nolint:dupl
 	t := s.T()
 	rc := RoleCredentials{}
 	arn := "arn:aws:iam::012344553243:role/AWSAdministratorAccess"
@@ -136,18 +137,18 @@ func (s *JsonStoreTestSuite) TestRoleCredentials() {
 	}
 	assert.Equal(t, rcTest, rc)
 
-	err = s.json.SaveRoleCredentials(arn, rc)
+	err = s.json.SaveRoleCredentials(context.Background(), arn, rc)
 	assert.Nil(t, err)
 	assert.Equal(t, rcTest, rc)
 
-	err = s.json.DeleteRoleCredentials(arn)
+	err = s.json.DeleteRoleCredentials(context.Background(), arn)
 	assert.Nil(t, err)
 
 	err = s.json.GetRoleCredentials(arn, &rc)
 	assert.NotNil(t, err)
 }
 
-func (s *JsonStoreTestSuite) TestCreateTokenResponse() {
+func (s *JsonStoreTestSuite) TestCreateTokenResponse() { //nolint:dupl
 	t := s.T()
 	tr := CreateTokenResponse{}
 	key := "us-east-1|https://d-xxxxxxx.awsapps.com/start"
@@ -168,11 +169,11 @@ func (s *JsonStoreTestSuite) TestCreateTokenResponse() {
 	}
 	assert.Equal(t, trTest, tr)
 
-	err = s.json.SaveCreateTokenResponse(key, tr)
+	err = s.json.SaveCreateTokenResponse(context.Background(), key, tr)
 	assert.Nil(t, err)
 	assert.Equal(t, trTest, tr)
 
-	err = s.json.DeleteCreateTokenResponse(key)
+	err = s.json.DeleteCreateTokenResponse(context.Background(), key)
 	assert.Nil(t, err)
 
 	err = s.json.GetCreateTokenResponse(key, &tr)
@@ -197,13 +198,13 @@ func (s *JsonStoreTestSuite) TestStaticCredentials() {
 	}
 	assert.Equal(t, cr2, cr)
 
-	assert.NoError(t, s.json.DeleteStaticCredentials(arn))
+	assert.NoError(t, s.json.DeleteStaticCredentials(context.Background(), arn))
 	assert.Empty(t, s.json.ListStaticCredentials())
 
 	assert.Error(t, s.json.GetStaticCredentials(arn, &cr))
-	assert.Error(t, s.json.DeleteStaticCredentials(arn))
+	assert.Error(t, s.json.DeleteStaticCredentials(context.Background(), arn))
 
-	assert.NoError(t, s.json.SaveStaticCredentials(arn, cr2))
+	assert.NoError(t, s.json.SaveStaticCredentials(context.Background(), arn, cr2))
 	assert.NoError(t, s.json.GetStaticCredentials("arn:aws:iam::123456789012:user/foobar", &cr))
 	assert.Equal(t, cr2, cr)
 }
@@ -215,14 +216,14 @@ func (s *JsonStoreTestSuite) TestEcsBearerToken() {
 	assert.NoError(t, err)
 	assert.Empty(t, token)
 
-	err = s.json.SaveEcsBearerToken("not a real token")
+	err = s.json.SaveEcsBearerToken(context.Background(), "not a real token")
 	assert.NoError(t, err)
 
 	token, err = s.json.GetEcsBearerToken()
 	assert.NoError(t, err)
 	assert.Equal(t, "not a real token", token)
 
-	err = s.json.DeleteEcsBearerToken()
+	err = s.json.DeleteEcsBearerToken(context.Background())
 	assert.NoError(t, err)
 
 	token, err = s.json.GetEcsBearerToken()
@@ -246,15 +247,15 @@ func (s *JsonStoreTestSuite) TestEcsSslKeyPair() { // nolint: dupl
 	keyBytes, err := os.ReadFile("../ecs/server/testdata/localhost.key")
 	assert.NoError(t, err)
 
-	err = s.json.SaveEcsSslKeyPair([]byte{}, certBytes)
+	err = s.json.SaveEcsSslKeyPair(context.Background(), []byte{}, certBytes)
 	assert.NoError(t, err)
 
-	err = s.json.SaveEcsSslKeyPair(keyBytes, certBytes)
+	err = s.json.SaveEcsSslKeyPair(context.Background(), keyBytes, certBytes)
 	assert.NoError(t, err)
 
-	err = s.json.SaveEcsSslKeyPair(keyBytes, keyBytes)
+	err = s.json.SaveEcsSslKeyPair(context.Background(), keyBytes, keyBytes)
 	assert.Error(t, err)
-	err = s.json.SaveEcsSslKeyPair(certBytes, certBytes)
+	err = s.json.SaveEcsSslKeyPair(context.Background(), certBytes, certBytes)
 	assert.Error(t, err)
 
 	cert, err = s.json.GetEcsSslCert()
@@ -265,7 +266,7 @@ func (s *JsonStoreTestSuite) TestEcsSslKeyPair() { // nolint: dupl
 	assert.NoError(t, err)
 	assert.Equal(t, string(keyBytes), key)
 
-	err = s.json.DeleteEcsSslKeyPair()
+	err = s.json.DeleteEcsSslKeyPair(context.Background())
 	assert.NoError(t, err)
 
 	cert, err = s.json.GetEcsSslCert()

--- a/internal/storage/keyring.go
+++ b/internal/storage/keyring.go
@@ -19,12 +19,14 @@ package storage
  */
 
 import (
+	"context"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path"
 	"runtime"
+	"time"
 
 	"github.com/99designs/keyring"
 	"github.com/synfinatic/aws-sso-cli/internal/fileutils"
@@ -34,6 +36,8 @@ import (
 
 	"golang.org/x/term"
 )
+
+const flockWaitTimeout = 30 * time.Second
 
 const (
 	KEYRING_ID                   = "aws-sso-cli"
@@ -167,7 +171,7 @@ func fileKeyringPassword(prompt string) (string, error) {
 	return s, nil
 }
 
-func OpenKeyring(cfg *keyring.Config) (SecureStorage, error) {
+func OpenKeyring(ctx context.Context, cfg *keyring.Config) (SecureStorage, error) {
 	ring, err := keyring.Open(*cfg)
 	if err != nil {
 		return nil, err
@@ -178,13 +182,7 @@ func OpenKeyring(cfg *keyring.Config) (SecureStorage, error) {
 		cache:   NewStorageData(),
 	}
 
-	err = fslock.WithSharedBlocking(FlockFile(true), FlockBlocker,
-		func() error {
-			return kr.getStorageData(&kr.cache)
-		},
-	)
-	FlockBlockerReset()
-	if err != nil {
+	if err = kr.getStorageData(ctx, &kr.cache); err != nil {
 		return nil, err
 	}
 
@@ -200,13 +198,17 @@ type Unmarshaler func([]byte, interface{}) error
 var storageDataUnmarshal Unmarshaler = json.Unmarshal
 
 // loads the entire StorageData into memory
-func (kr *KeyringStore) getStorageData(s *StorageData) error {
+func (kr *KeyringStore) getStorageData(ctx context.Context, s *StorageData) error {
 	var data []byte
 	var err error
 
+	lockCtx, cancel := context.WithTimeout(ctx, flockWaitTimeout)
+	defer cancel()
+	blocker := FlockBlockerWithCtx(lockCtx)
+
 	switch keyringGOOS {
 	case "windows":
-		err = fslock.WithSharedBlocking(FlockFile(true), FlockBlocker,
+		err = fslock.WithSharedBlocking(FlockFile(true), blocker,
 			func() error {
 				data, err = kr.joinAndGetKeyringData(RECORD_KEY)
 				return err
@@ -214,7 +216,7 @@ func (kr *KeyringStore) getStorageData(s *StorageData) error {
 		)
 
 	default:
-		err = fslock.WithSharedBlocking(FlockFile(true), FlockBlocker,
+		err = fslock.WithSharedBlocking(FlockFile(true), blocker,
 			func() error {
 				data, err = kr.getKeyringData(RECORD_KEY)
 				return err
@@ -291,26 +293,33 @@ func (kr *KeyringStore) joinAndGetKeyringData(key string) ([]byte, error) {
 }
 
 // saves the entire StorageData into our KeyringStore
-func (kr *KeyringStore) saveStorageData() error {
+func (kr *KeyringStore) saveStorageData(ctx context.Context) error {
 	var err error
 	jdata, _ := json.Marshal(kr.cache)
 
+	lockCtx, cancel := context.WithTimeout(ctx, flockWaitTimeout)
+	defer cancel()
+	blocker := FlockBlockerWithCtx(lockCtx)
+
 	switch keyringGOOS {
 	case "windows":
-		err = fslock.WithBlocking(FlockFile(true), FlockBlocker,
+		err = fslock.WithBlocking(FlockFile(true), blocker,
 			func() error {
 				return kr.splitAndSetStorageData(jdata, RECORD_KEY, KEYRING_ID)
 			},
 		)
 	default:
-		err = fslock.WithBlocking(FlockFile(true), FlockBlocker,
+		err = fslock.WithBlocking(FlockFile(true), blocker,
 			func() error {
 				return kr.setStorageData(jdata, RECORD_KEY, KEYRING_ID)
 			},
 		)
 	}
 	FlockBlockerReset()
-	return err
+	if err != nil {
+		return fmt.Errorf("%w (run 'lsof %s' to find blocking process)", err, FlockFile(false))
+	}
+	return nil
 }
 
 // splitAndSetStorageData writes all the data in WINCRED_MAX_LENGTH length chunks
@@ -357,11 +366,11 @@ func (kr *KeyringStore) setStorageData(jdata []byte, key string, label string) e
 }
 
 // Save our RegisterClientData in the key chain
-func (kr *KeyringStore) SaveRegisterClientData(region string, client RegisterClientData) error {
+func (kr *KeyringStore) SaveRegisterClientData(ctx context.Context, region string, client RegisterClientData) error {
 	key := kr.RegisterClientKey(region)
 	kr.cache.RegisterClientData[key] = client
 
-	return kr.saveStorageData()
+	return kr.saveStorageData(ctx)
 }
 
 // Get our RegisterClientData from the key chain
@@ -375,7 +384,7 @@ func (kr *KeyringStore) GetRegisterClientData(region string, client *RegisterCli
 }
 
 // Delete the RegisterClientData from the keychain
-func (kr *KeyringStore) DeleteRegisterClientData(region string) error {
+func (kr *KeyringStore) DeleteRegisterClientData(ctx context.Context, region string) error {
 	key := kr.RegisterClientKey(region)
 	if _, ok := kr.cache.RegisterClientData[key]; !ok {
 		// return error if key doesn't exist
@@ -383,7 +392,7 @@ func (kr *KeyringStore) DeleteRegisterClientData(region string) error {
 	}
 
 	delete(kr.cache.RegisterClientData, key)
-	return kr.saveStorageData()
+	return kr.saveStorageData(ctx)
 }
 
 func (kr *KeyringStore) CreateTokenResponseKey(key string) string {
@@ -391,11 +400,11 @@ func (kr *KeyringStore) CreateTokenResponseKey(key string) string {
 }
 
 // SaveCreateTokenResponse stores the token in the keyring
-func (kr *KeyringStore) SaveCreateTokenResponse(key string, token CreateTokenResponse) error {
+func (kr *KeyringStore) SaveCreateTokenResponse(ctx context.Context, key string, token CreateTokenResponse) error {
 	k := kr.CreateTokenResponseKey(key)
 	kr.cache.CreateTokenResponse[k] = token
 
-	return kr.saveStorageData()
+	return kr.saveStorageData(ctx)
 }
 
 // GetCreateTokenResponse retrieves the CreateTokenResponse from the keyring
@@ -409,7 +418,7 @@ func (kr *KeyringStore) GetCreateTokenResponse(key string, token *CreateTokenRes
 }
 
 // DeleteCreateTokenResponse deletes the CreateTokenResponse from the keyring
-func (kr *KeyringStore) DeleteCreateTokenResponse(key string) error {
+func (kr *KeyringStore) DeleteCreateTokenResponse(ctx context.Context, key string) error {
 	k := kr.CreateTokenResponseKey(key)
 	if _, ok := kr.cache.CreateTokenResponse[k]; !ok {
 		// return error if key doesn't exist
@@ -417,13 +426,13 @@ func (kr *KeyringStore) DeleteCreateTokenResponse(key string) error {
 	}
 
 	delete(kr.cache.CreateTokenResponse, k)
-	return kr.saveStorageData()
+	return kr.saveStorageData(ctx)
 }
 
 // SaveRoleCredentials stores the token in the arnring
-func (kr *KeyringStore) SaveRoleCredentials(arn string, token RoleCredentials) error {
+func (kr *KeyringStore) SaveRoleCredentials(ctx context.Context, arn string, token RoleCredentials) error {
 	kr.cache.RoleCredentials[arn] = token
-	return kr.saveStorageData()
+	return kr.saveStorageData(ctx)
 }
 
 // GetRoleCredentials retrieves the RoleCredentials from the Keyring
@@ -436,20 +445,20 @@ func (kr *KeyringStore) GetRoleCredentials(arn string, token *RoleCredentials) e
 }
 
 // DeleteRoleCredentials deletes the RoleCredentials from the Keyring
-func (kr *KeyringStore) DeleteRoleCredentials(arn string) error {
+func (kr *KeyringStore) DeleteRoleCredentials(ctx context.Context, arn string) error {
 	if _, ok := kr.cache.RoleCredentials[arn]; !ok {
 		// return error if key doesn't exist
 		return fmt.Errorf("no RoleCredentials for ARN: %s", arn)
 	}
 
 	delete(kr.cache.RoleCredentials, arn)
-	return kr.saveStorageData()
+	return kr.saveStorageData(ctx)
 }
 
 // SaveStaticCredentials stores the token in the arnring
-func (kr *KeyringStore) SaveStaticCredentials(arn string, creds StaticCredentials) error {
+func (kr *KeyringStore) SaveStaticCredentials(ctx context.Context, arn string, creds StaticCredentials) error {
 	kr.cache.StaticCredentials[arn] = creds
-	return kr.saveStorageData()
+	return kr.saveStorageData(ctx)
 }
 
 // GetStaticCredentials retrieves the StaticCredentials from the Keyring
@@ -462,14 +471,14 @@ func (kr *KeyringStore) GetStaticCredentials(arn string, creds *StaticCredential
 }
 
 // DeleteStaticCredentials deletes the StaticCredentials from the Keyring
-func (kr *KeyringStore) DeleteStaticCredentials(arn string) error {
+func (kr *KeyringStore) DeleteStaticCredentials(ctx context.Context, arn string) error {
 	if _, ok := kr.cache.StaticCredentials[arn]; !ok {
 		// return error if key doesn't exist
 		return fmt.Errorf("no StaticCredentials for ARN: %s", arn)
 	}
 
 	delete(kr.cache.StaticCredentials, arn)
-	return kr.saveStorageData()
+	return kr.saveStorageData(ctx)
 }
 
 // ListStaticCredentials returns a list of all the ARNs in the keyring
@@ -484,9 +493,9 @@ func (kr *KeyringStore) ListStaticCredentials() []string {
 }
 
 // SaveEcsBearerToken stores the token in the keyring
-func (kr *KeyringStore) SaveEcsBearerToken(token string) error {
+func (kr *KeyringStore) SaveEcsBearerToken(ctx context.Context, token string) error {
 	kr.cache.EcsBearerToken = token
-	return kr.saveStorageData()
+	return kr.saveStorageData(ctx)
 }
 
 // GetEcsBearerToken retrieves the token from the keyring
@@ -495,13 +504,13 @@ func (kr *KeyringStore) GetEcsBearerToken() (string, error) {
 }
 
 // DeleteEcsBearerToken deletes the token from the keyring
-func (kr *KeyringStore) DeleteEcsBearerToken() error {
+func (kr *KeyringStore) DeleteEcsBearerToken(ctx context.Context) error {
 	kr.cache.EcsBearerToken = ""
-	return kr.saveStorageData()
+	return kr.saveStorageData(ctx)
 }
 
 // SaveEcsSslKeyPair stores the private key and certificate chain in the keyring
-func (kr *KeyringStore) SaveEcsSslKeyPair(privateKey, certChain []byte) error {
+func (kr *KeyringStore) SaveEcsSslKeyPair(ctx context.Context, privateKey, certChain []byte) error {
 	if err := ValidateSSLCertificate(certChain); err != nil {
 		return err
 	}
@@ -511,7 +520,7 @@ func (kr *KeyringStore) SaveEcsSslKeyPair(privateKey, certChain []byte) error {
 		return err
 	}
 	kr.cache.EcsPrivateKey = string(privateKey)
-	return kr.saveStorageData()
+	return kr.saveStorageData(ctx)
 }
 
 // GetEcsSslCert retrieves the private key and cert chain from the keyring
@@ -525,8 +534,8 @@ func (kr *KeyringStore) GetEcsSslKey() (string, error) {
 }
 
 // DeleteEcsSslKeyPair deletes the private key and cert chain from the keyring
-func (kr *KeyringStore) DeleteEcsSslKeyPair() error {
+func (kr *KeyringStore) DeleteEcsSslKeyPair(ctx context.Context) error {
 	kr.cache.EcsCertChain = ""
 	kr.cache.EcsPrivateKey = ""
-	return kr.saveStorageData()
+	return kr.saveStorageData(ctx)
 }

--- a/internal/storage/keyring_test.go
+++ b/internal/storage/keyring_test.go
@@ -19,6 +19,7 @@ package storage
  */
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -54,7 +55,7 @@ func TestKeyringSuite(t *testing.T) {
 	assert.NoError(t, err)
 
 	s := KeyringSuite{}
-	s.store, err = OpenKeyring(c)
+	s.store, err = OpenKeyring(context.Background(), c)
 	assert.NoError(t, err)
 	suite.Run(t, &s)
 }
@@ -70,7 +71,7 @@ func (suite *KeyringSuite) TestRegisterClientData() {
 		ClientSecretExpiresAt: time.Now().Unix() + 1,
 		TokenEndpoint:         "IhavenoideawhatI'mdoing",
 	}
-	err := suite.store.SaveRegisterClientData("foo", rcd)
+	err := suite.store.SaveRegisterClientData(context.Background(), "foo", rcd)
 	assert.NoError(t, err)
 
 	rcd2 := RegisterClientData{}
@@ -78,7 +79,7 @@ func (suite *KeyringSuite) TestRegisterClientData() {
 	assert.NoError(t, err)
 	assert.Equal(t, rcd, rcd2)
 
-	err = suite.store.DeleteRegisterClientData("foo")
+	err = suite.store.DeleteRegisterClientData(context.Background(), "foo")
 	assert.NoError(t, err)
 
 	err = suite.store.GetRegisterClientData("foo", &rcd2)
@@ -87,7 +88,7 @@ func (suite *KeyringSuite) TestRegisterClientData() {
 	err = suite.store.GetRegisterClientData("cow", &rcd2)
 	assert.Error(t, err)
 
-	err = suite.store.DeleteRegisterClientData("cow")
+	err = suite.store.DeleteRegisterClientData(context.Background(), "cow")
 	assert.Error(t, err)
 }
 
@@ -102,7 +103,7 @@ func (suite *KeyringSuite) TestCreateTokenResponse() {
 		RefreshToken: "just another token",
 		TokenType:    "yes",
 	}
-	err := suite.store.SaveCreateTokenResponse("foo", ctr)
+	err := suite.store.SaveCreateTokenResponse(context.Background(), "foo", ctr)
 	assert.NoError(t, err)
 
 	ctr2 := CreateTokenResponse{}
@@ -110,13 +111,13 @@ func (suite *KeyringSuite) TestCreateTokenResponse() {
 	assert.NoError(t, err)
 	assert.Equal(t, ctr, ctr2)
 
-	err = suite.store.DeleteCreateTokenResponse("foo")
+	err = suite.store.DeleteCreateTokenResponse(context.Background(), "foo")
 	assert.NoError(t, err)
 
 	err = suite.store.GetCreateTokenResponse("cow", &ctr2)
 	assert.Error(t, err)
 
-	err = suite.store.DeleteCreateTokenResponse("cow")
+	err = suite.store.DeleteCreateTokenResponse(context.Background(), "cow")
 	assert.Error(t, err)
 }
 
@@ -131,7 +132,7 @@ func (suite *KeyringSuite) TestRoleCredentials() {
 		SessionToken:    "Another secret string",
 		Expiration:      time.Now().Unix(),
 	}
-	err := suite.store.SaveRoleCredentials("foo", rc)
+	err := suite.store.SaveRoleCredentials(context.Background(), "foo", rc)
 	assert.NoError(t, err)
 
 	rc2 := RoleCredentials{}
@@ -139,7 +140,7 @@ func (suite *KeyringSuite) TestRoleCredentials() {
 	assert.NoError(t, err)
 	assert.Equal(t, rc, rc2)
 
-	err = suite.store.DeleteRoleCredentials("foo")
+	err = suite.store.DeleteRoleCredentials(context.Background(), "foo")
 	assert.NoError(t, err)
 
 	err = suite.store.GetRoleCredentials("foo", &rc2)
@@ -148,7 +149,7 @@ func (suite *KeyringSuite) TestRoleCredentials() {
 	err = suite.store.GetRoleCredentials("cow", &rc2)
 	assert.Error(t, err)
 
-	err = suite.store.DeleteRoleCredentials("cow")
+	err = suite.store.DeleteRoleCredentials(context.Background(), "cow")
 	assert.Error(t, err)
 }
 
@@ -159,14 +160,14 @@ func (suite *KeyringSuite) TestEcsBearerToken() {
 	assert.NoError(t, err)
 	assert.Empty(t, token)
 
-	err = suite.store.SaveEcsBearerToken("not a real token")
+	err = suite.store.SaveEcsBearerToken(context.Background(), "not a real token")
 	assert.NoError(t, err)
 
 	token, err = suite.store.GetEcsBearerToken()
 	assert.NoError(t, err)
 	assert.Equal(t, "not a real token", token)
 
-	err = suite.store.DeleteEcsBearerToken()
+	err = suite.store.DeleteEcsBearerToken(context.Background())
 	assert.NoError(t, err)
 
 	token, err = suite.store.GetEcsBearerToken()
@@ -190,16 +191,16 @@ func (suite *KeyringSuite) TestEcsSslKeyPair() { // nolint: dupl
 	keyBytes, err := os.ReadFile("../ecs/server/testdata/localhost.key")
 	assert.NoError(t, err)
 
-	err = suite.store.SaveEcsSslKeyPair([]byte{}, certBytes)
+	err = suite.store.SaveEcsSslKeyPair(context.Background(), []byte{}, certBytes)
 	assert.NoError(t, err)
 
-	err = suite.store.SaveEcsSslKeyPair(keyBytes, certBytes)
+	err = suite.store.SaveEcsSslKeyPair(context.Background(), keyBytes, certBytes)
 	assert.NoError(t, err)
 
-	err = suite.store.SaveEcsSslKeyPair(keyBytes, keyBytes)
+	err = suite.store.SaveEcsSslKeyPair(context.Background(), keyBytes, keyBytes)
 	assert.Error(t, err)
 
-	err = suite.store.SaveEcsSslKeyPair(certBytes, certBytes)
+	err = suite.store.SaveEcsSslKeyPair(context.Background(), certBytes, certBytes)
 	assert.Error(t, err)
 
 	cert, err = suite.store.GetEcsSslCert()
@@ -210,7 +211,7 @@ func (suite *KeyringSuite) TestEcsSslKeyPair() { // nolint: dupl
 	assert.NoError(t, err)
 	assert.Equal(t, string(keyBytes), key)
 
-	err = suite.store.DeleteEcsSslKeyPair()
+	err = suite.store.DeleteEcsSslKeyPair(context.Background())
 	assert.NoError(t, err)
 
 	cert, err = suite.store.GetEcsSslCert()
@@ -270,7 +271,7 @@ func TestGetStorageData(t *testing.T) {
 	assert.NoError(t, err)
 
 	s := KeyringSuite{}
-	s.store, err = OpenKeyring(c)
+	s.store, err = OpenKeyring(context.Background(), c)
 	assert.NoError(t, err)
 	suite.Run(t, &s)
 }
@@ -305,40 +306,40 @@ func TestKeyringErrors(t *testing.T) {
 		cache:   NewStorageData(),
 	}
 
-	err = ks.getStorageData(&StorageData{})
+	err = ks.getStorageData(context.Background(), &StorageData{})
 	assert.NoError(t, err)
 
-	err = ks.saveStorageData()
+	err = ks.saveStorageData(context.Background())
 	assert.Error(t, err)
 
 	// RegisterClientData
 	err = ks.GetRegisterClientData("region", &RegisterClientData{})
 	assert.Error(t, err)
 
-	err = ks.SaveRegisterClientData("region", RegisterClientData{})
+	err = ks.SaveRegisterClientData(context.Background(), "region", RegisterClientData{})
 	assert.Error(t, err)
 
-	err = ks.DeleteRegisterClientData("region")
+	err = ks.DeleteRegisterClientData(context.Background(), "region")
 	assert.Error(t, err)
 
 	// RoleCredentials
 	err = ks.GetRoleCredentials("foo", &RoleCredentials{})
 	assert.Error(t, err)
 
-	err = ks.SaveRoleCredentials("foo", RoleCredentials{})
+	err = ks.SaveRoleCredentials(context.Background(), "foo", RoleCredentials{})
 	assert.Error(t, err)
 
-	err = ks.DeleteRoleCredentials("bar")
+	err = ks.DeleteRoleCredentials(context.Background(), "bar")
 	assert.Error(t, err)
 
 	// CreateTokenResponse
 	err = ks.GetCreateTokenResponse("key", &CreateTokenResponse{})
 	assert.Error(t, err)
 
-	err = ks.SaveCreateTokenResponse("key", CreateTokenResponse{})
+	err = ks.SaveCreateTokenResponse(context.Background(), "key", CreateTokenResponse{})
 	assert.Error(t, err)
 
-	err = ks.DeleteCreateTokenResponse("key")
+	err = ks.DeleteCreateTokenResponse(context.Background(), "key")
 	assert.Error(t, err)
 }
 
@@ -362,17 +363,17 @@ func (suite *KeyringSuite) TestStaticCredentials() {
 	}
 	assert.Empty(t, suite.store.ListStaticCredentials())
 
-	assert.NoError(t, suite.store.SaveStaticCredentials(arn, cr))
+	assert.NoError(t, suite.store.SaveStaticCredentials(context.Background(), arn, cr))
 	assert.Equal(t, []string{arn}, suite.store.ListStaticCredentials())
 
 	cr2 := StaticCredentials{}
 	assert.NoError(t, suite.store.GetStaticCredentials(arn, &cr2))
 	assert.Equal(t, cr, cr2)
 
-	assert.NoError(t, suite.store.DeleteStaticCredentials(arn))
+	assert.NoError(t, suite.store.DeleteStaticCredentials(context.Background(), arn))
 	assert.Empty(t, suite.store.ListStaticCredentials())
 	assert.Error(t, suite.store.GetStaticCredentials(arn, &cr2))
-	assert.Error(t, suite.store.DeleteStaticCredentials(arn))
+	assert.Error(t, suite.store.DeleteStaticCredentials(context.Background(), arn))
 }
 
 func TestNewStorageData(t *testing.T) {
@@ -505,11 +506,11 @@ func TestKeyringSuiteFails(t *testing.T) {
 	err = os.WriteFile(path.Join(d, "secure", "aws-sso-cli-records"), in, 0600)
 	assert.NoError(t, err)
 
-	err = kr.getStorageData(&kr.cache)
+	err = kr.getStorageData(context.Background(), &kr.cache)
 	assert.Error(t, err)
 	assert.Equal(t, "unmarshal failure", err.Error())
 
-	_, err = OpenKeyring(c)
+	_, err = OpenKeyring(context.Background(), c)
 	assert.Error(t, err)
 	assert.Equal(t, "unmarshal failure", err.Error())
 }
@@ -537,7 +538,7 @@ func TestSplitCredentials(t *testing.T) {
 	c, err := NewKeyringConfig("file", d, "")
 	assert.NoError(t, err)
 
-	store, err := OpenKeyring(c)
+	store, err := OpenKeyring(context.Background(), c)
 	assert.NoError(t, err)
 
 	rc := RoleCredentials{ // nolint:gosec
@@ -566,36 +567,36 @@ func TestSplitCredentials(t *testing.T) {
 	}
 
 	keyringGOOS = "linux"
-	err = store.SaveRoleCredentials("bar", largeRC)
+	err = store.SaveRoleCredentials(context.Background(), "bar", largeRC)
 	assert.NoError(t, err)
 	rc2 := RoleCredentials{}
 	err = store.GetRoleCredentials("bar", &rc2)
 	assert.NoError(t, err)
 	assert.Equal(t, largeRC, rc2)
-	err = store.DeleteRoleCredentials("bar")
+	err = store.DeleteRoleCredentials(context.Background(), "bar")
 	assert.NoError(t, err)
 
 	keyringGOOS = "windows"
-	err = store.SaveRoleCredentials("bar", largeRC)
+	err = store.SaveRoleCredentials(context.Background(), "bar", largeRC)
 	assert.NoError(t, err)
 	rc2 = RoleCredentials{}
 	err = store.GetRoleCredentials("bar", &rc2)
 	assert.NoError(t, err)
 	assert.Equal(t, largeRC, rc2)
-	err = store.DeleteRoleCredentials("bar")
+	err = store.DeleteRoleCredentials(context.Background(), "bar")
 	assert.NoError(t, err)
-	err = store.SaveRoleCredentials("bar", rc)
+	err = store.SaveRoleCredentials(context.Background(), "bar", rc)
 	assert.NoError(t, err)
 	rc2 = RoleCredentials{}
 
 	err = store.GetRoleCredentials("bar", &rc2)
 	assert.NoError(t, err)
 	assert.Equal(t, rc, rc2)
-	err = store.DeleteRoleCredentials("bar")
+	err = store.DeleteRoleCredentials(context.Background(), "bar")
 	assert.NoError(t, err)
 
 	// Replace a chunk with wrong data
-	err = store.SaveRoleCredentials("bar", largeRC)
+	err = store.SaveRoleCredentials(context.Background(), "bar", largeRC)
 	assert.NoError(t, err)
 
 	ks := store.(*KeyringStore)
@@ -606,6 +607,6 @@ func TestSplitCredentials(t *testing.T) {
 	assert.Error(t, err)
 
 	// but OpenKeyring is fine
-	_, err = OpenKeyring(c)
+	_, err = OpenKeyring(context.Background(), c)
 	assert.NoError(t, err)
 }

--- a/internal/storage/secure_store.go
+++ b/internal/storage/secure_store.go
@@ -18,35 +18,40 @@ package storage
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Define the interface for storing our AWS SSO data
-type SecureStorage interface {
-	SaveRegisterClientData(string, RegisterClientData) error
-	GetRegisterClientData(string, *RegisterClientData) error
-	DeleteRegisterClientData(string) error
+import "context"
 
-	SaveCreateTokenResponse(string, CreateTokenResponse) error
-	GetCreateTokenResponse(string, *CreateTokenResponse) error
-	DeleteCreateTokenResponse(string) error
+// Define the interface for storing our AWS SSO data.
+// Save* and Delete* methods accept a context for cancellation and timeout
+// during file-lock acquisition. Get* methods read from an in-memory cache
+// and do not need a context.
+type SecureStorage interface {
+	SaveRegisterClientData(ctx context.Context, region string, client RegisterClientData) error
+	GetRegisterClientData(region string, client *RegisterClientData) error
+	DeleteRegisterClientData(ctx context.Context, region string) error
+
+	SaveCreateTokenResponse(ctx context.Context, key string, token CreateTokenResponse) error
+	GetCreateTokenResponse(key string, token *CreateTokenResponse) error
+	DeleteCreateTokenResponse(ctx context.Context, key string) error
 
 	// Temporary STS creds
-	SaveRoleCredentials(string, RoleCredentials) error
-	GetRoleCredentials(string, *RoleCredentials) error
-	DeleteRoleCredentials(string) error
+	SaveRoleCredentials(ctx context.Context, arn string, token RoleCredentials) error
+	GetRoleCredentials(arn string, token *RoleCredentials) error
+	DeleteRoleCredentials(ctx context.Context, arn string) error
 
 	// Static API creds
-	SaveStaticCredentials(string, StaticCredentials) error
-	GetStaticCredentials(string, *StaticCredentials) error
-	DeleteStaticCredentials(string) error
+	SaveStaticCredentials(ctx context.Context, arn string, creds StaticCredentials) error
+	GetStaticCredentials(arn string, creds *StaticCredentials) error
+	DeleteStaticCredentials(ctx context.Context, arn string) error
 	ListStaticCredentials() []string
 
 	// ECS Server Bearer Token
-	SaveEcsBearerToken(string) error
+	SaveEcsBearerToken(ctx context.Context, token string) error
 	GetEcsBearerToken() (string, error)
-	DeleteEcsBearerToken() error
+	DeleteEcsBearerToken(ctx context.Context) error
 
 	// ECS Server SSL Cert
-	SaveEcsSslKeyPair([]byte, []byte) error
-	DeleteEcsSslKeyPair() error
+	SaveEcsSslKeyPair(ctx context.Context, privateKey []byte, certChain []byte) error
+	DeleteEcsSslKeyPair(ctx context.Context) error
 	GetEcsSslCert() (string, error)
 	GetEcsSslKey() (string, error)
 }


### PR DESCRIPTION
Threads context.Context through SecureStorage so lock-wait loops honour cancellation. A signal.NotifyContext in main() cancels on SIGINT/SIGTERM; a goroutine calls os.Exit(1) when that fires, releasing storage.lock even if a D-Bus call is blocking.

Fixes #1379