### PR TITLE
add --default flag to ecs server/docker start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 * Add aws-sso exec --overwrite-env flag to allow overriding AWS_ env variables #1095
 * Add support for /healthcheck endpoint for ECS server #1356
+* Add `--default <profile>` flag to `ecs server` and `ecs docker start` to automatically load
+  a named profile as the default credential slot on startup
 
 ### Changes
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT_VERSION        := 2.2.4
+PROJECT_VERSION        := 2.3.0
 DOCKER_REPO            := synfinatic
 PROJECT_NAME           := aws-sso
 DOCKER_PROJECT_NAME    := aws-sso-cli-ecs-server
@@ -293,5 +293,5 @@ serve-docs:  ## Run mkdocs server on localhost:8000
 		synfinatic/mkdocs-material:latest
 
 docker:  ## Build docker image
-	docker build -t $(DOCKER_REPO)/$(DOCKER_PROJECT_NAME):$(PROJECT_VERSION) \
+	docker build -t $(DOCKER_REPO)/$(DOCKER_PROJECT_NAME):v$(PROJECT_VERSION) \
 		-t $(DOCKER_REPO)/$(DOCKER_PROJECT_NAME):latest .

--- a/cmd/aws-sso/e2e_ecs_test.go
+++ b/cmd/aws-sso/e2e_ecs_test.go
@@ -1,0 +1,171 @@
+//go:build integration
+
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2026 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/synfinatic/aws-sso-cli/internal/ecs/server"
+	"golang.org/x/net/nettest"
+)
+
+// TestE2EEcsServerDefault exercises the full `ecs server --default` path:
+//  1. Populate the SSO cache with a test account and role via the mock AWS server.
+//  2. Queue a GetRoleCredentials response so the mock returns predictable creds.
+//  3. Call setServerDefaultProfile to resolve the profile and inject creds into
+//     the server's default slot (the same code path as `ecs server --default`).
+//  4. Start the ECS HTTP server and verify that:
+//     - GET / returns the expected credentials.
+//     - GET /healthcheck returns HTTP 200.
+func TestE2EEcsServerDefault(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+	queueRoleCredentials(setup.Server)
+
+	l, err := nettest.NewLocalListener("tcp")
+	require.NoError(t, err)
+
+	s, err := server.NewEcsServer(context.Background(), "", l, "", "")
+	require.NoError(t, err)
+	t.Cleanup(s.Close)
+
+	ctx := newRunContext(setup, AUTH_REQUIRED)
+
+	// setServerDefaultProfile resolves the profile via the cache and injects credentials
+	// into the server's default slot — this is the core of `ecs server --default`.
+	err = setServerDefaultProfile(ctx, s, "123456789012:ReadOnly")
+	require.NoError(t, err, "setServerDefaultProfile should succeed with a populated cache")
+
+	assert.Equal(t, "123456789012:ReadOnly", s.DefaultCreds.ProfileName,
+		"default slot profile name should match the requested profile")
+	assert.Equal(t, "AKIDTEST12345", s.DefaultCreds.Creds.AccessKeyId,
+		"default slot should hold the queued test access key")
+
+	// Start the HTTP server in the background; Close() shuts it down on cleanup.
+	go func() { _ = s.Serve() }()
+
+	serverAddr := l.Addr().String()
+	baseURL := fmt.Sprintf("http://%s", serverAddr)
+
+	// Poll until the server is reachable (it may not be listening yet).
+	require.NoError(t, waitForEcsServerUp("http", serverAddr, "", 5*time.Second),
+		"ECS server should become reachable after Serve() is called")
+
+	// GET / should return the pre-loaded credentials.
+	resp, err := http.Get(baseURL + "/") // nolint:gosec,noctx
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode,
+		"GET / should return 200 once default credentials are loaded")
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var creds map[string]string
+	require.NoError(t, json.Unmarshal(body, &creds), "response body should be valid JSON")
+	assert.Equal(t, "AKIDTEST12345", creds["AccessKeyId"],
+		"credential endpoint should return the queued access key ID")
+	assert.Equal(t, "SECRETTEST12345", creds["SecretAccessKey"],
+		"credential endpoint should return the queued secret access key")
+	assert.Equal(t, "TOKENTEST12345", creds["Token"],
+		"credential endpoint should return the queued session token")
+
+	// GET /healthcheck should return 200 now that default credentials are loaded.
+	hcResp, err := http.Get(baseURL + "/healthcheck") // nolint:gosec,noctx
+	require.NoError(t, err)
+	defer hcResp.Body.Close()
+	assert.Equal(t, http.StatusOK, hcResp.StatusCode,
+		"healthcheck should return 200 after default credentials are loaded")
+}
+
+// TestE2EEcsDockerStartDefault exercises the `ecs docker start --default` sequence
+// without requiring a real Docker daemon. It validates the three-step handshake
+// that the docker start command performs after the container is running:
+//
+//  1. waitForEcsServerUp — succeeds as soon as the server responds (even 503).
+//  2. loadProfileToEcsServer — resolves the profile and PUTs credentials via HTTP.
+//  3. waitForEcsHealthcheck — polls until GET /healthcheck returns 200.
+//
+// This proves the full post-container-start flow works end-to-end.
+func TestE2EEcsDockerStartDefault(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+	queueRoleCredentials(setup.Server)
+
+	l, err := nettest.NewLocalListener("tcp")
+	require.NoError(t, err)
+
+	// No auth and no SSL — mirrors what a simple `ecs docker start` uses in a
+	// test environment where auth/TLS are not configured.
+	s, err := server.NewEcsServer(context.Background(), "", l, "", "")
+	require.NoError(t, err)
+	t.Cleanup(s.Close)
+
+	go func() { _ = s.Serve() }()
+
+	serverAddr := l.Addr().String()
+
+	// Step 1: wait until the server is up (any HTTP response, including 503).
+	err = waitForEcsServerUp("http", serverAddr, "", 5*time.Second)
+	require.NoError(t, err, "waitForEcsServerUp should succeed once the server is listening")
+
+	// Healthcheck should be 503 before any credentials are loaded.
+	hcURL := fmt.Sprintf("http://%s/healthcheck", serverAddr)
+	hcResp, err := http.Get(hcURL) // nolint:gosec,noctx
+	require.NoError(t, err)
+	hcResp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, hcResp.StatusCode,
+		"healthcheck should be 503 before default credentials are loaded")
+
+	// Step 2: resolve the profile and PUT credentials into the running server.
+	ctx := newRunContext(setup, AUTH_REQUIRED)
+	err = loadProfileToEcsServer(ctx, "123456789012:ReadOnly", serverAddr)
+	require.NoError(t, err, "loadProfileToEcsServer should succeed with a populated cache")
+
+	// Step 3: healthcheck should now return 200.
+	err = waitForEcsHealthcheck("http", serverAddr, "", 5*time.Second)
+	require.NoError(t, err, "waitForEcsHealthcheck should return 200 after credentials are loaded")
+
+	// Verify the credentials are actually served correctly via GET /.
+	resp, err := http.Get(fmt.Sprintf("http://%s/", serverAddr)) // nolint:gosec,noctx
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var creds map[string]string
+	require.NoError(t, json.Unmarshal(body, &creds))
+	assert.Equal(t, "AKIDTEST12345", creds["AccessKeyId"])
+	assert.Equal(t, "SECRETTEST12345", creds["SecretAccessKey"])
+	assert.Equal(t, "TOKENTEST12345", creds["Token"])
+}

