### PR TITLE
fix: resolve OIDC and federation endpoints per AWS partition (EU Sovereign Cloud)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 * Fix `aws-sso process` exiting non-zero on success, breaking its use as an AWS
   credential_process (regression from the SIGINT handling in #1379)
+* Fix AWS European Sovereign Cloud (EUSC) login: derive the OIDC `/authorize`
+  endpoint and the federation sign-in URL from the region's partition
+  (`amazonaws.eu` / `amazonaws-eusc.eu`) instead of hardcoding `amazonaws.com`
 * Fix zombie processes holding storage.lock after SIGINT #1379
 
 ### Changes

--- a/internal/sso/auth/awssso_auth.go
+++ b/internal/sso/auth/awssso_auth.go
@@ -339,7 +339,9 @@ func (as *AWSSSO) pkceRedirectURIBase() string {
 }
 
 // pkceAuthorizationEndpoint returns the OIDC /authorize endpoint URL.
-// AWS does not return this from RegisterClient, so we construct it from the region.
+// AWS does not return this from RegisterClient, so we construct it from the region
+// using the SDK's partition-aware endpoint rules (so e.g. the AWS European
+// Sovereign Cloud resolves to amazonaws.eu instead of amazonaws.com).
 func (as *AWSSSO) pkceAuthorizationEndpoint() string {
 	if as.ClientData.AuthorizationEndpoint != "" {
 		ep := strings.TrimSuffix(as.ClientData.AuthorizationEndpoint, "/")
@@ -348,7 +350,7 @@ func (as *AWSSSO) pkceAuthorizationEndpoint() string {
 		}
 		return ep
 	}
-	return fmt.Sprintf("https://oidc.%s.amazonaws.com/authorize", as.SsoRegion)
+	return oidc.AuthorizationEndpoint(as.SsoRegion)
 }
 
 func (as *AWSSSO) reauthenticateDeviceCode(ctx context.Context) error {

--- a/internal/sso/auth/awssso_auth.go
+++ b/internal/sso/auth/awssso_auth.go
@@ -342,13 +342,13 @@ func (as *AWSSSO) pkceRedirectURIBase() string {
 // AWS does not return this from RegisterClient, so we construct it from the region
 // using the SDK's partition-aware endpoint rules (so e.g. the AWS European
 // Sovereign Cloud resolves to amazonaws.eu instead of amazonaws.com).
-func (as *AWSSSO) pkceAuthorizationEndpoint() string {
+func (as *AWSSSO) pkceAuthorizationEndpoint() (string, error) {
 	if as.ClientData.AuthorizationEndpoint != "" {
 		ep := strings.TrimSuffix(as.ClientData.AuthorizationEndpoint, "/")
 		if !strings.HasSuffix(ep, "/authorize") {
 			ep += "/authorize"
 		}
-		return ep
+		return ep, nil
 	}
 	return oidc.AuthorizationEndpoint(as.SsoRegion)
 }
@@ -401,8 +401,13 @@ func (as *AWSSSO) reauthenticatePKCE(ctx context.Context) error {
 	_ = ln.Close()
 	redirectURI := fmt.Sprintf("http://127.0.0.1:%d", port)
 
+	authEndpoint, err := as.pkceAuthorizationEndpoint()
+	if err != nil {
+		return fmt.Errorf("unable to determine pkce authorization endpoint: %w", err)
+	}
+
 	flow, err := as.oidcClient.StartPKCEAuthCodeFlow(ctx, oidc.StartPKCEAuthCodeInput{
-		AuthorizationEndpoint: as.pkceAuthorizationEndpoint(),
+		AuthorizationEndpoint: authEndpoint,
 		ClientID:              as.ClientData.ClientId,
 		RedirectURI:           redirectURI,
 		Scopes:                []string{SSO_ACCOUNT_ACCESS_SCOPE},

--- a/internal/sso/auth/awssso_auth_test.go
+++ b/internal/sso/auth/awssso_auth_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	ssoconfig "github.com/synfinatic/aws-sso-cli/internal/sso/config"
 	"github.com/synfinatic/aws-sso-cli/internal/sso/oidc"
 	"github.com/synfinatic/aws-sso-cli/internal/storage"
@@ -863,7 +864,9 @@ func (m *mockOIDCClient) ExchangeRefreshToken(_ context.Context, in oidc.Exchang
 func TestPkceAuthorizationEndpoint(t *testing.T) {
 	t.Run("default from region", func(t *testing.T) {
 		as := &AWSSSO{SsoRegion: "us-east-1"}
-		assert.Equal(t, "https://oidc.us-east-1.amazonaws.com/authorize", as.pkceAuthorizationEndpoint())
+		ep, err := as.pkceAuthorizationEndpoint()
+		require.NoError(t, err)
+		assert.Equal(t, "https://oidc.us-east-1.amazonaws.com/authorize", ep)
 	})
 
 	t.Run("custom endpoint without /authorize", func(t *testing.T) {
@@ -871,7 +874,9 @@ func TestPkceAuthorizationEndpoint(t *testing.T) {
 			SsoRegion:  "us-east-1",
 			ClientData: storage.RegisterClientData{AuthorizationEndpoint: "https://custom.example.com/oauth2"},
 		}
-		assert.Equal(t, "https://custom.example.com/oauth2/authorize", as.pkceAuthorizationEndpoint())
+		ep, err := as.pkceAuthorizationEndpoint()
+		require.NoError(t, err)
+		assert.Equal(t, "https://custom.example.com/oauth2/authorize", ep)
 	})
 
 	t.Run("custom endpoint already has /authorize", func(t *testing.T) {
@@ -879,7 +884,9 @@ func TestPkceAuthorizationEndpoint(t *testing.T) {
 			SsoRegion:  "us-east-1",
 			ClientData: storage.RegisterClientData{AuthorizationEndpoint: "https://custom.example.com/oauth2/authorize"},
 		}
-		assert.Equal(t, "https://custom.example.com/oauth2/authorize", as.pkceAuthorizationEndpoint())
+		ep, err := as.pkceAuthorizationEndpoint()
+		require.NoError(t, err)
+		assert.Equal(t, "https://custom.example.com/oauth2/authorize", ep)
 	})
 
 	t.Run("custom endpoint with trailing slash", func(t *testing.T) {
@@ -887,7 +894,16 @@ func TestPkceAuthorizationEndpoint(t *testing.T) {
 			SsoRegion:  "us-east-1",
 			ClientData: storage.RegisterClientData{AuthorizationEndpoint: "https://custom.example.com/oauth2/"},
 		}
-		assert.Equal(t, "https://custom.example.com/oauth2/authorize", as.pkceAuthorizationEndpoint())
+		ep, err := as.pkceAuthorizationEndpoint()
+		require.NoError(t, err)
+		assert.Equal(t, "https://custom.example.com/oauth2/authorize", ep)
+	})
+
+	t.Run("empty region without custom endpoint errors", func(t *testing.T) {
+		as := &AWSSSO{SsoRegion: ""}
+		ep, err := as.pkceAuthorizationEndpoint()
+		assert.Error(t, err)
+		assert.Empty(t, ep)
 	})
 }
 

--- a/internal/sso/oidc/endpoint.go
+++ b/internal/sso/oidc/endpoint.go
@@ -35,15 +35,20 @@ import (
 // `amazonaws.com` suffix, so non-commercial partitions resolve correctly -- e.g.
 // the AWS European Sovereign Cloud (`eusc-de-east-1`) lives under `amazonaws.eu`
 // and China under `amazonaws.com.cn`.
-func AuthorizationEndpoint(region string) string {
+//
+// An empty region or a resolver failure returns an error rather than a guessed
+// URL, so a misconfigured region surfaces as a clear error instead of a request
+// to a non-existent host.
+func AuthorizationEndpoint(region string) (string, error) {
+	if region == "" {
+		return "", fmt.Errorf("cannot resolve authorization endpoint: empty region")
+	}
 	ep, err := ssooidc.NewDefaultEndpointResolverV2().ResolveEndpoint(
 		context.Background(),
 		ssooidc.EndpointParameters{Region: aws.String(region)},
 	)
 	if err != nil {
-		// Fall back to the commercial partition host if the region is unknown
-		// to the SDK's endpoint rules.
-		return fmt.Sprintf("https://oidc.%s.amazonaws.com/authorize", region)
+		return "", fmt.Errorf("resolve authorization endpoint for region %q: %w", region, err)
 	}
-	return strings.TrimSuffix(ep.URI.String(), "/") + "/authorize"
+	return strings.TrimSuffix(ep.URI.String(), "/") + "/authorize", nil
 }

--- a/internal/sso/oidc/endpoint.go
+++ b/internal/sso/oidc/endpoint.go
@@ -1,0 +1,49 @@
+package oidc
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2026 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
+)
+
+// AuthorizationEndpoint returns the OIDC `/authorize` endpoint URL for the given
+// SSO region. AWS does not return the authorization endpoint from RegisterClient,
+// so we have to construct it ourselves.
+//
+// The host is resolved via the SDK's own endpoint rules instead of hardcoding the
+// `amazonaws.com` suffix, so non-commercial partitions resolve correctly -- e.g.
+// the AWS European Sovereign Cloud (`eusc-de-east-1`) lives under `amazonaws.eu`
+// and China under `amazonaws.com.cn`.
+func AuthorizationEndpoint(region string) string {
+	ep, err := ssooidc.NewDefaultEndpointResolverV2().ResolveEndpoint(
+		context.Background(),
+		ssooidc.EndpointParameters{Region: aws.String(region)},
+	)
+	if err != nil {
+		// Fall back to the commercial partition host if the region is unknown
+		// to the SDK's endpoint rules.
+		return fmt.Sprintf("https://oidc.%s.amazonaws.com/authorize", region)
+	}
+	return strings.TrimSuffix(ep.URI.String(), "/") + "/authorize"
+}

--- a/internal/sso/oidc/endpoint_test.go
+++ b/internal/sso/oidc/endpoint_test.go
@@ -1,0 +1,27 @@
+package oidc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthorizationEndpoint(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		// commercial partition lives under amazonaws.com
+		"us-east-1": "https://oidc.us-east-1.amazonaws.com/authorize",
+		"eu-west-1": "https://oidc.eu-west-1.amazonaws.com/authorize",
+		// AWS European Sovereign Cloud lives under amazonaws.eu, not amazonaws.com
+		"eusc-de-east-1": "https://oidc.eusc-de-east-1.amazonaws.eu/authorize",
+		// China lives under amazonaws.com.cn
+		"cn-north-1": "https://oidc.cn-north-1.amazonaws.com.cn/authorize",
+		// GovCloud lives under amazonaws.com
+		"us-gov-east-1": "https://oidc.us-gov-east-1.amazonaws.com/authorize",
+	}
+
+	for region, expected := range tests {
+		assert.Equal(t, expected, AuthorizationEndpoint(region), "region %q", region)
+	}
+}

--- a/internal/sso/oidc/endpoint_test.go
+++ b/internal/sso/oidc/endpoint_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAuthorizationEndpoint(t *testing.T) {
@@ -22,6 +23,16 @@ func TestAuthorizationEndpoint(t *testing.T) {
 	}
 
 	for region, expected := range tests {
-		assert.Equal(t, expected, AuthorizationEndpoint(region), "region %q", region)
+		ep, err := AuthorizationEndpoint(region)
+		require.NoError(t, err, "region %q", region)
+		assert.Equal(t, expected, ep, "region %q", region)
 	}
+}
+
+func TestAuthorizationEndpointEmptyRegion(t *testing.T) {
+	t.Parallel()
+
+	ep, err := AuthorizationEndpoint("")
+	assert.Error(t, err)
+	assert.Empty(t, ep)
 }

--- a/internal/uri/uri.go
+++ b/internal/uri/uri.go
@@ -381,6 +381,9 @@ func AWSFederatedUrl(ssoRegion string) string {
 	} else if strings.HasPrefix(ssoRegion, "us-gov-") {
 		// US Gov
 		return fmt.Sprintf(AWS_FEDERATED_URL_FORMAT, ssoRegion, "amazonaws-us-gov.com")
+	} else if strings.HasPrefix(ssoRegion, "eusc-") {
+		// AWS European Sovereign Cloud
+		return fmt.Sprintf(AWS_FEDERATED_URL_FORMAT, ssoRegion, "amazonaws-eusc.eu")
 	}
 	// Default
 	return fmt.Sprintf(AWS_FEDERATED_URL_FORMAT, ssoRegion, "aws.amazon.com")

--- a/internal/uri/uri_test.go
+++ b/internal/uri/uri_test.go
@@ -315,6 +315,14 @@ func TestAWSFederatedUrl(t *testing.T) {
 	assert.NoError(t, err)
 	_, err = net.LookupIP(pUrl.Hostname())
 	assert.NoError(t, err)
+
+	// AWS European Sovereign Cloud lives under amazonaws-eusc.eu
+	u = AWSFederatedUrl("eusc-de-east-1")
+	assert.Equal(t, u, "https://eusc-de-east-1.signin.amazonaws-eusc.eu/federation")
+	pUrl, err = url.Parse(u)
+	assert.NoError(t, err)
+	_, err = net.LookupIP(pUrl.Hostname())
+	assert.NoError(t, err)
 }
 
 // retryLookupIP is a helper function that retries net.LookupIP


### PR DESCRIPTION
## Summary

Login and console access fail in the AWS European Sovereign Cloud (partition
`aws-eusc`, region `eusc-de-east-1`) because two endpoint URLs are built with a
hardcoded commercial `amazonaws.com` domain.

With a `eusc-de-east-1` Identity Center instance the PKCE flow opens
`https://oidc.eusc-de-east-1.amazonaws.com/authorize` — a host that does not
exist. The correct host lives under `amazonaws.eu`.

## Root cause

1. `pkceAuthorizationEndpoint()` falls back to
   `fmt.Sprintf("https://oidc.%s.amazonaws.com/authorize", region)`. AWS does
   not return the authorization endpoint from `RegisterClient`, so this fallback
   is always used — and it hardcodes `amazonaws.com`.
2. `AWSFederatedUrl()` only handles `cn-`, `us-gov-` and the commercial default,
   so EUSC regions fall through to `signin.aws.amazon.com`.

The SDK's endpoint rules already know the partition
(`oidc.{region}.amazonaws.eu`); only these hand-built URLs were wrong.

## Fix

- Add `oidc.AuthorizationEndpoint(region)`, resolving the OIDC host via the
  SDK's partition-aware resolver (`ssooidc.NewDefaultEndpointResolverV2`) and
  appending `/authorize`. Correct for all partitions (commercial
  `amazonaws.com`, China `amazonaws.com.cn`, GovCloud, EUSC `amazonaws.eu`).
  `pkceAuthorizationEndpoint()` now uses it.
- Add a `eusc-` branch to `AWSFederatedUrl()` →
  `https://<region>.signin.amazonaws-eusc.eu/federation` (matching the existing
  EUSC console URL `console.amazonaws-eusc.eu`).

## Testing

- New `TestAuthorizationEndpoint`: commercial / EU / EUSC / China / GovCloud all
  resolve to the expected host.
- Extended `TestAWSFederatedUrl` with the EUSC case.
- Verified live against a real EUSC account:
  - `aws-sso login` (PKCE) opens `oidc.eusc-de-east-1.amazonaws.eu` and succeeds.
  - `aws-sso console` performs the `getSigninToken` request against
    `eusc-de-east-1.signin.amazonaws-eusc.eu` and returns a valid sign-in token
    plus a `console.amazonaws-eusc.eu` login URL.
- Full suite green; `go vet` / `gofmt` clean.

Follow-up to #1309 (initial EUSC support).
