### PR TITLE
hardExitOnSignal now checks the channel's ok value

### DIFF
--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -180,18 +180,24 @@ type CLI struct {
 // which would otherwise make even successful commands exit non-zero -- breaking `process`
 // as an AWS credential_process.
 func watchSignals() (context.Context, context.CancelFunc) {
-	appCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	appCtx, ctxStop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	go hardExitOnSignal(sigCh)
-	return appCtx, stop
+	return appCtx, func() {
+		ctxStop()
+		signal.Stop(sigCh)
+		close(sigCh)
+	}
 }
 
-// hardExitOnSignal calls osExit(1) once a signal arrives on sigCh. Extracted so the
+// hardExitOnSignal calls osExit(1) once a real signal arrives on sigCh. Extracted so the
 // exit-on-signal behaviour can be unit tested without sending real OS signals.
+// It returns without calling osExit when sigCh is closed (clean stop path).
 func hardExitOnSignal(sigCh <-chan os.Signal) {
-	<-sigCh
-	osExit(1)
+	if _, ok := <-sigCh; ok {
+		osExit(1)
+	}
 }
 
 func main() {

--- a/cmd/aws-sso/main_test.go
+++ b/cmd/aws-sso/main_test.go
@@ -100,6 +100,31 @@ func TestHardExitOnSignalExitsOnSignal(t *testing.T) {
 	}
 }
 
+// TestHardExitOnSignalDoesNotExitOnClose verifies that closing sigCh (the stop() path)
+// causes hardExitOnSignal to return without calling osExit — fixing the goroutine leak.
+func TestHardExitOnSignalDoesNotExitOnClose(t *testing.T) {
+	orig := osExit
+	var exited int32
+	osExit = func(int) { atomic.StoreInt32(&exited, 1) }
+	t.Cleanup(func() { osExit = orig })
+
+	sigCh := make(chan os.Signal, 1)
+	returned := make(chan struct{})
+	go func() {
+		hardExitOnSignal(sigCh)
+		close(returned)
+	}()
+	close(sigCh)
+
+	select {
+	case <-returned:
+		assert.Equal(t, int32(0), atomic.LoadInt32(&exited),
+			"closing the signal channel must not call os.Exit")
+	case <-time.After(2 * time.Second):
+		t.Fatal("hardExitOnSignal did not return after channel was closed")
+	}
+}
+
 func TestLogLevelTypeValidate(t *testing.T) {
 	tests := []struct {
 		level   string


### PR DESCRIPTION
ok=true means a real signal arrived (call osExit(1)); 
ok=false means the channel was closed by stop() (return without exiting).