--- a/cmd/aws-sso/ecs_docker_cmd.go
+++ b/cmd/aws-sso/ecs_docker_cmd.go
@@ -21,14 +21,17 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"net/netip"
 	"os"
+	"time"
 
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/network"
-	"github.com/moby/moby/client"
+	dockerclient "github.com/moby/moby/client"
 	"github.com/synfinatic/aws-sso-cli/internal/ecs"
+	ecsclient "github.com/synfinatic/aws-sso-cli/internal/ecs/client"
 	// "github.com/davecgh/go-spew/spew"
 )
 
@@ -48,17 +51,22 @@ type EcsDockerStartCmd struct {
 	Port        string `kong:"help='Host port to bind to the ECS Server',default='4144'"`
 	Image       string `kong:"help='ECS Server docker image',default='synfinatic/aws-sso-cli-ecs-server'"`
 	Version     string `kong:"help='ECS Server docker image version',default='v${VERSION}'"`
+	Default     string `kong:"short='d',help='Profile name to load as default credentials on start',predictor='profile'"`
 }
 
 // AfterApply determines if SSO auth token is required
 func (e EcsDockerStartCmd) AfterApply(runCtx *RunContext) error {
-	runCtx.Auth = AUTH_SKIP
+	if e.Default != "" {
+		runCtx.Auth = AUTH_REQUIRED
+	} else {
+		runCtx.Auth = AUTH_SKIP
+	}
 	return nil
 }
 
 func (cc *EcsDockerStartCmd) Run(ctx *RunContext) error {
 	// Start the ECS Server in a Docker container
-	dockerClient, err := client.New(client.FromEnv)
+	dockerClient, err := dockerclient.New(dockerclient.FromEnv)
 	if err != nil {
 		return err
 	}
@@ -139,7 +147,7 @@ func (cc *EcsDockerStartCmd) Run(ctx *RunContext) error {
 		},
 	}
 
