### PR TITLE
security: Update to Go 1.26.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 
 * Add unit tests for cmd/aws-sso
 * Add lock support for JSON SecureStore
-* Add e2e integration tests for CLI commands (login, cache, list, credentials, eval, exec, process)
+* Add e2e integration tests for CLI commands
+* Security: Update to Go 1.26.4
 
 ## [v2.2.4] - 2026-05-21
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/synfinatic/aws-sso-cli
 
-go 1.26.3
+go 1.26.4
 
 // toolchain go1.23.6
 


### PR DESCRIPTION
Fixes for:
* https://pkg.go.dev/vuln/GO-2026-5039
* https://pkg.go.dev/vuln/GO-2026-5037