### PR TITLE
add Profile to interactive mode selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add support for /healthcheck endpoint for ECS server #1356
 * Add `--default <profile>` flag to `ecs server` and `ecs docker start` to automatically load
   a named profile as the default credential slot on startup
+* Interactive mode now supports selecting by Profile name
 
 ### Bugs
 
@@ -22,8 +23,8 @@
 
 ### Changes
 
-* Add unit tests for cmd/aws-sso
 * Add lock support for JSON SecureStore
+* Add unit tests for cmd/aws-sso/*
 * Add e2e integration tests for CLI commands
 
 ## [v2.2.4] - 2026-05-21

--- a/cmd/aws-sso/interactive.go
+++ b/cmd/aws-sso/interactive.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/c-bata/go-prompt"
@@ -76,6 +77,7 @@ type TagsCompleter struct {
 	suggest        []prompt.Suggest
 	exec           CompleterExec
 	fullTextSearch bool
+	profiles       map[string]string // ProfileName => ARN
 }
 
 // NewTagsCompleter creates our TagsCompleter
@@ -84,14 +86,28 @@ func NewTagsCompleter(ctx *RunContext, s *ssoconfig.SSOConfig, exec CompleterExe
 	roleTags := set.Cache.GetRoleTagsSelect()
 	allTags := set.Cache.GetAllTagsSelect()
 
+	profiles := map[string]string{}
+	if ssoCache := set.Cache.GetSSO(); ssoCache != nil && ssoCache.Roles != nil {
+		for aid := range ssoCache.Roles.Accounts {
+			for _, rFlat := range ssoCache.Roles.GetAccountRoles(aid) {
+				pName, err := rFlat.ProfileName(set)
+				if err != nil {
+					continue
+				}
+				profiles[pName] = rFlat.Arn
+			}
+		}
+	}
+
 	return &TagsCompleter{
 		ctx:            ctx,
 		sso:            s,
 		roleTags:       roleTags,
 		allTags:        allTags,
-		suggest:        completeTags(roleTags, allTags, set.AccountPrimaryTag, []string{}, set.FirstTag),
+		suggest:        completeTags(roleTags, allTags, set.AccountPrimaryTag, []string{}, set.FirstTag, profiles),
 		exec:           exec,
 		fullTextSearch: set.FullTextSearch,
+		profiles:       profiles,
 	}
 }
 
@@ -112,7 +128,7 @@ func (tc *TagsCompleter) Complete(d prompt.Document) []prompt.Suggest {
 	// remove any extra spaces
 	cleanArgs := CompleteSpaceReplace.ReplaceAllString(args, " ")
 	argsList := strings.Split(cleanArgs, " ")
-	suggest := completeTags(tc.roleTags, tc.allTags, tc.ctx.Settings.AccountPrimaryTag, argsList, tc.ctx.Settings.FirstTag)
+	suggest := completeTags(tc.roleTags, tc.allTags, tc.ctx.Settings.AccountPrimaryTag, argsList, tc.ctx.Settings.FirstTag, tc.profiles)
 	if tc.fullTextSearch {
 		return prompt.FilterContains(suggest, w, true)
 	} else {
@@ -133,9 +149,13 @@ func (tc *TagsCompleter) Executor(args string) {
 
 	var roleArn string
 	argsList := strings.Split(args, " ")
-	if isRoleARN.MatchString(argsList[len(argsList)-1]) {
+	lastArg := argsList[len(argsList)-1]
+	if arn, ok := tc.profiles[lastArg]; ok {
+		// last word is a profile name, resolve it to an ARN
+		roleArn = arn
+	} else if isRoleARN.MatchString(lastArg) {
 		// last word is our ARN, no need to filter
-		roleArn = argsList[len(argsList)-1]
+		roleArn = lastArg
 	} else {
 		// Use the filter map
 		argsMap, _, _ := argsToMap(strings.Split(args, " "))
@@ -165,11 +185,66 @@ func (tc *TagsCompleter) ExitChecker(in string, breakline bool) bool {
 	return breakline // exit our Run() loop after user selects something
 }
 
+// completeProfileValues returns profile name suggestions filtered by the partial nextValue string.
+// Only profiles whose roles match currentTags are included.
+func completeProfileValues(profiles map[string]string, currentTags map[string]string, roleTags *sso.RoleTags, nextValue string) []prompt.Suggest {
+	currentRoles := roleTags.GetMatchingRoles(currentTags)
+	roleSet := map[string]bool{}
+	for _, arn := range currentRoles {
+		roleSet[arn] = true
+	}
+	suggests := []prompt.Suggest{}
+	for pName, arn := range profiles {
+		if strings.Contains(strings.ToLower(pName), strings.ToLower(nextValue)) {
+			if len(currentTags) == 0 || roleSet[arn] {
+				suggests = append(suggests, prompt.Suggest{Text: pName, Description: arn})
+			}
+		}
+	}
+	sort.Slice(suggests, func(i, j int) bool { return suggests[i].Text < suggests[j].Text })
+	return suggests
+}
+
+// roleDescription returns a "tag:value" description for a role using the first matching accountPrimaryTag.
+func roleDescription(role string, args []string, accountPrimaryTags []string, roleTags *sso.RoleTags) string {
+	argSet := make(map[string]bool, len(args))
+	for _, v := range args {
+		argSet[v] = true
+	}
+	for _, tag := range accountPrimaryTags {
+		if argSet[tag] {
+			continue
+		}
+		if val, ok := roleTags.GetRoleTags(role)[tag]; ok && val != "" {
+			return fmt.Sprintf("%s:%s", tag, val)
+		}
+	}
+	return ""
+}
+
 // return a list of suggestions based on user selected []key:value
-func completeTags(roleTags *sso.RoleTags, allTags *tags.TagsList, accountPrimaryTags []string, args []string, firstTag string) []prompt.Suggest {
+func completeTags(roleTags *sso.RoleTags, allTags *tags.TagsList, accountPrimaryTags []string, args []string, firstTag string, profiles map[string]string) []prompt.Suggest {
 	suggestions := []prompt.Suggest{}
 
 	currentTags, nextKey, nextValue := argsToMap(args)
+
+	// "ProfileName" is a virtual tag key distinct from the real flat.Tags["Profile"] tag.
+	// argsToMap may store a partial profile value in currentTags, so strip it before
+	// real-tag processing.
+	_, profileSelected := currentTags["ProfileName"]
+	if profileSelected {
+		delete(currentTags, "ProfileName")
+	}
+
+	if nextKey == "ProfileName" {
+		return completeProfileValues(profiles, currentTags, roleTags, nextValue)
+	}
+
+	// A completed ProfileName selection uniquely identifies a role; no more suggestions needed.
+	if profileSelected && nextKey == "" {
+		return suggestions
+	}
+
 	if roleTags.GetMatchCount(currentTags) == 1 {
 		return suggestions // empty list if we have a single role
 	}
@@ -194,26 +269,9 @@ func completeTags(roleTags *sso.RoleTags, allTags *tags.TagsList, accountPrimary
 						// don't return the same role multiple times
 						continue
 					}
-
-					var description string
-					for _, tag := range accountPrimaryTags {
-						// don't re-use a tag that was alraedy specified by the user
-						for _, v := range args {
-							if v == tag {
-								continue
-							}
-						}
-						if val, ok := roleTags.GetRoleTags(role)[tag]; ok {
-							if val == "" { // ignore empty values
-								continue
-							}
-							description = fmt.Sprintf("%s:%s", tag, val)
-							break
-						}
-					}
 					suggestions = append(suggestions, prompt.Suggest{
 						Text:        role,
-						Description: description,
+						Description: roleDescription(role, args, accountPrimaryTags, roleTags),
 					})
 					returnedRoles[role] = true
 				}
@@ -227,6 +285,13 @@ func completeTags(roleTags *sso.RoleTags, allTags *tags.TagsList, accountPrimary
 				})
 			}
 		}
+		if len(profiles) > 0 && len(currentTags) == 0 {
+			suggestions = append(suggestions, prompt.Suggest{
+				Text:        "ProfileName",
+				Description: fmt.Sprintf("%d roles/%d choices", len(currentRoles), len(profiles)),
+			})
+		}
+		sort.Slice(suggestions, func(i, j int) bool { return suggestions[i].Text < suggestions[j].Text })
 	} else if nextValue == "" {
 		// We have a 'nextKey', so search for Tag values which match
 		values := (*allTags).UniqueValues(nextKey)

--- a/cmd/aws-sso/interactive_test.go
+++ b/cmd/aws-sso/interactive_test.go
@@ -3,7 +3,10 @@ package main
 import (
 	"testing"
 
+	"github.com/c-bata/go-prompt"
 	"github.com/stretchr/testify/assert"
+	ssocache "github.com/synfinatic/aws-sso-cli/internal/sso/cache"
+	"github.com/synfinatic/aws-sso-cli/internal/tags"
 )
 
 func TestArgsToMap(t *testing.T) {
@@ -72,6 +75,161 @@ func TestArgsToMap(t *testing.T) {
 			assert.Equal(t, tt.wantTags, gotTags)
 			assert.Equal(t, tt.wantKey, gotKey)
 			assert.Equal(t, tt.wantVal, gotVal)
+		})
+	}
+}
+
+func TestCompleteTags(t *testing.T) {
+	const (
+		arn1  = "arn:aws:iam::111111111111:role/Admin"
+		arn2  = "arn:aws:iam::222222222222:role/ReadOnly"
+		arn3  = "arn:aws:iam::333333333333:role/Viewer"
+		prof1 = "111111111111:Admin"
+		prof2 = "222222222222:ReadOnly"
+		prof3 = "333333333333:Viewer"
+	)
+
+	rt := ssocache.RoleTags{
+		arn1: {"env": "prod"},
+		arn2: {"env": "dev"},
+		arn3: {"env": "dev"},
+	}
+	tl := tags.TagsList{
+		"env": {"dev", "prod"},
+	}
+	profiles := map[string]string{
+		prof1: arn1,
+		prof2: arn2,
+		prof3: arn3,
+	}
+
+	suggestTexts := func(suggests []prompt.Suggest) []string {
+		texts := make([]string, len(suggests))
+		for i, s := range suggests {
+			texts[i] = s.Text
+		}
+		return texts
+	}
+
+	t.Run("empty args shows ProfileName key not individual profiles", func(t *testing.T) {
+		got := completeTags(&rt, &tl, []string{}, []string{}, "", profiles)
+		texts := suggestTexts(got)
+		assert.Contains(t, texts, "ProfileName")
+		assert.NotContains(t, texts, prof1)
+		assert.NotContains(t, texts, prof2)
+		assert.NotContains(t, texts, prof3)
+	})
+
+	t.Run("top-level tag keys and ProfileName are in sorted order", func(t *testing.T) {
+		// "ProfileName" (uppercase P=0x50) sorts before "env" (lowercase e=0x65)
+		got := completeTags(&rt, &tl, []string{}, []string{}, "", profiles)
+		texts := suggestTexts(got)
+		assert.Equal(t, []string{"ProfileName", "env"}, texts)
+	})
+
+	t.Run("ProfileName description follows roles/choices pattern", func(t *testing.T) {
+		got := completeTags(&rt, &tl, []string{}, []string{}, "", profiles)
+		for _, s := range got {
+			if s.Text == "ProfileName" {
+				assert.Equal(t, "3 roles/3 choices", s.Description)
+				return
+			}
+		}
+		t.Fatal("ProfileName suggestion not found")
+	})
+
+	t.Run("ProfileName key absent after tag selection", func(t *testing.T) {
+		// Once a tag has been selected, ProfileName is no longer a top-level option.
+		got := completeTags(&rt, &tl, []string{}, []string{"env", "dev", ""}, "", profiles)
+		texts := suggestTexts(got)
+		assert.NotContains(t, texts, "ProfileName")
+	})
+
+	t.Run("nextKey ProfileName shows all profile names with ARN descriptions", func(t *testing.T) {
+		// user typed "ProfileName " → nextKey="ProfileName", nextValue=""
+		got := completeTags(&rt, &tl, []string{}, []string{"ProfileName", ""}, "", profiles)
+		texts := suggestTexts(got)
+		assert.Contains(t, texts, prof1)
+		assert.Contains(t, texts, prof2)
+		assert.Contains(t, texts, prof3)
+		for _, s := range got {
+			assert.Equal(t, profiles[s.Text], s.Description)
+		}
+	})
+
+	t.Run("profile suggestions are returned in sorted order", func(t *testing.T) {
+		got := completeTags(&rt, &tl, []string{}, []string{"ProfileName", ""}, "", profiles)
+		texts := suggestTexts(got)
+		assert.Equal(t, []string{prof1, prof2, prof3}, texts)
+	})
+
+	t.Run("nextKey ProfileName with partial value filters profile names", func(t *testing.T) {
+		// user typed "ProfileName 222" → nextKey="ProfileName", nextValue="222"
+		got := completeTags(&rt, &tl, []string{}, []string{"ProfileName", "222"}, "", profiles)
+		texts := suggestTexts(got)
+		assert.Contains(t, texts, prof2)
+		assert.NotContains(t, texts, prof1)
+		assert.NotContains(t, texts, prof3)
+	})
+
+	t.Run("nextKey ProfileName shows all profiles when only one prior pair exists", func(t *testing.T) {
+		// argsToMap drops the completed "env dev" pair when nextKey is present (existing
+		// behavior for odd-length cleanArgs), so all profiles are shown unfiltered.
+		got := completeTags(&rt, &tl, []string{}, []string{"env", "dev", "ProfileName", ""}, "", profiles)
+		texts := suggestTexts(got)
+		assert.Contains(t, texts, prof1)
+		assert.Contains(t, texts, prof2)
+		assert.Contains(t, texts, prof3)
+	})
+
+	t.Run("completed ProfileName selection returns empty", func(t *testing.T) {
+		// user selected "ProfileName 111111111111:Admin " (complete) → empty, executor fires
+		got := completeTags(&rt, &tl, []string{}, []string{"ProfileName", prof1, ""}, "", profiles)
+		assert.Empty(t, got)
+	})
+
+	t.Run("filtered to single role by tags returns empty", func(t *testing.T) {
+		// "env prod " = env:prod selected, only Admin matches → early return
+		got := completeTags(&rt, &tl, []string{}, []string{"env", "prod", ""}, "", profiles)
+		assert.Empty(t, got)
+	})
+}
+
+func TestRoleDescription(t *testing.T) {
+	const arn = "arn:aws:iam::111111111111:role/Admin"
+	rt := ssocache.RoleTags{
+		arn: {"env": "prod", "AccountAlias": "prod-account"},
+	}
+
+	tests := []struct {
+		name               string
+		args               []string
+		accountPrimaryTags []string
+		want               string
+	}{
+		{
+			name:               "no args returns first primary tag value",
+			args:               []string{},
+			accountPrimaryTags: []string{"env"},
+			want:               "env:prod",
+		},
+		{
+			name:               "tag already in args is skipped",
+			args:               []string{"env", "prod", ""},
+			accountPrimaryTags: []string{"env", "AccountAlias"},
+			want:               "AccountAlias:prod-account",
+		},
+		{
+			name:               "all primary tags selected returns empty string",
+			args:               []string{"env", "prod", ""},
+			accountPrimaryTags: []string{"env"},
+			want:               "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := roleDescription(arn, tt.args, tt.accountPrimaryTags, &rt)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,6 +22,14 @@ You can then iterate in this manner to narrow the results via key/value pairs un
 make a selection that narrows down the results to a single IAM Role and the interactive selection
 interface disappears.  At this point the `<enter>` key will execute the command.
 
+Alternatively, you can select `ProfileName` from the top-level list to navigate directly to a
+role by its [profile name](config.md#profileformat) rather than filtering through tags.
+
+**Note:** Profile names containing spaces are not supported in the interactive prompt. The prompt
+uses spaces as delimiters between key/value tokens, so a profile name with a space cannot be
+entered or selected. Ensure your `ProfileFormat` and any manually configured `Profile:` values do
+not contain spaces if you intend to use interactive mode.
+
 ## Commands
 
 ### cache

--- a/docs/config.md
+++ b/docs/config.md
@@ -501,6 +501,11 @@ functions, but a few custom functions are available:
 single-quote (`'`) the value because because `ProfileFormat` values often start
 with a `{`.
 
+**Note:** Profile names that contain spaces cannot be used in the interactive role selection
+prompt (`exec`/`console` without explicit flags). The interactive prompt is space-delimited, so
+a profile name with spaces will not be selectable interactively. This applies both to
+`ProfileFormat` templates that produce spaces and to manually configured `Profile:` values.
+
 For more information, [see the FAQ](FAQ.md#profiles-and-tags).
 
 #### ConfigVariables


### PR DESCRIPTION
You can now choose `Profile` from the interactive mode (exec, console) and directly search for the profile if you'd like.

Refs: #800