-	resp, err := dockerClient.ContainerCreate(context.Background(), client.ContainerCreateOptions{
+	resp, err := dockerClient.ContainerCreate(context.Background(), dockerclient.ContainerCreateOptions{
 		Config:     config,
 		HostConfig: hostConfig,
 		Name:       CONTAINER_NAME,
@@ -148,21 +156,141 @@ func (cc *EcsDockerStartCmd) Run(ctx *RunContext) error {
 		return err
 	}
 
-	// must create the named pipe before we start the container
+	// Write security config and close before starting the container so the
+	// file is fully flushed to the shared filesystem before the container reads it.
+	if err = writeAndCloseSecurityFile(privateKey, certChain, bearerToken); err != nil {
+		_, _ = dockerClient.ContainerRemove(context.Background(), resp.ID, dockerclient.ContainerRemoveOptions{})
+		return err
+	}
+
+	if _, err = dockerClient.ContainerStart(context.Background(), resp.ID, dockerclient.ContainerStartOptions{}); err != nil {
+		os.Remove(ecs.SecurityFilePath(ecs.WRITE_ONLY)) // clean up on failure
+		_, _ = dockerClient.ContainerRemove(context.Background(), resp.ID, dockerclient.ContainerRemoveOptions{})
+		return err
+	}
+
+	if cc.Default != "" {
+		// Use http when no cert chain is configured — the server requires both privateKey
+		// and certChain to enable TLS; certChain alone is not sufficient.
+		proto := "http"
+		if !cc.DisableSSL && privateKey != "" && certChain != "" {
+			proto = "https"
+		}
+		serverAddr := fmt.Sprintf("%s:%s", cc.BindIP, cc.Port)
+
+		stopAndRemove := func() {
+			_, _ = dockerClient.ContainerStop(context.Background(), resp.ID, dockerclient.ContainerStopOptions{})
+			_, _ = dockerClient.ContainerRemove(context.Background(), resp.ID, dockerclient.ContainerRemoveOptions{})
+		}
+
+		// Wait until the container is accepting connections (503 = up but no creds yet).
+		if err := waitForEcsServerUp(proto, serverAddr, certChain, 30*time.Second); err != nil {
+			stopAndRemove()
+			return err
+		}
+		if err := loadProfileToEcsServer(ctx, cc.Default, serverAddr); err != nil {
+			stopAndRemove()
+			return err
+		}
+		if err := waitForEcsHealthcheck(proto, serverAddr, certChain, 30*time.Second); err != nil {
+			stopAndRemove()
+			return err
+		}
+	}
+	return nil
+}
+
+// writeAndCloseSecurityFile writes the ECS security config and closes the file
+// synchronously before the container starts, ensuring the data is visible on the
+// shared filesystem (e.g. VirtioFS) before the container process reads it.
+func writeAndCloseSecurityFile(privateKey, certChain, bearerToken string) error {
 	f, err := ecs.OpenSecurityFile(ecs.WRITE_ONLY)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
 	if err = ecs.WriteSecurityConfig(f, privateKey, certChain, bearerToken); err != nil {
+		f.Close()
 		return err
 	}
+	return f.Close()
+}
 
-	if _, err = dockerClient.ContainerStart(context.Background(), resp.ID, client.ContainerStartOptions{}); err != nil {
-		os.Remove(ecs.SecurityFilePath(ecs.WRITE_ONLY)) // clean up on failure
-		return err
+// waitForEcsHealthcheck polls the ECS server healthcheck endpoint until it returns
+// HTTP 200 or the timeout elapses. certChain must be provided when the server uses TLS
+// so that the self-signed certificate is trusted.
+func waitForEcsHealthcheck(proto, serverAddr, certChain string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	url := fmt.Sprintf("%s://%s%s", proto, serverAddr, ecs.HEALTHCHECK_ROUTE)
+
+	var httpClient *http.Client
+	var err error
+	if certChain != "" {
+		httpClient, err = ecsclient.NewHTTPClient(certChain)
+		if err != nil {
+			return fmt.Errorf("failed to build TLS client for healthcheck: %w", err)
+		}
+	} else {
+		httpClient = &http.Client{}
 	}
-	return nil
+	httpClient.Timeout = 2 * time.Second
+
+	for time.Now().Before(deadline) {
+		resp, err := httpClient.Get(url) // nolint:gosec,noctx
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return fmt.Errorf("ECS server at %s did not become healthy within %s", serverAddr, timeout)
+}
+
+// waitForEcsServerUp polls the ECS server healthcheck endpoint until the server
+// responds with any HTTP status code (including 503, which means running but no
+// credentials loaded yet) or the timeout elapses. Connection errors are retried.
+func waitForEcsServerUp(proto, serverAddr, certChain string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	url := fmt.Sprintf("%s://%s%s", proto, serverAddr, ecs.HEALTHCHECK_ROUTE)
+
+	var httpClient *http.Client
+	var err error
+	if certChain != "" {
+		httpClient, err = ecsclient.NewHTTPClient(certChain)
+		if err != nil {
+			return fmt.Errorf("failed to build TLS client for server-up check: %w", err)
+		}
+	} else {
+		httpClient = &http.Client{}
+	}
+	httpClient.Timeout = 2 * time.Second
+
+	for time.Now().Before(deadline) {
+		resp, err := httpClient.Get(url) // nolint:gosec,noctx
+		if err == nil {
+			resp.Body.Close()
+			return nil // any HTTP response means the server process is up
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	return fmt.Errorf("ECS server at %s did not start within %s", serverAddr, timeout)
+}
+
+// loadProfileToEcsServer resolves a profile name to credentials and PUTs them
+// into the default slot of the running ECS server.
+func loadProfileToEcsServer(ctx *RunContext, profileName, serverAddr string) error {
+	cache := ctx.Settings.Cache.GetSSO()
+	rFlat, err := cache.Roles.GetRoleByProfile(profileName, ctx.Settings)
+	if err != nil {
+		return fmt.Errorf("profile %q not found: %w", profileName, err)
+	}
+	creds := GetRoleCredentials(ctx, AwsSSO, false, rFlat.AccountId, rFlat.RoleName)
+	if p, err := rFlat.ProfileName(ctx.Settings); err == nil {
+		rFlat.Profile = p
+	}
+	c := newClient(serverAddr, ctx)
+	return c.SubmitCreds(creds, rFlat.Profile, false)
 }
 
 type EcsDockerStopCmd struct {
@@ -177,15 +305,15 @@ func (e EcsDockerStopCmd) AfterApply(runCtx *RunContext) error {
 
 func (cc *EcsDockerStopCmd) Run(ctx *RunContext) error {
 	// Stop the ECS Server in a Docker container
-	dockerClient, err := client.New(client.FromEnv)
+	dockerClient, err := dockerclient.New(dockerclient.FromEnv)
 	if err != nil {
 		return err
 	}
 
-	if _, err = dockerClient.ContainerStop(context.Background(), CONTAINER_NAME, client.ContainerStopOptions{}); err != nil {
+	if _, err = dockerClient.ContainerStop(context.Background(), CONTAINER_NAME, dockerclient.ContainerStopOptions{}); err != nil {
 		return err
 	}
 
-	_, err = dockerClient.ContainerRemove(context.Background(), CONTAINER_NAME, client.ContainerRemoveOptions{})
+	_, err = dockerClient.ContainerRemove(context.Background(), CONTAINER_NAME, dockerclient.ContainerRemoveOptions{})
 	return err
 }

--- a/cmd/aws-sso/ecs_docker_cmd_test.go
+++ b/cmd/aws-sso/ecs_docker_cmd_test.go
@@ -1,0 +1,118 @@
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2026 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ssocache "github.com/synfinatic/aws-sso-cli/internal/sso/cache"
+)
+
+func TestEcsDockerStartCmdAfterApply(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      EcsDockerStartCmd
+		wantAuth CommandAuth
+	}{
+		{
+			name:     "Default set requires auth",
+			cmd:      EcsDockerStartCmd{Default: "my-profile"},
+			wantAuth: AUTH_REQUIRED,
+		},
+		{
+			name:     "no Default skips auth",
+			cmd:      EcsDockerStartCmd{},
+			wantAuth: AUTH_SKIP,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runCtx := &RunContext{}
+			err := tt.cmd.AfterApply(runCtx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAuth, runCtx.Auth)
+		})
+	}
+}
+
+func TestWaitForEcsHealthcheck_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	// Extract host:port from the test server URL.
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	err := waitForEcsHealthcheck("http", addr, "", 2*time.Second)
+	assert.NoError(t, err)
+}
+
+func TestWaitForEcsHealthcheck_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	err := waitForEcsHealthcheck("http", addr, "", 50*time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not become healthy")
+}
+
+func TestWaitForEcsServerUp_Ready(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable) // 503 = server up, no creds yet
+	}))
+	defer srv.Close()
+
+	addr := strings.TrimPrefix(srv.URL, "http://")
+	err := waitForEcsServerUp("http", addr, "", 2*time.Second)
+	assert.NoError(t, err)
+}
+
+func TestWaitForEcsServerUp_Timeout(t *testing.T) {
+	// Reserve an ephemeral port then immediately release it so we have an address
+	// guaranteed not to be listening when waitForEcsServerUp is called.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := ln.Addr().String()
+	ln.Close()
+
+	err = waitForEcsServerUp("http", addr, "", 50*time.Millisecond)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not start")
+}
+
+func TestLoadProfileToEcsServerNotFound(t *testing.T) {
+	c := &ssocache.Cache{SSO: map[string]*ssocache.SSOCache{}}
+	ctx := &RunContext{
+		Settings: newMinimalSettings(c),
+		Cli:      &CLI{},
+	}
+	err := loadProfileToEcsServer(ctx, "nonexistent-profile", "localhost:4144")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent-profile")
+}

--- a/cmd/aws-sso/ecs_server_cmd.go
+++ b/cmd/aws-sso/ecs_server_cmd.go
@@ -29,8 +29,9 @@ import (
 )
 
 type EcsServerCmd struct {
-	BindIP string `kong:"help='Bind address for ECS Server',default='127.0.0.1'"`
-	Port   int    `kong:"help='TCP port to listen on',default=4144"`
+	BindIP  string `kong:"help='Bind address for ECS Server',default='127.0.0.1'"`
+	Port    int    `kong:"help='TCP port to listen on',default=4144"`
+	Default string `kong:"short='d',help='Profile name to load as default credentials on start',predictor='profile'"`
 	// hidden flags are for internal use only when running in a docker container
 	Docker      bool `kong:"hidden"`
 	DisableAuth bool `kong:"help='Disable HTTP Auth for the ECS Server'"`
@@ -41,6 +42,8 @@ type EcsServerCmd struct {
 func (e EcsServerCmd) AfterApply(runCtx *RunContext) error {
 	if e.Docker {
 		runCtx.Auth = AUTH_NO_CONFIG
+	} else if e.Default != "" {
+		runCtx.Auth = AUTH_REQUIRED
 	} else {
 		runCtx.Auth = AUTH_SKIP
 	}
@@ -119,5 +122,29 @@ func (cc *EcsServerCmd) Run(ctx *RunContext) error {
 	if err != nil {
 		return err
 	}
+	if cc.Default != "" && !cc.Docker {
+		if err := setServerDefaultProfile(ctx, s, cc.Default); err != nil {
+			return err
+		}
+	}
 	return s.Serve()
+}
+
+// setServerDefaultProfile resolves a profile name to credentials and injects them
+// directly into the server's default slot before Serve() is called.
+func setServerDefaultProfile(ctx *RunContext, s *server.EcsServer, profileName string) error {
+	cache := ctx.Settings.Cache.GetSSO()
+	rFlat, err := cache.Roles.GetRoleByProfile(profileName, ctx.Settings)
+	if err != nil {
+		return fmt.Errorf("profile %q not found: %w", profileName, err)
+	}
+	creds := GetRoleCredentials(ctx, AwsSSO, false, rFlat.AccountId, rFlat.RoleName)
+	if p, err := rFlat.ProfileName(ctx.Settings); err == nil {
+		rFlat.Profile = p
+	}
+	s.DefaultCreds = &ecs.ECSClientRequest{
+		Creds:       creds,
+		ProfileName: rFlat.Profile,
+	}
+	return nil
 }

--- a/cmd/aws-sso/ecs_server_cmd_test.go
+++ b/cmd/aws-sso/ecs_server_cmd_test.go
@@ -1,0 +1,72 @@
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2026 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ssocache "github.com/synfinatic/aws-sso-cli/internal/sso/cache"
+)
+
+func TestEcsServerCmdAfterApply(t *testing.T) {
+	tests := []struct {
+		name     string
+		cmd      EcsServerCmd
+		wantAuth CommandAuth
+	}{
+		{
+			name:     "docker mode ignores Default",
+			cmd:      EcsServerCmd{Docker: true, Default: "any-profile"},
+			wantAuth: AUTH_NO_CONFIG,
+		},
+		{
+			name:     "Default set without docker requires auth",
+			cmd:      EcsServerCmd{Default: "my-profile"},
+			wantAuth: AUTH_REQUIRED,
+		},
+		{
+			name:     "no Default and no docker skips auth",
+			cmd:      EcsServerCmd{},
+			wantAuth: AUTH_SKIP,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runCtx := &RunContext{}
+			err := tt.cmd.AfterApply(runCtx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAuth, runCtx.Auth)
+		})
+	}
+}
+
+func TestSetServerDefaultProfileNotFound(t *testing.T) {
+	// Build a RunContext with an empty SSO cache so GetRoleByProfile returns "not found".
+	c := &ssocache.Cache{SSO: map[string]*ssocache.SSOCache{}}
+	ctx := &RunContext{
+		Settings: newMinimalSettings(c),
+		Cli:      &CLI{},
+	}
+	// s can be nil: the function returns before touching the server on error.
+	err := setServerDefaultProfile(ctx, nil, "nonexistent-profile")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent-profile")
+}

--- a/cmd/aws-sso/ecs_test_helpers_test.go
+++ b/cmd/aws-sso/ecs_test_helpers_test.go
@@ -1,0 +1,30 @@
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2026 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	sso "github.com/synfinatic/aws-sso-cli/internal/sso"
+	ssocache "github.com/synfinatic/aws-sso-cli/internal/sso/cache"
+)
+
+// newMinimalSettings constructs a *sso.Settings backed by the supplied cache.
+// Useful in tests that need a RunContext.Settings without a real config file.
+func newMinimalSettings(c *ssocache.Cache) *sso.Settings {
+	return &sso.Settings{Cache: c}
+}


### PR DESCRIPTION
* --default flag now loads the default profile AWS credentials
* bump version to 2.3.0
* fix docker image build tag

Fixes: #1356