### PR TITLE
fix: don't exit non-zero on clean shutdown after SIGINT handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Bugs
 
+* Fix `aws-sso process` exiting non-zero on success, breaking its use as an AWS
+  credential_process (regression from the SIGINT handling in #1379)
 * Fix zombie processes holding storage.lock after SIGINT #1379
 
 ### Changes

--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -52,6 +52,9 @@ var VALID_LOG_LEVELS = []string{"error", "warn", "info", "debug", "trace"}
 
 var AwsSSO *ssoauth.AWSSSO // global
 
+// osExit is a seam so tests can observe a hard exit without terminating the test binary.
+var osExit = os.Exit
+
 // AccountID is a custom type that safely parses AWS account IDs from strings with leading zeros.
 type AccountID int64
 
@@ -164,16 +167,36 @@ type CLI struct {
 	Process     ProcessCmd     `kong:"cmd,help='Generate JSON for AWS SDK credential_process command',group='login-required'"`
 }
 
-func main() {
+// watchSignals wires SIGINT/SIGTERM handling. It returns a context that is cancelled
+// when a signal arrives (so lock-wait loops can honour cancellation) plus a stop func
+// to release the handler on a clean exit.
+//
+// It also force-exits via osExit(1) on an actual signal, so the process terminates even
+// when the main goroutine is blocked inside an uninterruptible keyring/D-Bus call; the
+// OS then releases all fcntl locks (e.g. storage.lock). See #1379.
+//
+// The hard-exit goroutine deliberately watches a dedicated signal channel rather than the
+// context's Done(): NotifyContext also cancels on the deferred stop() of a normal exit,
+// which would otherwise make even successful commands exit non-zero -- breaking `process`
+// as an AWS credential_process.
+func watchSignals() (context.Context, context.CancelFunc) {
 	appCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go hardExitOnSignal(sigCh)
+	return appCtx, stop
+}
 
-	// Exit on first signal even when blocked inside a keyring/D-Bus call.
-	// The OS then releases all fcntl locks held by this process.
-	go func() {
-		<-appCtx.Done()
-		os.Exit(1)
-	}()
+// hardExitOnSignal calls osExit(1) once a signal arrives on sigCh. Extracted so the
+// exit-on-signal behaviour can be unit tested without sending real OS signals.
+func hardExitOnSignal(sigCh <-chan os.Signal) {
+	<-sigCh
+	osExit(1)
+}
+
+func main() {
+	appCtx, stop := watchSignals()
+	defer stop()
 
 	cli := CLI{}
 	var err error

--- a/cmd/aws-sso/main_test.go
+++ b/cmd/aws-sso/main_test.go
@@ -1,14 +1,13 @@
 package main
 
 import (
-	"context"
 	"os"
-	"os/exec"
+	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAccountIDUnmarshalText(t *testing.T) {
@@ -58,27 +57,47 @@ func TestAccountIDUnmarshalText(t *testing.T) {
 	}
 }
 
-// TestSignalExitGoroutine verifies that cancelling the signal context causes os.Exit(1).
-// It uses a subprocess so os.Exit doesn't terminate the test runner.
-func TestSignalExitGoroutine(t *testing.T) {
-	if os.Getenv("TEST_SIGNAL_EXIT_SUBPROCESS") == "1" {
-		ctx, cancel := context.WithCancel(context.Background())
-		go func() {
-			<-ctx.Done()
-			os.Exit(1)
-		}()
-		cancel()
-		time.Sleep(time.Second) // should not reach here
-		return
-	}
+// TestWatchSignalsCleanStopDoesNotExit is the regression test for the credential_process
+// exit-code bug: a clean shutdown (the deferred stop() on a successful run) must NOT
+// trigger the hard-exit goroutine. Otherwise even successful commands exit non-zero and
+// `aws-sso process` becomes unusable as an AWS credential_process.
+//
+// With the buggy wiring (goroutine watching appCtx.Done()) stop() cancels the context and
+// the goroutine calls os.Exit(1); with the fix (goroutine watching a dedicated signal
+// channel) stop() is a no-op for the exit path.
+func TestWatchSignalsCleanStopDoesNotExit(t *testing.T) {
+	orig := osExit
+	var exited int32
+	osExit = func(int) { atomic.StoreInt32(&exited, 1) }
+	t.Cleanup(func() { osExit = orig })
 
-	cmd := exec.Command(os.Args[0], "-test.run=TestSignalExitGoroutine", "-test.v") //nolint:gosec
-	cmd.Env = append(os.Environ(), "TEST_SIGNAL_EXIT_SUBPROCESS=1")
-	err := cmd.Run()
-	require.Error(t, err)
-	var exitErr *exec.ExitError
-	require.ErrorAs(t, err, &exitErr)
-	assert.Equal(t, 1, exitErr.ExitCode())
+	_, stop := watchSignals()
+	stop()                             // normal, successful-exit path
+	time.Sleep(100 * time.Millisecond) // give the goroutine time to (wrongly) fire
+
+	assert.Equal(t, int32(0), atomic.LoadInt32(&exited),
+		"a clean stop() must not call os.Exit -- would break credential_process")
+}
+
+// TestHardExitOnSignalExitsOnSignal verifies the intended behaviour from #1379: an actual
+// signal forces os.Exit(1). It feeds the signal channel directly, so no real OS signal is
+// sent and the test never touches AWS, the keyring, or the network.
+func TestHardExitOnSignalExitsOnSignal(t *testing.T) {
+	orig := osExit
+	done := make(chan int, 1)
+	osExit = func(code int) { done <- code }
+	t.Cleanup(func() { osExit = orig })
+
+	sigCh := make(chan os.Signal, 1)
+	go hardExitOnSignal(sigCh)
+	sigCh <- syscall.SIGINT
+
+	select {
+	case code := <-done:
+		assert.Equal(t, 1, code)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected os.Exit(1) after receiving a signal")
+	}
 }
 
 func TestLogLevelTypeValidate(t *testing.T) {


### PR DESCRIPTION
## Summary

Fast commands such as `aws-sso process` exit with status **1 on success**. This
breaks `aws-sso process` as an AWS `credential_process`: the SDK discards the
(valid) credentials printed to stdout because the process returned non-zero.
Downstream this surfaces e.g. in CDK as `Unable to resolve AWS account to use…`.

Regression introduced by the SIGINT handling added in #1379.

## Root cause

```go
appCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
defer stop()

go func() {
    <-appCtx.Done()
    os.Exit(1)
}()
```

`signal.NotifyContext` returns a context cancelled on **a signal OR on `stop()`**.
`defer stop()` runs on every normal return, so a successful exit cancels the
context, the goroutine unblocks and calls `os.Exit(1)`, racing the runtime's
`exit(0)`. For fast commands the goroutine wins deterministically (reproduced
3/3 with `process`).

## Fix

Watch a dedicated signal channel for the hard-exit instead of `appCtx.Done()`,
so only a real SIGINT/SIGTERM triggers `os.Exit(1)`. The context is still
cancelled on signal, so the lock-wait cancellation from #1379 is preserved.

Signal wiring is extracted into `watchSignals()` / `hardExitOnSignal()` with an
`osExit` seam so the behaviour is unit-testable without sending real signals.

## Testing

- New `TestWatchSignalsCleanStopDoesNotExit`: a clean `stop()` must not call
  `os.Exit` — fails against the old wiring, passes with the fix.
- New `TestHardExitOnSignalExitsOnSignal`: a real signal still forces
  `os.Exit(1)`, by feeding the channel directly (no OS signal, no AWS).
- Replaces `TestSignalExitGoroutine`, which tested a reimplemented mock rather
  than `main()` and asserted the buggy "cancel → exit 1" behaviour as expected.
- Verified live: `aws-sso process …` exits 0 with valid JSON on stdout. Full
  suite green; `go vet` / `gofmt` clean.

Refs #1379
