### PR TITLE
enable codecov for cmd/aws-sso

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -84,7 +84,7 @@ jobs:
 
     - name: Generate Coverage Report
       run: |
-        make unittest
+        make coverage
     #     echo "Run, Build Application using script"
     #     ./location_of_script_within_repo/buildscript.sh
 

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,7 @@ e2e: ## Run end-to-end tests against mock AWS HTTP servers
 coverage: coverage.out
 coverage.out: .build_files
 	go test -tags e2etests -ldflags='$(LDFLAGS)' -covermode=atomic -coverprofile=coverage.out ./...
+	@echo "total coverage (all files): $$(go tool cover -func=coverage.out | grep ^total | sed -Ee 's/.*[^0-9]([0-9]+\.[0-9]%$$)/\1/')"
 
 .PHONY: test-race
 test-race: ## Run `go test -race` on the code

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,10 @@ ALL: $(DIST_DIR)$(PROJECT_NAME) ## Build binary for this platform
 
 include help.mk  # place after ALL target and before all other targets
 
-$(DIST_DIR)$(PROJECT_NAME):	$(wildcard */*.go) .prepare
+.PHONY: .build_files
+.build_files: $(wildcard */*.go */*/*.go */*/*/*.go) go.mod go.sum .prepare
+
+$(DIST_DIR)$(PROJECT_NAME): .build_files
 	go build $(GOBFLAGS) -ldflags='$(LDFLAGS)' -o $(DIST_DIR)$(PROJECT_NAME) ./cmd/aws-sso/...
 	@echo "Created: $(DIST_DIR)$(PROJECT_NAME)"
 
@@ -144,11 +147,15 @@ debug: .prepare ## Run debug in dlv
 
 .PHONY: unittest
 unittest: ## Run go unit tests
-	go test -ldflags='$(LDFLAGS)' -covermode=atomic -coverprofile=coverage.out  ./...
+	go test -ldflags='$(LDFLAGS)' ./...
 
 .PHONY: e2e
 e2e: ## Run end-to-end tests against mock AWS HTTP servers
 	go test -tags e2etests -ldflags='$(LDFLAGS)' ./cmd/aws-sso/...
+
+coverage: coverage.out
+coverage.out: .build_files
+	go test -tags e2etests -ldflags='$(LDFLAGS)' -covermode=atomic -coverprofile=coverage.out ./...
 
 .PHONY: test-race
 test-race: ## Run `go test -race` on the code
@@ -168,7 +175,7 @@ govulncheck:  ## Run govulncheck
 	@govulncheck ./...
 
 # run everything but `lint`and govulncheck because they run seperately
-.build-tests: vet unittest test-tidy test-fmt test-homebrew e2e
+.build-tests: vet coverage test-tidy test-fmt test-homebrew
 
 $(DIST_DIR):
 	@if test ! -d $(DIST_DIR); then mkdir -p $(DIST_DIR) ; fi
@@ -219,25 +226,25 @@ test-homebrew: $(DIST_DIR)$(PROJECT_NAME)  ## Run the homebrew tests
 # Build targets for our supported plaforms
 windows: $(WINDOWS_BIN)  ## Build 64bit x86 Windows binary
 
-$(WINDOWS_BIN): $(wildcard */*.go) .prepare
+$(WINDOWS_BIN): .build_files
 	GOARCH=amd64 GOOS=windows go build $(GOBFLAGS) -ldflags='$(LDFLAGS)' -o $(WINDOWS_BIN) ./cmd/aws-sso/...
 	@echo "Created: $(WINDOWS_BIN)"
 
 windows32: $(WINDOWS32_BIN)  ## Build 32bit x86 Windows binary
 
-$(WINDOWS32_BIN): $(wildcard */*.go) .prepare
+$(WINDOWS32_BIN): .build_files
 	GOARCH=386 GOOS=windows go build $(GOBFLAGS) -ldflags='$(LDFLAGS)' -o $(WINDOWS32_BIN) ./cmd/aws-sso/...
 	@echo "Created: $(WINDOWS32_BIN)"
 
 linux: $(LINUX_BIN)  ## Build Linux/x86_64 binary
 
-$(LINUX_BIN): $(wildcard */*.go) .prepare
+$(LINUX_BIN): .build_files
 	CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build $(GOBFLAGS) -ldflags='$(LDFLAGS)' -o $(LINUX_BIN) ./cmd/aws-sso/...
 	@echo "Created: $(LINUX_BIN)"
 
 linux-arm64: $(LINUXARM64_BIN)  ## Build Linux/arm64 binary
 
-$(LINUXARM64_BIN): $(wildcard */*.go) .prepare
+$(LINUXARM64_BIN): .build_files
 	CGO_ENABLED=0 GOARCH=arm64 GOOS=linux go build $(GOBFLAGS) -ldflags='$(LDFLAGS)' -o $(LINUXARM64_BIN) ./cmd/aws-sso/...
 	@echo "Created: $(LINUXARM64_BIN)"
 
@@ -246,7 +253,7 @@ $(LINUXARM64_BIN): $(wildcard */*.go) .prepare
 
 darwin: $(DARWIN_BIN)  ## Build MacOS/x86_64 binary
 
-$(DARWIN_BIN): $(wildcard */*.go) .prepare
+$(DARWIN_BIN): .build_files
 ifeq ($(ARCH), x86_64)
 	CGO_ENABLED=1 GOARCH=amd64 GOOS=darwin go build $(GOBFLAGS) -ldflags='$(LDFLAGS)' -o $(DARWIN_BIN) ./cmd/aws-sso/...
 else
@@ -257,7 +264,7 @@ endif
 
 darwin-arm64: $(DARWINARM64_BIN)  ## Build MacOS/ARM64 binary
 
-$(DARWINARM64_BIN): $(wildcard */*.go) .prepare
+$(DARWINARM64_BIN): .build_files
 ifeq ($(ARCH), arm64)
 	CGO_ENABLED=1 GOARCH=arm64 GOOS=darwin go build $(GOBFLAGS) -ldflags='$(LDFLAGS)' -o $(DARWINARM64_BIN) ./cmd/aws-sso/...
 else
@@ -266,7 +273,7 @@ else
 endif
 	@echo "Created: $(DARWINARM64_BIN)"
 
