### PR TITLE
Add lock/context for JSON SecureStore

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,6 +58,8 @@ jobs:
       with:
         go-version-file: 'go.mod'
 
+    - name: Setup Environment
+      run: mkdir -p ${HOME}/.config/aws-sso
 
     # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,9 @@ jobs:
       with:
         go-version-file: 'go.mod'
         cache: false
-      id: go
+      id: go 
+    - name: Setup Environment
+      run: mkdir -p ${HOME}/.config/aws-sso
     - name: Tests
       run: make .build-tests
     - name: Upload to codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changes
 
 * Add unit tests for cmd/aws-sso
+* Add lock support for JSON SecureStore
 
 ## [v2.2.4] - 2026-05-21
 

--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -256,7 +256,7 @@ func loadSecureStore(ctx *RunContext) {
 		if ctx.Settings.JsonStore != "" {
 			sfile = fileutils.GetHomePath(ctx.Settings.JsonStore)
 		}
-		ctx.Store, err = storage.OpenJsonStore(sfile)
+		ctx.Store, err = storage.OpenJsonStore(ctx.Ctx, sfile)
 		if err != nil {
 			log.Fatal("Unable to open JsonStore", "file", sfile, "error", err.Error())
 		}

--- a/internal/sso/auth/awssso_auth_test.go
+++ b/internal/sso/auth/awssso_auth_test.go
@@ -154,7 +154,7 @@ func TestAuthenticateSteps(t *testing.T) {
 	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
-	jstore, err := storage.OpenJsonStore(tfile.Name())
+	jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 	assert.NoError(t, err)
 
 	defer os.Remove(tfile.Name())
@@ -234,7 +234,7 @@ func TestAuthenticate(t *testing.T) {
 	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
-	jstore, err := storage.OpenJsonStore(tfile.Name())
+	jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 	assert.NoError(t, err)
 
 	defer os.Remove(tfile.Name())
@@ -400,7 +400,7 @@ func authTokenSetup(t *testing.T, workflow oidc.AuthWorkflow) (as *AWSSSO, key s
 	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
-	jstore, err = storage.OpenJsonStore(tfile.Name())
+	jstore, err = storage.OpenJsonStore(context.Background(), tfile.Name())
 	assert.NoError(t, err)
 
 	t.Cleanup(func() {
@@ -502,7 +502,7 @@ func TestAuthenticateFailure(t *testing.T) {
 	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
-	jstore, err := storage.OpenJsonStore(tfile.Name())
+	jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 	assert.NoError(t, err)
 
 	defer os.Remove(tfile.Name())
@@ -676,7 +676,7 @@ func TestReauthenticate(t *testing.T) {
 	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
-	jstore, err := storage.OpenJsonStore(tfile.Name())
+	jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 	assert.NoError(t, err)
 
 	defer os.Remove(tfile.Name())
@@ -737,7 +737,7 @@ func TestLogout(t *testing.T) {
 	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
-	jstore, err := storage.OpenJsonStore(tfile.Name())
+	jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 	assert.NoError(t, err)
 
 	defer os.Remove(tfile.Name())
@@ -901,7 +901,7 @@ func TestSaveToken(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.Remove(tfile.Name())
 
-	jstore, err := storage.OpenJsonStore(tfile.Name())
+	jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 	assert.NoError(t, err)
 
 	as := &AWSSSO{
@@ -935,7 +935,7 @@ func TestRegisterClientPKCE(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.Remove(tfile.Name())
 
-	jstore, err := storage.OpenJsonStore(tfile.Name())
+	jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 	assert.NoError(t, err)
 
 	mock := &mockOIDCClient{
@@ -975,7 +975,7 @@ func TestReauthenticatePKCE(t *testing.T) {
 		assert.NoError(t, err)
 		defer os.Remove(tfile.Name())
 
-		jstore, err := storage.OpenJsonStore(tfile.Name())
+		jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 		assert.NoError(t, err)
 
 		mock := &mockOIDCClient{
@@ -1033,7 +1033,7 @@ func TestReauthenticatePKCE(t *testing.T) {
 		assert.NoError(t, err)
 		defer os.Remove(tfile.Name())
 
-		jstore, err := storage.OpenJsonStore(tfile.Name())
+		jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 		assert.NoError(t, err)
 
 		mock := &mockOIDCClient{
@@ -1060,7 +1060,7 @@ func TestReauthenticatePKCE(t *testing.T) {
 		assert.NoError(t, err)
 		defer os.Remove(tfile.Name())
 
-		jstore, err := storage.OpenJsonStore(tfile.Name())
+		jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 		assert.NoError(t, err)
 
 		mock := &mockOIDCClient{
@@ -1092,7 +1092,7 @@ func TestReauthenticatePKCE(t *testing.T) {
 		assert.NoError(t, err)
 		defer os.Remove(tfile.Name())
 
-		jstore, err := storage.OpenJsonStore(tfile.Name())
+		jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 		assert.NoError(t, err)
 
 		mock := &mockOIDCClient{
@@ -1139,7 +1139,7 @@ func TestTryRefreshToken(t *testing.T) {
 		assert.NoError(t, err)
 		defer os.Remove(tfile.Name())
 
-		jstore, err := storage.OpenJsonStore(tfile.Name())
+		jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 		assert.NoError(t, err)
 
 		newToken := storage.CreateTokenResponse{
@@ -1184,7 +1184,7 @@ func TestTryRefreshToken(t *testing.T) {
 		assert.NoError(t, err)
 		defer os.Remove(tfile.Name())
 
-		jstore, err := storage.OpenJsonStore(tfile.Name())
+		jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 		assert.NoError(t, err)
 
 		mock := &mockOIDCClient{
@@ -1210,7 +1210,7 @@ func TestValidAuthTokenRefresh(t *testing.T) {
 		assert.NoError(t, err)
 		defer os.Remove(tfile.Name())
 
-		jstore, err := storage.OpenJsonStore(tfile.Name())
+		jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 		assert.NoError(t, err)
 
 		newToken := storage.CreateTokenResponse{
@@ -1265,7 +1265,7 @@ func TestValidAuthTokenRefresh(t *testing.T) {
 		assert.NoError(t, err)
 		defer os.Remove(tfile.Name())
 
-		jstore, err := storage.OpenJsonStore(tfile.Name())
+		jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 		assert.NoError(t, err)
 
 		mock := &mockOIDCClient{
@@ -1305,7 +1305,7 @@ func TestValidAuthTokenRefresh(t *testing.T) {
 		assert.NoError(t, err)
 		defer os.Remove(tfile.Name())
 
-		jstore, err := storage.OpenJsonStore(tfile.Name())
+		jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 		assert.NoError(t, err)
 
 		mock := &mockOIDCClient{}

--- a/internal/sso/auth/awssso_test.go
+++ b/internal/sso/auth/awssso_test.go
@@ -93,7 +93,7 @@ func TestNewAWSSSO(t *testing.T) {
 	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
-	jstore, err = storage.OpenJsonStore(tfile.Name())
+	jstore, err = storage.OpenJsonStore(context.Background(), tfile.Name())
 	assert.NoError(t, err)
 
 	defer os.Remove(tfile.Name())
@@ -145,7 +145,7 @@ func TestGetRoles(t *testing.T) {
 	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
-	jstore, err := storage.OpenJsonStore(tfile.Name())
+	jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 	assert.NoError(t, err)
 
 	defer os.Remove(tfile.Name())
@@ -466,7 +466,7 @@ func TestGetAccounts(t *testing.T) {
 	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
-	jstore, err := storage.OpenJsonStore(tfile.Name())
+	jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 	assert.NoError(t, err)
 
 	defer os.Remove(tfile.Name())
@@ -645,7 +645,7 @@ func TestGetRoleCredentials(t *testing.T) {
 	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
 
-	jstore, err := storage.OpenJsonStore(tfile.Name())
+	jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 	assert.NoError(t, err)
 
 	defer os.Remove(tfile.Name())
@@ -736,7 +736,7 @@ func makeChainTestAWSSSOBase(t *testing.T) (*AWSSSO, func()) {
 	t.Helper()
 	tfile, err := os.CreateTemp("", "*storage.json")
 	assert.NoError(t, err)
-	jstore, err := storage.OpenJsonStore(tfile.Name())
+	jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 	assert.NoError(t, err)
 
 	duration, _ := time.ParseDuration("10s")
@@ -865,7 +865,7 @@ func TestListAccountsMaxResultsWithinAPILimit(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.Remove(tfile.Name())
 
-	jstore, err := storage.OpenJsonStore(tfile.Name())
+	jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 	assert.NoError(t, err)
 
 	duration, _ := time.ParseDuration("10s")
@@ -912,7 +912,7 @@ func TestListAccountRolesMaxResultsWithinAPILimit(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.Remove(tfile.Name())
 
-	jstore, err := storage.OpenJsonStore(tfile.Name())
+	jstore, err := storage.OpenJsonStore(context.Background(), tfile.Name())
 	assert.NoError(t, err)
 
 	duration, _ := time.ParseDuration("10s")

--- a/internal/sso/roles_test.go
+++ b/internal/sso/roles_test.go
@@ -19,6 +19,7 @@ package sso
  */
 
 import (
+	"context"
 	"math"
 	"os"
 	"strings"
@@ -86,7 +87,7 @@ func TestCacheRolesTestSuite(t *testing.T) {
 	err = os.WriteFile(jsonFile, input, 0600) // nolint:gosec
 	assert.Nil(t, err)
 
-	sstore, err := storage.OpenJsonStore(jsonFile)
+	sstore, err := storage.OpenJsonStore(context.Background(), jsonFile)
 	assert.Nil(t, err)
 
 	defaults := map[string]interface{}{}

--- a/internal/storage/json_store.go
+++ b/internal/storage/json_store.go
@@ -26,6 +26,7 @@ import (
 	"io/fs"
 	"os"
 
+	"github.com/danjacques/gofslock/fslock"
 	"github.com/synfinatic/aws-sso-cli/internal/fileutils"
 	// "github.com/davecgh/go-spew/spew"
 )
@@ -44,7 +45,7 @@ type JsonStore struct {
 }
 
 // OpenJsonStore opens our insecure JSON storage backend
-func OpenJsonStore(filename string) (SecureStorage, error) {
+func OpenJsonStore(ctx context.Context, filename string) (SecureStorage, error) {
 	jstore := JsonStore{
 		filename:            filename,
 		RegisterClient:      map[string]RegisterClientData{},
@@ -57,22 +58,40 @@ func OpenJsonStore(filename string) (SecureStorage, error) {
 		EcsCertChain:        "",
 	}
 
-	cacheBytes, err := os.ReadFile(filename)
-	if errors.Is(err, fs.ErrNotExist) {
+	lockCtx, cancel := context.WithTimeout(ctx, flockWaitTimeout)
+	defer cancel()
+	blocker := FlockBlockerWithCtx(lockCtx)
+
+	var cacheBytes []byte
+	var notExist bool
+	lockErr := fslock.WithSharedBlocking(FlockFile(true), blocker, func() error {
+		var err error
+		cacheBytes, err = os.ReadFile(filename)
+		if errors.Is(err, fs.ErrNotExist) {
+			notExist = true
+			return nil
+		}
+		return err
+	})
+	FlockBlockerReset()
+
+	if lockErr != nil {
+		return &jstore, fmt.Errorf("unable to open %s: %w", filename, lockErr)
+	}
+	if notExist {
 		return &jstore, nil
-	} else if err != nil {
-		return &jstore, fmt.Errorf("unable to open %s: %s", filename, err.Error())
 	}
 
 	if len(cacheBytes) > 0 {
-		err = json.Unmarshal(cacheBytes, &jstore)
+		if err := json.Unmarshal(cacheBytes, &jstore); err != nil {
+			return &jstore, err
+		}
 	}
-
-	return &jstore, err
+	return &jstore, nil
 }
 
-// save writes the JSON store file, creating the directory if necessary
-func (jc *JsonStore) save() error {
+// save writes the JSON store file under an exclusive flock, creating the directory if necessary
+func (jc *JsonStore) save(ctx context.Context) error {
 	log.Debug("Saving JSON Cache")
 	jbytes, err := json.MarshalIndent(jc, "", "  ")
 	if err != nil {
@@ -80,18 +99,28 @@ func (jc *JsonStore) save() error {
 		return err
 	}
 
-	err = fileutils.EnsureDirExists(jc.filename)
-	if err != nil {
+	if err = fileutils.EnsureDirExists(jc.filename); err != nil {
 		return err
 	}
 
-	return os.WriteFile(jc.filename, jbytes, 0600)
+	lockCtx, cancel := context.WithTimeout(ctx, flockWaitTimeout)
+	defer cancel()
+	blocker := FlockBlockerWithCtx(lockCtx)
+
+	err = fslock.WithBlocking(FlockFile(true), blocker, func() error {
+		return os.WriteFile(jc.filename, jbytes, 0600)
+	})
+	FlockBlockerReset()
+	if err != nil {
+		return fmt.Errorf("%w (run 'lsof %s' to find blocking process)", err, FlockFile(false))
+	}
+	return nil
 }
 
 // SaveRegisterClientData saves the RegisterClientData in our JSON store
-func (jc *JsonStore) SaveRegisterClientData(_ context.Context, key string, client RegisterClientData) error {
+func (jc *JsonStore) SaveRegisterClientData(ctx context.Context, key string, client RegisterClientData) error {
 	jc.RegisterClient[key] = client
-	return jc.save()
+	return jc.save(ctx)
 }
 
 // GetRegisterClientData retrieves the RegisterClientData from our JSON store
@@ -105,15 +134,15 @@ func (jc *JsonStore) GetRegisterClientData(key string, client *RegisterClientDat
 }
 
 // DeleteRegisterClientData deletes the RegisterClientData from the JSON store
-func (jc *JsonStore) DeleteRegisterClientData(_ context.Context, key string) error {
+func (jc *JsonStore) DeleteRegisterClientData(ctx context.Context, key string) error {
 	delete(jc.RegisterClient, key)
-	return jc.save()
+	return jc.save(ctx)
 }
 
 // SaveCreateTokenResponse stores the token in the json file
-func (jc *JsonStore) SaveCreateTokenResponse(_ context.Context, key string, token CreateTokenResponse) error {
+func (jc *JsonStore) SaveCreateTokenResponse(ctx context.Context, key string, token CreateTokenResponse) error {
 	jc.CreateTokenResponse[key] = token
-	return jc.save()
+	return jc.save(ctx)
 }
 
 // GetCreateTokenResponse retrieves the CreateTokenResponse from the json file
@@ -127,15 +156,15 @@ func (jc *JsonStore) GetCreateTokenResponse(key string, token *CreateTokenRespon
 }
 
 // DeleteCreateTokenResponse deletes the token from the json file
-func (jc *JsonStore) DeleteCreateTokenResponse(_ context.Context, key string) error {
+func (jc *JsonStore) DeleteCreateTokenResponse(ctx context.Context, key string) error {
 	delete(jc.CreateTokenResponse, key)
-	return jc.save()
+	return jc.save(ctx)
 }
 
 // SaveRoleCredentials stores the token in the json file
-func (jc *JsonStore) SaveRoleCredentials(_ context.Context, arn string, token RoleCredentials) error {
+func (jc *JsonStore) SaveRoleCredentials(ctx context.Context, arn string, token RoleCredentials) error {
 	jc.RoleCredentials[arn] = token
-	return jc.save()
+	return jc.save(ctx)
 }
 
 // GetRoleCredentials retrieves the RoleCredentials from the json file
@@ -149,15 +178,15 @@ func (jc *JsonStore) GetRoleCredentials(arn string, token *RoleCredentials) erro
 }
 
 // DeleteRoleCredentials deletes the token from the json file
-func (jc *JsonStore) DeleteRoleCredentials(_ context.Context, arn string) error {
+func (jc *JsonStore) DeleteRoleCredentials(ctx context.Context, arn string) error {
 	delete(jc.RoleCredentials, arn)
-	return jc.save()
+	return jc.save(ctx)
 }
 
 // SaveStaticCredentials stores the token in the json file
-func (jc *JsonStore) SaveStaticCredentials(_ context.Context, arn string, creds StaticCredentials) error {
+func (jc *JsonStore) SaveStaticCredentials(ctx context.Context, arn string, creds StaticCredentials) error {
 	jc.StaticCredentials[arn] = creds
-	return jc.save()
+	return jc.save(ctx)
 }
 
 // GetStaticCredentials retrieves the StaticCredentials from the json file
@@ -171,14 +200,14 @@ func (jc *JsonStore) GetStaticCredentials(arn string, creds *StaticCredentials) 
 }
 
 // DeleteStaticCredentials deletes the StaticCredentials from the json file
-func (jc *JsonStore) DeleteStaticCredentials(_ context.Context, arn string) error {
+func (jc *JsonStore) DeleteStaticCredentials(ctx context.Context, arn string) error {
 	if _, ok := jc.StaticCredentials[arn]; !ok {
 		// return error if key doesn't exist
 		return fmt.Errorf("no StaticCredentials for ARN: %s", arn)
 	}
 
 	delete(jc.StaticCredentials, arn)
-	return jc.save()
+	return jc.save(ctx)
 }
 
 // ListStaticCredentials returns all the ARN's of static credentials
@@ -193,9 +222,9 @@ func (jc *JsonStore) ListStaticCredentials() []string {
 }
 
 // SaveEcsBearerToken stores the token in the json file
-func (jc *JsonStore) SaveEcsBearerToken(_ context.Context, token string) error {
+func (jc *JsonStore) SaveEcsBearerToken(ctx context.Context, token string) error {
 	jc.EcsBearerToken = token
-	return jc.save()
+	return jc.save(ctx)
 }
 
 // GetEcsBearerToken retrieves the token from the json file
@@ -204,13 +233,13 @@ func (jc *JsonStore) GetEcsBearerToken() (string, error) {
 }
 
 // DeleteEcsBearerToken deletes the token from the json file
-func (jc *JsonStore) DeleteEcsBearerToken(_ context.Context) error {
+func (jc *JsonStore) DeleteEcsBearerToken(ctx context.Context) error {
 	jc.EcsBearerToken = ""
-	return jc.save()
+	return jc.save(ctx)
 }
 
 // SaveEcsSslKeyPair stores the SSL private key and certificate chain in the json file
-func (jc *JsonStore) SaveEcsSslKeyPair(_ context.Context, privateKey, certChain []byte) error {
+func (jc *JsonStore) SaveEcsSslKeyPair(ctx context.Context, privateKey, certChain []byte) error {
 	if err := ValidateSSLCertificate(certChain); err != nil {
 		return err
 	}
@@ -220,7 +249,7 @@ func (jc *JsonStore) SaveEcsSslKeyPair(_ context.Context, privateKey, certChain 
 		return err
 	}
 	jc.EcsPrivateKey = string(privateKey)
-	return jc.save()
+	return jc.save(ctx)
 }
 
 // GetEcsSslCert retrieves the SSL certificate chain from the json file
@@ -234,8 +263,8 @@ func (jc *JsonStore) GetEcsSslKey() (string, error) {
 }
 
 // DeleteEcsSslKeyPair deletes the SSL private key and certificate chain from the json file
-func (jc *JsonStore) DeleteEcsSslKeyPair(_ context.Context) error {
+func (jc *JsonStore) DeleteEcsSslKeyPair(ctx context.Context) error {
 	jc.EcsPrivateKey = ""
 	jc.EcsCertChain = ""
-	return jc.save()
+	return jc.save(ctx)
 }

--- a/internal/storage/json_store_test.go
+++ b/internal/storage/json_store_test.go
@@ -33,12 +33,12 @@ const TEST_JSON_STORE_FILE = "./testdata/store.json"
 func TestNewFile(t *testing.T) {
 	fname := "./testdata/new-store.json"
 	defer os.Remove(fname)
-	s, err := OpenJsonStore(fname)
+	s, err := OpenJsonStore(context.Background(), fname)
 	assert.Nil(t, err)
 
 	assert.Error(t, s.GetRegisterClientData("foobar", &RegisterClientData{}))
 
-	err = s.(*JsonStore).save()
+	err = s.(*JsonStore).save(context.Background())
 	assert.Nil(t, err)
 }
 
@@ -48,7 +48,7 @@ func TestBadFilePerms(t *testing.T) {
 	err := os.WriteFile(fname, []byte{}, 0000)
 	assert.NoError(t, err)
 
-	_, err = OpenJsonStore(fname)
+	_, err = OpenJsonStore(context.Background(), fname)
 	assert.Error(t, err)
 }
 
@@ -78,7 +78,7 @@ func (s *JsonStoreTestSuite) SetupTest() {
 	err = os.WriteFile(s.jsonFile, input, 0600)
 	assert.Nil(t, err)
 
-	s.json, err = OpenJsonStore(s.jsonFile)
+	s.json, err = OpenJsonStore(context.Background(), s.jsonFile)
 	assert.Nil(t, err)
 }
 


### PR DESCRIPTION
JSON SecureStore now uses the context and performs locking to prevent multiple aws-sso instances from read/writing the file at the sametime.