-$(OUTPUT_NAME): $(wildcard */*.go) .prepare
+$(OUTPUT_NAME): .build_files
 	go build $(GOBFLAGS) -ldflags='$(LDFLAGS)' -o $(OUTPUT_NAME) ./cmd/aws-sso/...
 
 docs: docs/default-region.png  ## Build document files

--- a/cmd/aws-sso/afterapply_test.go
+++ b/cmd/aws-sso/afterapply_test.go
@@ -1,0 +1,63 @@
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2026 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAfterApply(t *testing.T) {
+	cases := []struct {
+		name     string
+		apply    func(*RunContext) error
+		wantAuth CommandAuth
+	}{
+		{"CacheCmd", CacheCmd{}.AfterApply, AUTH_REQUIRED},
+		{"CompleteCmd", CompleteCmd{}.AfterApply, AUTH_NO_CONFIG},
+		{"ConsoleCmd", ConsoleCmd{}.AfterApply, AUTH_REQUIRED},
+		{"CredentialsCmd", CredentialsCmd{}.AfterApply, AUTH_REQUIRED},
+		{"DefaultCmd", DefaultCmd{}.AfterApply, AUTH_SKIP},
+		{"EcsAuthCmd", EcsAuthCmd{}.AfterApply, AUTH_SKIP},
+		{"EcsListCmd", EcsListCmd{}.AfterApply, AUTH_SKIP},
+		{"EcsLoadCmd", EcsLoadCmd{}.AfterApply, AUTH_REQUIRED},
+		{"EcsProfileCmd", EcsProfileCmd{}.AfterApply, AUTH_SKIP},
+		{"EcsSSLCmd", EcsSSLCmd{}.AfterApply, AUTH_SKIP},
+		{"EcsUnloadCmd", EcsUnloadCmd{}.AfterApply, AUTH_NO_CONFIG},
+		{"ExecCmd", ExecCmd{}.AfterApply, AUTH_REQUIRED},
+		{"ListCmd", ListCmd{}.AfterApply, AUTH_SKIP},
+		{"ListSSORolesCmd", ListSSORolesCmd{}.AfterApply, AUTH_SKIP},
+		{"LoginCmd", LoginCmd{}.AfterApply, AUTH_SKIP},
+		{"LogoutCmd", LogoutCmd{}.AfterApply, AUTH_SKIP},
+		{"ProcessCmd", ProcessCmd{}.AfterApply, AUTH_REQUIRED},
+		{"SetupProfilesCmd", SetupProfilesCmd{}.AfterApply, AUTH_REQUIRED},
+		{"SetupWizardCmd", SetupWizardCmd{}.AfterApply, AUTH_SKIP},
+		{"TagsCmd", TagsCmd{}.AfterApply, AUTH_SKIP},
+		{"TimeCmd", TimeCmd{}.AfterApply, AUTH_SKIP},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rctx := &RunContext{}
+			require.NoError(t, tc.apply(rctx))
+			assert.Equal(t, tc.wantAuth, rctx.Auth)
+		})
+	}
+}

--- a/cmd/aws-sso/e2e_cache_test.go
+++ b/cmd/aws-sso/e2e_cache_test.go
@@ -66,3 +66,65 @@ func TestE2ECache(t *testing.T) {
 	assert.Contains(t, roleNames, "PowerUser")
 	_ = output // output goes to stdout but we don't assert on its format
 }
+
+// TestE2ECacheSilentFalse verifies that when Silent is false the diff lines are
+// printed to stdout.
+func TestE2ECacheSilentFalse(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+
+	setup.Server.SSO.QueueListAccounts(awsmock.ListAccountsResponse{
+		AccountList: []awsmock.AccountInfo{
+			{AccountID: "123456789012", AccountName: "TestAccount", EmailAddress: "admin@example.com"},
+		},
+	})
+	setup.Server.SSO.QueueListAccountRoles(awsmock.ListAccountRolesResponse{
+		RoleList: []awsmock.RoleInfo{
+			{AccountID: "123456789012", RoleName: "ReadOnly"},
+		},
+	})
+
+	ctx := newRunContext(setup, AUTH_REQUIRED)
+	ctx.Cli.Cache = CacheCmd{Threads: 1, NoConfigCheck: true, Silent: false}
+
+	output := captureStdout(func() {
+		err := (&ctx.Cli.Cache).Run(ctx)
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "+", "non-silent output should include '+' diff lines for added roles")
+}
+
+// TestE2ECacheNoRoleChange verifies that when the cache already contains the same
+// roles, no diff output is printed.
+func TestE2ECacheNoRoleChange(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+
+	// Populate the cache with a known role first.
+	populateCache(t, setup)
+
+	// Queue the same accounts and roles for the second refresh.
+	setup.Server.SSO.QueueListAccounts(awsmock.ListAccountsResponse{
+		AccountList: []awsmock.AccountInfo{
+			{AccountID: "123456789012", AccountName: "TestAccount", EmailAddress: "admin@example.com"},
+		},
+	})
+	setup.Server.SSO.QueueListAccountRoles(awsmock.ListAccountRolesResponse{
+		RoleList: []awsmock.RoleInfo{
+			{AccountID: "123456789012", RoleName: "ReadOnly"},
+			{AccountID: "123456789012", RoleName: "PowerUser"},
+		},
+	})
+
+	ctx := newRunContext(setup, AUTH_REQUIRED)
+	ctx.Cli.Cache = CacheCmd{Threads: 1, NoConfigCheck: true, Silent: false}
+
+	output := captureStdout(func() {
+		err := (&ctx.Cli.Cache).Run(ctx)
+		require.NoError(t, err)
+	})
+
+	assert.NotContains(t, output, "+", "no diff output expected when roles are unchanged")
+	assert.NotContains(t, output, "-", "no diff output expected when roles are unchanged")
+}

--- a/cmd/aws-sso/e2e_ecs_test.go
+++ b/cmd/aws-sso/e2e_ecs_test.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"testing"
 	"time"
@@ -168,4 +169,387 @@ func TestE2EEcsDockerStartDefault(t *testing.T) {
 	assert.Equal(t, "AKIDTEST12345", creds["AccessKeyId"])
 	assert.Equal(t, "SECRETTEST12345", creds["SecretAccessKey"])
 	assert.Equal(t, "TOKENTEST12345", creds["Token"])
+}
+
+// freePort returns a TCP port number that was free at the time of the call.  There
+// is a brief TOCTOU window between Close() and the caller's Listen(), which is
+// acceptable for tests running on loopback.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+	return port
+}
+
+// newEcsServerForTest starts an in-process ECS server on a random port and returns
+// the server and its host:port address.  The server is closed via t.Cleanup.
+func newEcsServerForTest(t *testing.T) (*server.EcsServer, string) {
+	t.Helper()
+	l, err := nettest.NewLocalListener("tcp")
+	require.NoError(t, err)
+	s, err := server.NewEcsServer(context.Background(), "", l, "", "")
+	require.NoError(t, err)
+	t.Cleanup(s.Close)
+	go func() { _ = s.Serve() }()
+	addr := l.Addr().String()
+	require.NoError(t, waitForEcsServerUp("http", addr, "", 5*time.Second))
+	return s, addr
+}
+
+// TestE2EEcsLoad exercises the `ecs load` path for the default slot:
+//  1. Populate the SSO cache and queue a GetRoleCredentials response.
+//  2. Call ecsLoadCmd to PUT credentials into the running server.
+//  3. Verify GET / returns the expected credentials.
+func TestE2EEcsLoad(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+	queueRoleCredentials(setup.Server)
+
+	_, addr := newEcsServerForTest(t)
+
+	ctx := newRunContext(setup, AUTH_REQUIRED)
+	ctx.Cli.Ecs.Load.Server = addr
+
+	err := ecsLoadCmd(ctx, 123456789012, "ReadOnly")
+	require.NoError(t, err)
+
+	resp, err := http.Get(fmt.Sprintf("http://%s/", addr)) // nolint:gosec,noctx
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(body, &got))
+	assert.Equal(t, "AKIDTEST12345", got["AccessKeyId"])
+	assert.Equal(t, "SECRETTEST12345", got["SecretAccessKey"])
+	assert.Equal(t, "TOKENTEST12345", got["Token"])
+}
+
+// TestE2EEcsLoadSlotted exercises the `ecs load --slotted` path:
+//  1. Populate the SSO cache and queue a GetRoleCredentials response.
+//  2. Call ecsLoadCmd with Slotted=true to PUT credentials into a named slot.
+//  3. Verify the slot healthcheck returns 200.
+func TestE2EEcsLoadSlotted(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+	queueRoleCredentials(setup.Server)
+
+	_, addr := newEcsServerForTest(t)
+
+	ctx := newRunContext(setup, AUTH_REQUIRED)
+	ctx.Cli.Ecs.Load.Server = addr
+	ctx.Cli.Ecs.Load.Slotted = true
+
+	err := ecsLoadCmd(ctx, 123456789012, "ReadOnly")
+	require.NoError(t, err)
+
+	// Default slot should still be empty (503).
+	hcResp, err := http.Get(fmt.Sprintf("http://%s/healthcheck", addr)) // nolint:gosec,noctx
+	require.NoError(t, err)
+	hcResp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, hcResp.StatusCode,
+		"default slot should remain empty when loading into a named slot")
+
+	// Named-slot healthcheck should return 200.
+	slotHC := fmt.Sprintf("http://%s/healthcheck/slot/123456789012:ReadOnly", addr)
+	slotResp, err := http.Get(slotHC) // nolint:gosec,noctx
+	require.NoError(t, err)
+	slotResp.Body.Close()
+	assert.Equal(t, http.StatusOK, slotResp.StatusCode,
+		"named-slot healthcheck should return 200 after slotted load")
+}
+
+// TestE2EEcsProfile exercises the `ecs profile` path:
+//  1. Load credentials into the default slot via setServerDefaultProfile.
+//  2. Call EcsProfileCmd.Run and capture stdout.
+//  3. Verify the output contains the account ID and role name.
+func TestE2EEcsProfile(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+	queueRoleCredentials(setup.Server)
+
+	s, addr := newEcsServerForTest(t)
+
+	ctx := newRunContext(setup, AUTH_REQUIRED)
+	err := setServerDefaultProfile(ctx, s, "123456789012:ReadOnly")
+	require.NoError(t, err)
+
+	ctx.Cli.Ecs.Profile.Server = addr
+	output := captureStdout(func() {
+		runErr := (&EcsProfileCmd{}).Run(ctx)
+		assert.NoError(t, runErr)
+	})
+	assert.Contains(t, output, "123456789012", "profile output should include the account ID")
+	assert.Contains(t, output, "ReadOnly", "profile output should include the role name")
+}
+
+// TestE2EEcsList exercises the `ecs list` path:
+//  1. Load a credential into a named slot via ecsLoadCmd with Slotted=true.
+//  2. Call EcsListCmd.Run and capture stdout.
+//  3. Verify the output contains the account ID and role name.
+func TestE2EEcsList(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+	queueRoleCredentials(setup.Server)
+
+	_, addr := newEcsServerForTest(t)
+
+	ctx := newRunContext(setup, AUTH_REQUIRED)
+	ctx.Cli.Ecs.Load.Server = addr
+	ctx.Cli.Ecs.Load.Slotted = true
+	err := ecsLoadCmd(ctx, 123456789012, "ReadOnly")
+	require.NoError(t, err)
+
+	ctx.Cli.Ecs.List.Server = addr
+	output := captureStdout(func() {
+		runErr := (&EcsListCmd{}).Run(ctx)
+		assert.NoError(t, runErr)
+	})
+	assert.Contains(t, output, "123456789012", "list output should include the account ID")
+	assert.Contains(t, output, "ReadOnly", "list output should include the role name")
+}
+
+// TestE2EEcsUnload exercises the `ecs unload` path for the default slot:
+//  1. Load credentials into the default slot.
+//  2. Confirm the healthcheck returns 200.
+//  3. Call EcsUnloadCmd.Run with no profile (default slot).
+//  4. Verify the healthcheck now returns 503.
+func TestE2EEcsUnload(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+	queueRoleCredentials(setup.Server)
+
+	s, addr := newEcsServerForTest(t)
+
+	ctx := newRunContext(setup, AUTH_REQUIRED)
+	err := setServerDefaultProfile(ctx, s, "123456789012:ReadOnly")
+	require.NoError(t, err)
+
+	hcResp, err := http.Get(fmt.Sprintf("http://%s/healthcheck", addr)) // nolint:gosec,noctx
+	require.NoError(t, err)
+	hcResp.Body.Close()
+	require.Equal(t, http.StatusOK, hcResp.StatusCode, "healthcheck should be 200 before unload")
+
+	ctx.Cli.Ecs.Unload.Server = addr
+	ctx.Cli.Ecs.Unload.Profile = ""
+	err = (&EcsUnloadCmd{}).Run(ctx)
+	require.NoError(t, err)
+
+	hcResp2, err := http.Get(fmt.Sprintf("http://%s/healthcheck", addr)) // nolint:gosec,noctx
+	require.NoError(t, err)
+	hcResp2.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, hcResp2.StatusCode,
+		"healthcheck should return 503 after unloading the default slot")
+}
+
+// TestE2EEcsUnloadSlotted exercises the `ecs unload --profile` path for a named slot:
+//  1. Load a credential into a named slot.
+//  2. Confirm the slot healthcheck returns 200.
+//  3. Call EcsUnloadCmd.Run with the profile name.
+//  4. Verify the slot healthcheck now returns 503.
+func TestE2EEcsUnloadSlotted(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+	queueRoleCredentials(setup.Server)
+
+	_, addr := newEcsServerForTest(t)
+
+	ctx := newRunContext(setup, AUTH_REQUIRED)
+	ctx.Cli.Ecs.Load.Server = addr
+	ctx.Cli.Ecs.Load.Slotted = true
+	err := ecsLoadCmd(ctx, 123456789012, "ReadOnly")
+	require.NoError(t, err)
+
+	slotHC := fmt.Sprintf("http://%s/healthcheck/slot/123456789012:ReadOnly", addr)
+	hcResp, err := http.Get(slotHC) // nolint:gosec,noctx
+	require.NoError(t, err)
+	hcResp.Body.Close()
+	require.Equal(t, http.StatusOK, hcResp.StatusCode, "slot healthcheck should be 200 before unload")
+
+	ctx.Cli.Ecs.Unload.Server = addr
+	ctx.Cli.Ecs.Unload.Profile = "123456789012:ReadOnly"
+	err = (&EcsUnloadCmd{}).Run(ctx)
+	require.NoError(t, err)
+
+	hcResp2, err := http.Get(slotHC) // nolint:gosec,noctx
+	require.NoError(t, err)
+	hcResp2.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, hcResp2.StatusCode,
+		"slot healthcheck should return 503 after unloading the named slot")
+}
+
+// TestE2EEcsServerRun exercises EcsServerCmd.Run() end-to-end without a default
+// profile (no credentials pre-loaded).  The server starts, accepts connections,
+// and shuts down cleanly when the context is cancelled.
+func TestE2EEcsServerRun(t *testing.T) {
+	setup := newE2ESetup(t)
+
+	cctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	port := freePort(t)
+	ctx := &RunContext{
+		Cli:      &CLI{},
+		Settings: setup.Settings,
+		Store:    setup.Store,
+		Auth:     AUTH_SKIP,
+		Ctx:      cctx,
+	}
+	ctx.Cli.Ecs.Server = EcsServerCmd{
+		BindIP:      "127.0.0.1",
+		Port:        port,
+		DisableAuth: true,
+		DisableSSL:  true,
+	}
+	cc := &ctx.Cli.Ecs.Server
+
+	done := make(chan error, 1)
+	go func() { done <- cc.Run(ctx) }()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	require.NoError(t, waitForEcsServerUp("http", addr, "", 5*time.Second))
+
+	// No credentials loaded → healthcheck returns 503.
+	hcResp, err := http.Get(fmt.Sprintf("http://%s/healthcheck", addr)) // nolint:gosec,noctx
+	require.NoError(t, err)
+	hcResp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, hcResp.StatusCode,
+		"healthcheck should be 503 when no credentials are loaded")
+
+	cancel()
+	assert.NoError(t, <-done, "Run() should return nil on context cancellation")
+}
+
+// TestE2EEcsServerRunWithDefault exercises EcsServerCmd.Run() with --default:
+// credentials are injected into the default slot before Serve() starts, so
+// the healthcheck immediately returns 200 and GET / returns the test credentials.
+func TestE2EEcsServerRunWithDefault(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+	queueRoleCredentials(setup.Server)
+
+	cctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	port := freePort(t)
+	ctx := &RunContext{
+		Cli:      &CLI{},
+		Settings: setup.Settings,
+		Store:    setup.Store,
+		Auth:     AUTH_REQUIRED,
+		Ctx:      cctx,
+	}
+	ctx.Cli.Ecs.Server = EcsServerCmd{
+		BindIP:      "127.0.0.1",
+		Port:        port,
+		DisableAuth: true,
+		DisableSSL:  true,
+		Default:     "123456789012:ReadOnly",
+	}
+	cc := &ctx.Cli.Ecs.Server
+
+	done := make(chan error, 1)
+	go func() { done <- cc.Run(ctx) }()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	require.NoError(t, waitForEcsServerUp("http", addr, "", 5*time.Second))
+
+	// Default credentials loaded before Serve() → healthcheck should be 200.
+	hcResp, err := http.Get(fmt.Sprintf("http://%s/healthcheck", addr)) // nolint:gosec,noctx
+	require.NoError(t, err)
+	hcResp.Body.Close()
+	assert.Equal(t, http.StatusOK, hcResp.StatusCode,
+		"healthcheck should be 200 after --default credentials are loaded")
+
+	// GET / should return the test credentials.
+	resp, err := http.Get(fmt.Sprintf("http://%s/", addr)) // nolint:gosec,noctx
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	var creds map[string]string
+	require.NoError(t, json.Unmarshal(body, &creds))
+	assert.Equal(t, "AKIDTEST12345", creds["AccessKeyId"])
+	assert.Equal(t, "SECRETTEST12345", creds["SecretAccessKey"])
+	assert.Equal(t, "TOKENTEST12345", creds["Token"])
+
+	cancel()
+	assert.NoError(t, <-done, "Run() should return nil on context cancellation")
+}
+
+// TestE2EEcsServerRunWithAuth exercises bearer-token enforcement in EcsServerCmd.Run():
+//   - A token saved in the store is applied to all non-healthcheck routes.
+//   - Requests without the Authorization header receive 403 Forbidden.
+//   - Requests with the correct Bearer token reach the credential handler.
+//   - The /healthcheck route bypasses auth and always responds.
+func TestE2EEcsServerRunWithAuth(t *testing.T) {
+	setup := newE2ESetup(t)
+
+	const token = "test-bearer-token"
+	require.NoError(t, setup.Store.SaveEcsBearerToken(context.Background(), token))
+
+	cctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	port := freePort(t)
+	ctx := &RunContext{
+		Cli:      &CLI{},
+		Settings: setup.Settings,
+		Store:    setup.Store,
+		Auth:     AUTH_SKIP,
+		Ctx:      cctx,
+	}
+	ctx.Cli.Ecs.Server = EcsServerCmd{
+		BindIP:     "127.0.0.1",
+		Port:       port,
+		DisableSSL: true,
+		// DisableAuth is false: bearer token from store will be enforced.
+	}
+	cc := &ctx.Cli.Ecs.Server
+
+	done := make(chan error, 1)
+	go func() { done <- cc.Run(ctx) }()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	require.NoError(t, waitForEcsServerUp("http", addr, "", 5*time.Second))
+
+	// /healthcheck bypasses auth → should respond even without a token.
+	hcResp, err := http.Get(fmt.Sprintf("http://%s/healthcheck", addr)) // nolint:gosec,noctx
+	require.NoError(t, err)
+	hcResp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, hcResp.StatusCode,
+		"healthcheck should return 503 (no creds) without needing auth")
+
+	// GET / without Authorization header → 403 Forbidden.
+	unauthResp, err := http.Get(fmt.Sprintf("http://%s/", addr)) // nolint:gosec,noctx
+	require.NoError(t, err)
+	unauthResp.Body.Close()
+	assert.Equal(t, http.StatusForbidden, unauthResp.StatusCode,
+		"unauthenticated request should be rejected with 403")
+
+	// GET / with correct Bearer token → reaches the credential handler (404: no creds loaded).
+	req, err := http.NewRequestWithContext(cctx, http.MethodGet, fmt.Sprintf("http://%s/", addr), nil)
+	require.NoError(t, err)
+	req.Header.Set("Authorization", "Bearer "+token)
+	authResp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	authResp.Body.Close()
+	assert.Equal(t, http.StatusNotFound, authResp.StatusCode,
+		"authenticated request should reach the credential handler (404: no creds loaded)")
+
+	cancel()
+	assert.NoError(t, <-done, "Run() should return nil on context cancellation")
 }

--- a/cmd/aws-sso/e2e_list_sso_roles_test.go
+++ b/cmd/aws-sso/e2e_list_sso_roles_test.go
@@ -1,0 +1,78 @@
+//go:build e2etests
+
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2026 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/synfinatic/aws-sso-cli/internal/awsmock"
+)
+
+// TestE2EListSSORoles verifies the happy path: accounts and roles returned by the
+// mock server appear in the output table.
+func TestE2EListSSORoles(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+
+	setup.Server.SSO.QueueListAccounts(awsmock.ListAccountsResponse{
+		AccountList: []awsmock.AccountInfo{
+			{AccountID: "123456789012", AccountName: "TestAccount", EmailAddress: "admin@example.com"},
+		},
+	})
+	setup.Server.SSO.QueueListAccountRoles(awsmock.ListAccountRolesResponse{
+		RoleList: []awsmock.RoleInfo{
+			{AccountID: "123456789012", RoleName: "ReadOnly"},
+			{AccountID: "123456789012", RoleName: "PowerUser"},
+		},
+	})
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	output := captureStdout(func() {
+		err := (&ListSSORolesCmd{}).Run(ctx)
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "123456789012")
+	assert.Contains(t, output, "ReadOnly")
+	assert.Contains(t, output, "PowerUser")
+}
+
+// TestE2EListSSORolesEmpty verifies that an empty account list produces no error
+// and no role rows.
+func TestE2EListSSORolesEmpty(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+
+	setup.Server.SSO.QueueListAccounts(awsmock.ListAccountsResponse{
+		AccountList: []awsmock.AccountInfo{},
+	})
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	output := captureStdout(func() {
+		err := (&ListSSORolesCmd{}).Run(ctx)
+		require.NoError(t, err)
+	})
+
+	assert.NotContains(t, output, "ReadOnly",
+		"empty account list should produce no role rows")
+}

--- a/cmd/aws-sso/e2e_list_test.go
+++ b/cmd/aws-sso/e2e_list_test.go
@@ -148,3 +148,145 @@ func TestE2ESubprocessExitCodeRace(t *testing.T) {
 			"before the runtime exits cleanly (regression: #1379); stderr: %s",
 		stderr.String())
 }
+
+// TestE2EListPrefix verifies that --prefix filters roles by field value prefix.
+func TestE2EListPrefix(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.List = ListCmd{Sort: "AccountId", Prefix: "AccountId=123"}
+
+	output := captureStdout(func() {
+		err := (&ctx.Cli.List).Run(ctx)
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "ReadOnly", "matching account should appear")
+}
+
+// TestE2EListPrefixMissingEquals verifies that a --prefix without '=' returns an error.
+func TestE2EListPrefixMissingEquals(t *testing.T) {
+	setup := newE2ESetup(t)
+	populateCache(t, setup)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.List = ListCmd{Sort: "AccountId", Prefix: "AccountId"}
+
+	err := (&ctx.Cli.List).Run(ctx)
+	assert.ErrorContains(t, err, "format of <FieldName>=<Prefix>")
+}
+
+// TestE2EListPrefixInvalidField verifies that an unknown --prefix field name returns an error.
+func TestE2EListPrefixInvalidField(t *testing.T) {
+	setup := newE2ESetup(t)
+	populateCache(t, setup)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.List = ListCmd{Sort: "AccountId", Prefix: "NoSuchField=x"}
+
+	err := (&ctx.Cli.List).Run(ctx)
+	assert.ErrorContains(t, err, "valid field")
+}
+
+// TestE2EListCSV verifies that the CSV flag produces comma-separated output.
+func TestE2EListCSV(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.List = ListCmd{Sort: "AccountId", CSV: true, Fields: []string{"AccountId", "RoleName"}}
+
+	output := captureStdout(func() {
+		err := (&ctx.Cli.List).Run(ctx)
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, ",", "CSV output should contain commas")
+	assert.Contains(t, output, "ReadOnly")
+}
+
+// TestE2EListSort verifies ascending sort by RoleName puts PowerUser before ReadOnly.
+func TestE2EListSort(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.List = ListCmd{Sort: "RoleName", Fields: []string{"RoleName"}}
+
+	output := captureStdout(func() {
+		err := (&ctx.Cli.List).Run(ctx)
+		require.NoError(t, err)
+	})
+
+	powerIdx := strings.Index(output, "PowerUser")
+	readOnlyIdx := strings.Index(output, "ReadOnly")
+	assert.True(t, powerIdx < readOnlyIdx, "ascending sort: PowerUser should appear before ReadOnly")
+}
+
+// TestE2EListSortReverse verifies descending sort by RoleName puts ReadOnly before PowerUser.
+func TestE2EListSortReverse(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.List = ListCmd{Sort: "RoleName", Reverse: true, Fields: []string{"RoleName"}}
+
+	output := captureStdout(func() {
+		err := (&ctx.Cli.List).Run(ctx)
+		require.NoError(t, err)
+	})
+
+	readOnlyIdx := strings.Index(output, "ReadOnly")
+	powerIdx := strings.Index(output, "PowerUser")
+	assert.True(t, readOnlyIdx < powerIdx, "descending sort: ReadOnly should appear before PowerUser")
+}
+
+// TestE2EListUnsupportedField verifies that an unknown field name returns an error.
+func TestE2EListUnsupportedField(t *testing.T) {
+	setup := newE2ESetup(t)
+	populateCache(t, setup)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.List = ListCmd{Sort: "AccountId", Fields: []string{"NoSuchField"}}
+
+	err := (&ctx.Cli.List).Run(ctx)
+	assert.ErrorContains(t, err, "unsupported field")
+}
+
+// TestE2EListFields verifies that the -f flag prints the available fields table.
+func TestE2EListFields(t *testing.T) {
+	setup := newE2ESetup(t)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.List = ListCmd{ListFields: true}
+
+	output := captureStdout(func() {
+		err := (&ctx.Cli.List).Run(ctx)
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "AccountId", "fields table should list AccountId")
+	assert.Contains(t, output, "RoleName", "fields table should list RoleName")
+}
+
+// TestE2EDefaultCmd verifies that DefaultCmd.Run prints the cached roles table.
+func TestE2EDefaultCmd(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+
+	output := captureStdout(func() {
+		err := (&DefaultCmd{}).Run(ctx)
+		require.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "ReadOnly")
+	assert.Contains(t, output, "123456789012")
+}

--- a/cmd/aws-sso/e2e_logout_test.go
+++ b/cmd/aws-sso/e2e_logout_test.go
@@ -1,0 +1,78 @@
+//go:build e2etests
+
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2026 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ssoauth "github.com/synfinatic/aws-sso-cli/internal/sso/auth"
+)
+
+// TestE2ELogout_Run exercises LogoutCmd.Run when the store has no cached SSO token.
+// In that case flushSts runs (no-op with empty cache) and Logout returns an error
+// from the missing token — no real AWS network call is made.
+func TestE2ELogout_Run(t *testing.T) {
+	setup := newE2ESetup(t)
+	// Intentionally do NOT call preAuth — store has no CreateTokenResponse.
+	// LogoutCmd.Run still runs flushSts, then Logout fails with "no token" error.
+	ctx := newRunContext(setup, AUTH_SKIP)
+	err := (&LogoutCmd{}).Run(ctx)
+	// The error comes from GetCreateTokenResponse returning "no token found".
+	assert.Error(t, err)
+}
+
+// TestFlushSts_Empty verifies flushSts is a no-op on an empty (no roles) cache.
+func TestFlushSts_Empty(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	// Do NOT call populateCache — cache has no roles.
+
+	s, err := setup.Settings.GetSelectedSSO(setup.SSOName)
+	require.NoError(t, err)
+	awssso := ssoauth.NewAWSSSO(s, setup.Store)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	// Should not panic or error even with an empty cache.
+	assert.NotPanics(t, func() {
+		flushSts(ctx, awssso)
+	})
+}
+
+// TestFlushSts_WithRoles verifies flushSts marks all roles expired after clearing STS creds.
+func TestFlushSts_WithRoles(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+
+	s, err := setup.Settings.GetSelectedSSO(setup.SSOName)
+	require.NoError(t, err)
+	awssso := ssoauth.NewAWSSSO(s, setup.Store)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	flushSts(ctx, awssso)
+
+	ssoCache := setup.Settings.Cache.GetSSO()
+	for _, role := range ssoCache.Roles.GetAllRoles() {
+		assert.True(t, role.IsExpired(), "role %s should be expired after flushSts", role.Arn)
+	}
+}

--- a/cmd/aws-sso/e2e_main_test.go
+++ b/cmd/aws-sso/e2e_main_test.go
@@ -1,0 +1,90 @@
+//go:build e2etests
+
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2026 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetRoleCredentials_CacheMiss verifies that when no credentials exist in
+// the cache or secure store, GetRoleCredentials fetches them from AWS SSO and
+// persists them for future calls.
+func TestGetRoleCredentials_CacheMiss(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+	queueRoleCredentials(setup.Server)
+
+	ctx := newRunContext(setup, AUTH_REQUIRED)
+	creds := GetRoleCredentials(ctx, AwsSSO, false, 123456789012, "ReadOnly")
+
+	require.NotNil(t, creds)
+	assert.Equal(t, "AKIDTEST12345", creds.AccessKeyId)
+	assert.Equal(t, "SECRETTEST12345", creds.SecretAccessKey)
+	assert.Equal(t, "TOKENTEST12345", creds.SessionToken)
+}
+
+// TestGetRoleCredentials_CacheHit verifies that a second call with no queued
+// SSO response succeeds by reading credentials from the secure store/cache
+// populated by the first call.
+func TestGetRoleCredentials_CacheHit(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+	queueRoleCredentials(setup.Server) // consumed by the first (cold) call
+
+	ctx := newRunContext(setup, AUTH_REQUIRED)
+
+	// First call: cold path — fetches from SSO and populates store + cache expiry.
+	first := GetRoleCredentials(ctx, AwsSSO, false, 123456789012, "ReadOnly")
+	require.NotNil(t, first)
+
+	// Second call: no response queued — must succeed from cache/store.
+	second := GetRoleCredentials(ctx, AwsSSO, false, 123456789012, "ReadOnly")
+	require.NotNil(t, second)
+	assert.Equal(t, first.AccessKeyId, second.AccessKeyId)
+	assert.Equal(t, first.SecretAccessKey, second.SecretAccessKey)
+}
+
+// TestGetRoleCredentials_ForceRefresh verifies that refreshSTS=true bypasses
+// the cache and always fetches fresh credentials from AWS SSO.
+func TestGetRoleCredentials_ForceRefresh(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+	queueRoleCredentials(setup.Server) // first fetch (cold)
+	queueRoleCredentials(setup.Server) // second fetch (forced refresh)
+
+	ctx := newRunContext(setup, AUTH_REQUIRED)
+
+	// First call: populate cache and store.
+	first := GetRoleCredentials(ctx, AwsSSO, false, 123456789012, "ReadOnly")
+	require.NotNil(t, first)
+
+	// Second call: force refresh must ignore the cached copy and consume the
+	// second queued response.
+	second := GetRoleCredentials(ctx, AwsSSO, true, 123456789012, "ReadOnly")
+	require.NotNil(t, second)
+	assert.Equal(t, "AKIDTEST12345", second.AccessKeyId)
+}

--- a/cmd/aws-sso/e2e_setup_ecs_test.go
+++ b/cmd/aws-sso/e2e_setup_ecs_test.go
@@ -1,0 +1,195 @@
+//go:build e2etests
+
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2026 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	ecsclient "github.com/synfinatic/aws-sso-cli/internal/ecs/client"
+)
+
+// generateSelfSignedCert creates an ECDSA P-256 self-signed certificate valid
+// for 127.0.0.1 / localhost.  Both PEM strings are returned.
+func generateSelfSignedCert(t *testing.T) (certPEM, keyPEM string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:     []string{"localhost"},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	certPEM = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
+
+	// SaveEcsSslKeyPair validates with x509.ParsePKCS8PrivateKey, so we must use
+	// PKCS#8 marshalling ("PRIVATE KEY" PEM type), not the SEC 1 EC form.
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	keyPEM = string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}))
+	return
+}
+
+// TestE2ESetupEcsSSL exercises all three operations of the `setup ecs ssl` command:
+//  1. Save a cert+key from PEM files (--certificate, --private-key, --force).
+//  2. Print the stored certificate (--print) and confirm the output.
+//  3. Delete the stored pair (--delete) and confirm the store is empty.
+func TestE2ESetupEcsSSL(t *testing.T) {
+	certPEM, keyPEM := generateSelfSignedCert(t)
+
+	tempDir := t.TempDir()
+	certFile := filepath.Join(tempDir, "cert.pem")
+	keyFile := filepath.Join(tempDir, "key.pem")
+	require.NoError(t, os.WriteFile(certFile, []byte(certPEM), 0600))
+	require.NoError(t, os.WriteFile(keyFile, []byte(keyPEM), 0600))
+
+	setup := newE2ESetup(t)
+	ctx := newRunContext(setup, AUTH_SKIP)
+
+	// --- Save: --certificate, --private-key, --force ---
+	ctx.Cli.Setup.Ecs.SSL = EcsSSLCmd{
+		Certificate: certFile,
+		PrivateKey:  keyFile,
+		Force:       true,
+	}
+	require.NoError(t, (&EcsSSLCmd{}).Run(ctx), "setup ecs ssl should store the cert+key")
+
+	storedCert, err := setup.Store.GetEcsSslCert()
+	require.NoError(t, err)
+	assert.Equal(t, certPEM, storedCert, "stored cert should match the PEM file content")
+
+	storedKey, err := setup.Store.GetEcsSslKey()
+	require.NoError(t, err)
+	assert.Equal(t, keyPEM, storedKey, "stored key should match the PEM file content")
+
+	// --- Print: --print ---
+	ctx.Cli.Setup.Ecs.SSL = EcsSSLCmd{Print: true}
+	output := captureStdout(func() {
+		assert.NoError(t, (&EcsSSLCmd{}).Run(ctx))
+	})
+	assert.Contains(t, output, "BEGIN CERTIFICATE",
+		"--print should output the PEM certificate block")
+
+	// --- Delete: --delete ---
+	ctx.Cli.Setup.Ecs.SSL = EcsSSLCmd{Delete: true}
+	require.NoError(t, (&EcsSSLCmd{}).Run(ctx))
+
+	afterCert, err := setup.Store.GetEcsSslCert()
+	require.NoError(t, err)
+	assert.Empty(t, afterCert, "cert should be cleared from store after --delete")
+
+	afterKey, err := setup.Store.GetEcsSslKey()
+	require.NoError(t, err)
+	assert.Empty(t, afterKey, "key should be cleared from store after --delete")
+}
+
+// TestE2EEcsServerSSL proves the full SSL/TLS path end-to-end:
+//  1. Generate a self-signed cert+key and store it via `setup ecs ssl --force`.
+//  2. Start EcsServerCmd.Run() without DisableSSL — it reads the pair from the
+//     store and passes them to server.Serve() → ServeTLS.
+//  3. Poll with waitForEcsServerUp using "https" and the cert chain: this fails
+//     unless the server is actually serving TLS (a plain-HTTP server would cause
+//     TLS handshake errors and the poll would time out).
+//  4. Make an explicit HTTPS GET /healthcheck with a custom TLS client to confirm
+//     the certificate is correctly presented and trusted.
+//  5. Cancel the context and verify Run() returns nil.
+func TestE2EEcsServerSSL(t *testing.T) {
+	certPEM, keyPEM := generateSelfSignedCert(t)
+
+	tempDir := t.TempDir()
+	certFile := filepath.Join(tempDir, "cert.pem")
+	keyFile := filepath.Join(tempDir, "key.pem")
+	require.NoError(t, os.WriteFile(certFile, []byte(certPEM), 0600))
+	require.NoError(t, os.WriteFile(keyFile, []byte(keyPEM), 0600))
+
+	setup := newE2ESetup(t)
+	ctx := newRunContext(setup, AUTH_SKIP)
+
+	// Store cert+key so EcsServerCmd.Run() can read them.
+	ctx.Cli.Setup.Ecs.SSL = EcsSSLCmd{
+		Certificate: certFile,
+		PrivateKey:  keyFile,
+		Force:       true,
+	}
+	require.NoError(t, (&EcsSSLCmd{}).Run(ctx))
+
+	// Start the ECS server with TLS enabled.
+	cctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	ctx.Ctx = cctx
+
+	port := freePort(t)
+	ctx.Cli.Ecs.Server = EcsServerCmd{
+		BindIP:      "127.0.0.1",
+		Port:        port,
+		DisableAuth: true,
+		// DisableSSL defaults to false — Run() reads the stored cert+key and calls ServeTLS.
+	}
+	cc := &ctx.Cli.Ecs.Server
+
+	done := make(chan error, 1)
+	go func() { done <- cc.Run(ctx) }()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+
+	// waitForEcsServerUp with "https" builds a TLS client that trusts certPEM.
+	// If the server were serving plain HTTP this would always fail (TLS error),
+	// proving that TLS must be active for the poll to succeed.
+	require.NoError(t, waitForEcsServerUp("https", addr, certPEM, 5*time.Second),
+		"HTTPS ECS server should become reachable once ServeTLS is active")
+
+	// Confirm the certificate is correctly presented by making a direct HTTPS request.
+	tlsClient, err := ecsclient.NewHTTPClient(certPEM)
+	require.NoError(t, err)
+	tlsClient.Timeout = 5 * time.Second
+
+	hcResp, err := tlsClient.Get(fmt.Sprintf("https://%s/healthcheck", addr)) // nolint:gosec,noctx
+	require.NoError(t, err)
+	hcResp.Body.Close()
+	assert.Equal(t, http.StatusServiceUnavailable, hcResp.StatusCode,
+		"HTTPS healthcheck should return 503 when no credentials are loaded")
+
+	cancel()
+	assert.NoError(t, <-done, "Run() should return nil on context cancellation")
+}

--- a/cmd/aws-sso/e2e_setup_profiles_test.go
+++ b/cmd/aws-sso/e2e_setup_profiles_test.go
@@ -1,0 +1,66 @@
+//go:build e2etests
+
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2026 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestE2ESetupProfilesCmd_Print verifies that SetupProfilesCmd.Run with Print=true succeeds.
+// PrintAwsConfig writes to a package-level var (not os.Stdout), so we only assert no error.
+func TestE2ESetupProfilesCmd_Print(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+
+	ctx := newRunContext(setup, AUTH_REQUIRED)
+	ctx.Cli.Setup.Profiles = SetupProfilesCmd{
+		Print: true,
+	}
+
+	require.NoError(t, (&SetupProfilesCmd{}).Run(ctx))
+}
+
+// TestE2ESetupProfilesCmd_Update verifies that SetupProfilesCmd.Run writes an AWS config file.
+func TestE2ESetupProfilesCmd_Update(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+
+	awsConfigPath := filepath.Join(t.TempDir(), "aws-config")
+
+	ctx := newRunContext(setup, AUTH_REQUIRED)
+	ctx.Cli.Setup.Profiles = SetupProfilesCmd{
+		Force:     true,
+		AwsConfig: awsConfigPath,
+	}
+
+	require.NoError(t, (&SetupProfilesCmd{}).Run(ctx))
+
+	data, err := os.ReadFile(awsConfigPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "[profile ")
+}

--- a/cmd/aws-sso/e2e_tags_test.go
+++ b/cmd/aws-sso/e2e_tags_test.go
@@ -1,0 +1,115 @@
+//go:build e2etests
+
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2026 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestE2ETagsCmd_AllRoles verifies that TagsCmd.Run prints all roles when no filter is set.
+func TestE2ETagsCmd_AllRoles(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+
+	output := captureStdout(func() {
+		require.NoError(t, (&TagsCmd{}).Run(ctx))
+	})
+
+	assert.Contains(t, output, "arn:aws:iam::123456789012:role/ReadOnly")
+	assert.Contains(t, output, "arn:aws:iam::123456789012:role/PowerUser")
+}
+
+// TestE2ETagsCmd_FilterByAccount verifies that specifying an AccountId shows only roles for
+// that account.
+func TestE2ETagsCmd_FilterByAccount(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.Tags = TagsCmd{AccountId: AccountID(123456789012)}
+
+	output := captureStdout(func() {
+		require.NoError(t, (&TagsCmd{}).Run(ctx))
+	})
+
+	assert.Contains(t, output, "arn:aws:iam::123456789012:role/ReadOnly")
+	assert.Contains(t, output, "arn:aws:iam::123456789012:role/PowerUser")
+}
+
+// TestE2ETagsCmd_FilterByRole verifies that specifying a Role name shows only that role.
+func TestE2ETagsCmd_FilterByRole(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.Tags = TagsCmd{Role: "ReadOnly"}
+
+	output := captureStdout(func() {
+		require.NoError(t, (&TagsCmd{}).Run(ctx))
+	})
+
+	assert.Contains(t, output, "arn:aws:iam::123456789012:role/ReadOnly")
+	assert.NotContains(t, output, "PowerUser")
+}
+
+// TestE2ETagsCmd_FilterByBoth verifies that specifying both AccountId and Role narrows results.
+func TestE2ETagsCmd_FilterByBoth(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.Tags = TagsCmd{
+		AccountId: AccountID(123456789012),
+		Role:      "PowerUser",
+	}
+
+	output := captureStdout(func() {
+		require.NoError(t, (&TagsCmd{}).Run(ctx))
+	})
+
+	assert.Contains(t, output, "arn:aws:iam::123456789012:role/PowerUser")
+	assert.NotContains(t, output, "ReadOnly")
+}
+
+// TestE2ETagsCmd_NoMatchingAccount verifies that a non-existent account produces no output.
+func TestE2ETagsCmd_NoMatchingAccount(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+	populateCache(t, setup)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.Tags = TagsCmd{AccountId: AccountID(999999999999)}
+
+	output := captureStdout(func() {
+		require.NoError(t, (&TagsCmd{}).Run(ctx))
+	})
+
+	assert.Empty(t, output)
+}

--- a/cmd/aws-sso/ecs_client_cmd.go
+++ b/cmd/aws-sso/ecs_client_cmd.go
@@ -131,7 +131,7 @@ func (e EcsListCmd) AfterApply(runCtx *RunContext) error {
 }
 
 func (cc *EcsListCmd) Run(ctx *RunContext) error {
-	c := newClient(ctx.Cli.Ecs.Profile.Server, ctx)
+	c := newClient(ctx.Cli.Ecs.List.Server, ctx)
 
 	profiles, err := c.ListProfiles()
 	if err != nil {

--- a/cmd/aws-sso/ecs_server_cmd.go
+++ b/cmd/aws-sso/ecs_server_cmd.go
@@ -20,8 +20,10 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 
 	"github.com/synfinatic/aws-sso-cli/internal/ecs"
@@ -127,7 +129,17 @@ func (cc *EcsServerCmd) Run(ctx *RunContext) error {
 			return err
 		}
 	}
-	return s.Serve()
+
+	// Shut down gracefully when the context is cancelled (handles SIGINT/SIGTERM from main).
+	go func() {
+		<-ctx.Ctx.Done()
+		s.Close()
+	}()
+
+	if err := s.Serve(); !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
 }
 
 // setServerDefaultProfile resolves a profile name to credentials and injects them

--- a/cmd/aws-sso/logout_cmd_test.go
+++ b/cmd/aws-sso/logout_cmd_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogoutCmdAfterApply(t *testing.T) {
+	ctx := &RunContext{Cli: &CLI{}}
+	cmd := LogoutCmd{}
+	require.NoError(t, cmd.AfterApply(ctx))
+	assert.Equal(t, AUTH_SKIP, ctx.Auth)
+}

--- a/cmd/aws-sso/main.go
+++ b/cmd/aws-sso/main.go
@@ -304,6 +304,11 @@ func loadSecureStore(ctx *RunContext) {
 
 // parseArgs parses our CLI arguments
 func parseArgs(ctx *RunContext) sso.OverrideSettings {
+	return parseArgsFrom(ctx, os.Args[1:])
+}
+
+// parseArgsFrom is the testable core of parseArgs.
+func parseArgsFrom(ctx *RunContext, args []string) sso.OverrideSettings {
 	var err error
 
 	// need to pass in the variables for defaults
@@ -349,7 +354,7 @@ func parseArgs(ctx *RunContext) sso.OverrideSettings {
 		kongplete.WithPredictors(p.KongpletePredictor()),
 	)
 
-	ctx.Kctx, err = parser.Parse(os.Args[1:])
+	ctx.Kctx, err = parser.Parse(args)
 	parser.FatalIfErrorf(err)
 
 	threads := 0
@@ -380,7 +385,7 @@ func (v VersionCmd) BeforeReset(ctx *RunContext) error {
 	}
 	fmt.Printf("AWS SSO CLI Version %s -- Copyright %s Aaron Turner\n", Version, COPYRIGHT_YEAR)
 	fmt.Printf("%s (%s)%s built at %s\n", CommitID, Tag, delta, Buildinfos)
-	os.Exit(0)
+	osExit(0)
 	return nil
 }
 

--- a/cmd/aws-sso/main_test.go
+++ b/cmd/aws-sso/main_test.go
@@ -1,13 +1,18 @@
 package main
 
 import (
+	"context"
+	"io"
 	"os"
+	"path/filepath"
 	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/synfinatic/aws-sso-cli/internal/sso"
 )
 
 func TestAccountIDUnmarshalText(t *testing.T) {
@@ -150,4 +155,174 @@ func TestLogLevelTypeValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// localCaptureOutput runs fn and returns everything written to os.Stdout during fn.
+func localCaptureOutput(fn func()) string {
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	func() {
+		defer func() {
+			w.Close()
+			os.Stdout = old
+		}()
+		fn()
+	}()
+	buf, _ := io.ReadAll(r)
+	r.Close()
+	return string(buf)
+}
+
+func TestVersionCmdBeforeReset(t *testing.T) {
+	origOsExit := osExit
+	origDelta := Delta
+	origTag := Tag
+	t.Cleanup(func() {
+		osExit = origOsExit
+		Delta = origDelta
+		Tag = origTag
+	})
+
+	tests := []struct {
+		name      string
+		delta     string
+		wantDelta bool
+	}{
+		{name: "no delta", delta: ""},
+		{name: "with delta", delta: "42", wantDelta: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exitCode := -1
+			osExit = func(code int) { exitCode = code }
+			Delta = tt.delta
+			Tag = "v1.0.0"
+
+			output := localCaptureOutput(func() {
+				_ = (VersionCmd{}).BeforeReset(&RunContext{})
+			})
+
+			assert.Equal(t, 0, exitCode)
+			assert.Contains(t, output, "AWS SSO CLI Version")
+			if tt.wantDelta {
+				assert.Contains(t, output, "delta")
+				assert.Equal(t, "Unknown", Tag)
+			} else {
+				assert.NotContains(t, output, "delta")
+			}
+		})
+	}
+}
+
+func TestVersionCmdRun(t *testing.T) {
+	v := &VersionCmd{}
+	err := v.Run(&RunContext{})
+	assert.NoError(t, err)
+}
+
+func TestParseArgsFrom(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantOverride sso.OverrideSettings
+		wantCommand  string
+	}{
+		{
+			name:        "default list command",
+			args:        []string{"list"},
+			wantCommand: "list",
+		},
+		{
+			name:         "debug log level",
+			args:         []string{"--level", "debug", "list"},
+			wantOverride: sso.OverrideSettings{LogLevel: "debug"},
+			wantCommand:  "list",
+		},
+		{
+			name:         "custom browser",
+			args:         []string{"--browser", "/usr/bin/firefox", "list"},
+			wantOverride: sso.OverrideSettings{Browser: "/usr/bin/firefox"},
+			wantCommand:  "list",
+		},
+		{
+			name:         "SSO override",
+			args:         []string{"-S", "mySSO", "list"},
+			wantOverride: sso.OverrideSettings{DefaultSSO: "mySSO"},
+			wantCommand:  "list",
+		},
+		{
+			name:         "log lines flag",
+			args:         []string{"--lines", "list"},
+			wantOverride: sso.OverrideSettings{LogLines: true},
+			wantCommand:  "list",
+		},
+		{
+			name:         "cache threads override",
+			args:         []string{"cache", "--threads", "10"},
+			wantOverride: sso.OverrideSettings{Threads: 10},
+			wantCommand:  "cache",
+		},
+		{
+			name:        "cache with default threads produces no override",
+			args:        []string{"cache"},
+			wantCommand: "cache",
+		},
+		{
+			name:         "login threads override",
+			args:         []string{"login", "--threads", "3"},
+			wantOverride: sso.OverrideSettings{Threads: 3},
+			wantCommand:  "login",
+		},
+		{
+			name:        "login with default threads produces no override",
+			args:        []string{"login"},
+			wantCommand: "login",
+		},
+		{
+			name: "multiple flags combined",
+			args: []string{"--level", "info", "-S", "prod", "--browser", "/opt/chrome", "list"},
+			wantOverride: sso.OverrideSettings{
+				LogLevel:   "info",
+				DefaultSSO: "prod",
+				Browser:    "/opt/chrome",
+			},
+			wantCommand: "list",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := &RunContext{
+				Cli:  &CLI{},
+				Auth: AUTH_UNKNOWN,
+			}
+			override := parseArgsFrom(ctx, tt.args)
+			assert.Equal(t, tt.wantOverride, override)
+			require.NotNil(t, ctx.Kctx)
+			assert.Equal(t, tt.wantCommand, ctx.Kctx.Command())
+		})
+	}
+}
+
+func TestLoadSecureStoreJSON(t *testing.T) {
+	tempDir := t.TempDir()
+	storePath := filepath.Join(tempDir, "store.json")
+
+	settings := &sso.Settings{
+		SecureStore: "json",
+		JsonStore:   storePath,
+	}
+	ctx := &RunContext{
+		Cli:      &CLI{},
+		Settings: settings,
+		Ctx:      context.Background(),
+	}
+
+	loadSecureStore(ctx)
+	assert.NotNil(t, ctx.Store)
 }

--- a/cmd/aws-sso/setup_cmd_test.go
+++ b/cmd/aws-sso/setup_cmd_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/synfinatic/aws-sso-cli/internal/storage"
+)
+
+func openTestStore(t *testing.T) storage.SecureStorage {
+	t.Helper()
+	ctx := context.Background()
+	store, err := storage.OpenJsonStore(ctx, filepath.Join(t.TempDir(), "store.json"))
+	require.NoError(t, err)
+	return store
+}
+
+func TestEcsSSLCmdAfterApply(t *testing.T) {
+	ctx := &RunContext{Cli: &CLI{}}
+	cmd := EcsSSLCmd{}
+	require.NoError(t, cmd.AfterApply(ctx))
+	assert.Equal(t, AUTH_SKIP, ctx.Auth)
+}
+
+func TestEcsSSLCmdRun_Delete(t *testing.T) {
+	store := openTestStore(t)
+	ctx := &RunContext{
+		Cli:   &CLI{},
+		Store: store,
+		Ctx:   context.Background(),
+	}
+	ctx.Cli.Setup.Ecs.SSL.Delete = true
+
+	cmd := &EcsSSLCmd{}
+	// Store is empty; DeleteEcsSslKeyPair on an empty store still returns nil.
+	assert.NoError(t, cmd.Run(ctx))
+}
+
+func TestEcsSSLCmdRun_Print_NoCert(t *testing.T) {
+	store := openTestStore(t)
+	ctx := &RunContext{
+		Cli:   &CLI{},
+		Store: store,
+		Ctx:   context.Background(),
+	}
+	ctx.Cli.Setup.Ecs.SSL.Print = true
+
+	cmd := &EcsSSLCmd{}
+	// No certificate stored; Run should return an error.
+	err := cmd.Run(ctx)
+	assert.Error(t, err)
+}
+
+func TestEcsAuthCmdAfterApply(t *testing.T) {
+	ctx := &RunContext{Cli: &CLI{}}
+	cmd := EcsAuthCmd{}
+	require.NoError(t, cmd.AfterApply(ctx))
+	assert.Equal(t, AUTH_SKIP, ctx.Auth)
+}
+
+func TestEcsAuthCmdRun_NoBearerToken(t *testing.T) {
+	store := openTestStore(t)
+	ctx := &RunContext{
+		Cli:   &CLI{},
+		Store: store,
+		Ctx:   context.Background(),
+	}
+	// BearerToken is empty, Delete is false → should return an error.
+	cmd := &EcsAuthCmd{}
+	err := cmd.Run(ctx)
+	assert.Error(t, err)
+}
+
+func TestEcsAuthCmdRun_SaveBearerToken(t *testing.T) {
+	store := openTestStore(t)
+	ctx := &RunContext{
+		Cli:   &CLI{},
+		Store: store,
+		Ctx:   context.Background(),
+	}
+	ctx.Cli.Setup.Ecs.Auth.BearerToken = "my-secret-token"
+
+	cmd := &EcsAuthCmd{}
+	assert.NoError(t, cmd.Run(ctx))
+}
+
+func TestEcsAuthCmdRun_BearerTokenWithPrefix(t *testing.T) {
+	store := openTestStore(t)
+	ctx := &RunContext{
+		Cli:   &CLI{},
+		Store: store,
+		Ctx:   context.Background(),
+	}
+	ctx.Cli.Setup.Ecs.Auth.BearerToken = "Bearer already-prefixed"
+
+	cmd := &EcsAuthCmd{}
+	err := cmd.Run(ctx)
+	assert.Error(t, err)
+}
+
+func TestEcsAuthCmdRun_Delete(t *testing.T) {
+	store := openTestStore(t)
+	ctx := &RunContext{
+		Cli:   &CLI{},
+		Store: store,
+		Ctx:   context.Background(),
+	}
+	ctx.Cli.Setup.Ecs.Auth.Delete = true
+
+	cmd := &EcsAuthCmd{}
+	// Nothing stored to delete; should return nil.
+	assert.NoError(t, cmd.Run(ctx))
+}

--- a/cmd/aws-sso/setup_wizard_test.go
+++ b/cmd/aws-sso/setup_wizard_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/synfinatic/aws-sso-cli/internal/predictor"
 )
 
@@ -176,4 +178,39 @@ func TestValidateBinaryOrNone(t *testing.T) {
 			assert.Error(t, validateBinaryOrNone(f.Name()))
 		})
 	}
+}
+
+func TestMakeSelectTemplate(t *testing.T) {
+	tmpl := makeSelectTemplate("Choose role")
+	require.NotNil(t, tmpl)
+	assert.NotEmpty(t, tmpl.Label)
+	assert.NotEmpty(t, tmpl.Active)
+	assert.NotEmpty(t, tmpl.Inactive)
+	assert.NotEmpty(t, tmpl.Selected)
+}
+
+func TestMakePromptTemplate(t *testing.T) {
+	tmpl := makePromptTemplate("Enter value")
+	require.NotNil(t, tmpl)
+	assert.NotEmpty(t, tmpl.Prompt)
+	assert.NotEmpty(t, tmpl.Success)
+}
+
+func TestCheckPromptError_Del(t *testing.T) {
+	// "^D" logs an error but does not call log.Fatal — must not panic.
+	assert.NotPanics(t, func() {
+		checkPromptError(errors.New("^D"))
+	})
+}
+
+func TestCheckPromptError_Default(t *testing.T) {
+	assert.NotPanics(t, func() {
+		checkPromptError(errors.New("some unexpected error"))
+	})
+}
+
+func TestCheckSelectError_Default(t *testing.T) {
+	assert.NotPanics(t, func() {
+		checkSelectError(errors.New("some select error"))
+	})
 }

--- a/cmd/aws-sso/time_cmd_test.go
+++ b/cmd/aws-sso/time_cmd_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureTimeCmdStdout redirects os.Stdout for the duration of fn and returns what was written.
+func captureTimeCmdStdout(fn func()) string {
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	func() {
+		defer func() {
+			w.Close()
+			os.Stdout = old
+		}()
+		fn()
+	}()
+	buf, _ := io.ReadAll(r)
+	r.Close()
+	return string(buf)
+}
+
+func TestTimeCmdAfterApply(t *testing.T) {
+	ctx := &RunContext{Cli: &CLI{}}
+	cmd := TimeCmd{}
+	require.NoError(t, cmd.AfterApply(ctx))
+	assert.Equal(t, AUTH_SKIP, ctx.Auth)
+}
+
+func TestTimeCmdRun_NoEnvVar(t *testing.T) {
+	unsetEnvForTest(t, "AWS_SSO_SESSION_EXPIRATION")
+	ctx := &RunContext{Cli: &CLI{}}
+	cmd := &TimeCmd{}
+	output := captureTimeCmdStdout(func() {
+		assert.NoError(t, cmd.Run(ctx))
+	})
+	assert.Empty(t, output)
+}
+
+func TestTimeCmdRun_FutureTime(t *testing.T) {
+	future := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
+	t.Setenv("AWS_SSO_SESSION_EXPIRATION", future)
+
+	ctx := &RunContext{Cli: &CLI{}}
+	cmd := &TimeCmd{}
+	output := captureTimeCmdStdout(func() {
+		assert.NoError(t, cmd.Run(ctx))
+	})
+	assert.NotEmpty(t, output)
+}
+
+func TestTimeCmdRun_InvalidTime(t *testing.T) {
+	t.Setenv("AWS_SSO_SESSION_EXPIRATION", "not-a-valid-time")
+	ctx := &RunContext{Cli: &CLI{}}
+	cmd := &TimeCmd{}
+	assert.Error(t, cmd.Run(ctx))
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,8 +9,15 @@ coverage:
         threshold: 0.25%
 
 ignore:
-#  - "cmd/**/*"
-#  - "cmd"
+  # these files are not appropriate for code coverage reporting
   - "cmd/aws-ssl-test/*"
-  - "internal/sso/auth/awssso_testing.go"
+  - "internal/sso/auth/e2e_awssso.go"
   - "internal/awsmock/*"
+  # these files are very difficult to have good coverage so ignore for now
+  - "cmd/aws-sso/completions_cmd.go"
+  - "cmd/aws-sso/console_cmd.go"
+  - "cmd/aws-sso/ecs_client_cmd.go"
+  - "cmd/aws-sso/ecs_docker_cmd.go"
+  - "cmd/aws-sso/setup_wizard.go"
+  - "cmd/aws-sso/setup_wizard_cmd.go"
+  - "cmd/aws-sso/interactive.go"

--- a/internal/sso/auth/e2e_awssso.go
+++ b/internal/sso/auth/e2e_awssso.go
@@ -1,3 +1,5 @@
+//go:build e2etests
+
 package auth
 
 /*


### PR DESCRIPTION
* make test: no longer generates coverage.out for codecov/etc
* make coverage: generates coverage.out (unit tests + e2e)