### PR TITLE
Split fish auto-complete file into multiple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 
 ### Bugs
 
+* Fix `aws-sso-profile` and `aws-sso-clear` fish functions not available on shell
+  start — split fish completions into separate files under `functions/` and
+  `completions/` so fish autoloads them correctly #1414
 * Fix `aws-sso process` exiting non-zero on success, breaking its use as an AWS
   credential_process (regression from the SIGINT handling in #1379)
 * Fix AWS European Sovereign Cloud (EUSC) login: derive the OIDC `/authorize`

--- a/internal/helper/fish/aws-sso-clear.fish
+++ b/internal/helper/fish/aws-sso-clear.fish
@@ -1,0 +1,9 @@
+function aws-sso-clear
+  set --local _args (string split -- ' ' $AWS_SSO_HELPER_ARGS)
+  set -q AWS_SSO_HELPER_ARGS; or set --local _args -L error
+  if [ -z "$AWS_SSO_PROFILE" ]
+      echo "AWS_SSO_PROFILE is not set"
+      return 1
+  end
+  eval "$({{ .Executable }} $_args eval -c | string replace "unset" "set --erase" )"
+end

--- a/internal/helper/fish/aws-sso-profile-comp.fish
+++ b/internal/helper/fish/aws-sso-profile-comp.fish
@@ -1,0 +1,11 @@
+function __aws_sso_profile_complete
+  set --local _args (string split -- ' ' $AWS_SSO_HELPER_ARGS)
+  set -q AWS_SSO_HELPER_ARGS; or set --local _args -L error
+  set -l cur (commandline -t)
+
+  set -l cmd "{{ .Executable }} list $_args --csv -P Profile=$cur Profile"
+  for completion in (eval $cmd)
+    printf "%s\n" $completion
+  end
+end
+complete -f -c aws-sso-profile -f -a '(__aws_sso_profile_complete)'

--- a/internal/helper/fish/aws-sso-profile.fish
+++ b/internal/helper/fish/aws-sso-profile.fish
@@ -1,19 +1,10 @@
-function __complete_aws-sso
-    set -lx COMP_LINE (commandline -cp)
-    test -z (commandline -ct)
-    and set COMP_LINE "$COMP_LINE "
-    export __NO_ESCAPE_COLONS=1
-    {{ .Executable }}
-end
-complete -f -c aws-sso -a "(__complete_aws-sso)"
-
 function aws-sso-profile
   set --local _args (string split -- ' ' $AWS_SSO_HELPER_ARGS)
   set -q AWS_SSO_HELPER_ARGS; or set --local _args -L error
   set --local _sso ""
   set --local _profile ""
   set --local _remaining_args
-  
+
   if [ -n "$AWS_PROFILE" ]
       echo "Unable to assume a role while AWS_PROFILE is set"
       return 1
@@ -56,30 +47,8 @@ function aws-sso-profile
   else
       eval $({{ .Executable }} $_args eval -p $_profile)
   end
-  
+
   if [ "$AWS_SSO_PROFILE" != "$_profile" ]
       return 1
   end
-end
-
-function __aws_sso_profile_complete
-  set --local _args (string split -- ' ' $AWS_SSO_HELPER_ARGS)
-  set -q AWS_SSO_HELPER_ARGS; or set --local _args -L error
-  set -l cur (commandline -t)
-
-  set -l cmd "{{ .Executable }} list $_args --csv -P Profile=$cur Profile"
-  for completion in (eval $cmd)
-    printf "%s\n" $completion
-  end
-end
-complete -f -c aws-sso-profile -f -a '(__aws_sso_profile_complete)'
-
-function aws-sso-clear
-  set --local _args (string split -- ' ' $AWS_SSO_HELPER_ARGS)
-  set -q AWS_SSO_HELPER_ARGS; or set --local _args -L error
-  if [ -z "$AWS_SSO_PROFILE" ]
-      echo "AWS_SSO_PROFILE is not set"
-      return 1
-  end
-  eval "$({{ .Executable }} $_args eval -c | string replace "unset" "set --erase" )"
 end

--- a/internal/helper/fish/aws-sso.fish
+++ b/internal/helper/fish/aws-sso.fish
@@ -1,0 +1,8 @@
+function __complete_aws-sso
+    set -lx COMP_LINE (commandline -cp)
+    test -z (commandline -ct)
+    and set COMP_LINE "$COMP_LINE "
+    export __NO_ESCAPE_COLONS=1
+    {{ .Executable }}
+end
+complete -f -c aws-sso -a "(__complete_aws-sso)"

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -38,7 +38,7 @@ func init() {
 	log = logger.GetLogger()
 }
 
-//go:embed bash_profile.sh zshrc.sh aws-sso.fish
+//go:embed bash_profile.sh zshrc.sh fish
 var embedFiles embed.FS
 
 type fileMap struct {
@@ -46,7 +46,7 @@ type fileMap struct {
 	Path string
 }
 
-// map of shells to their file we edit by default
+// map of single-file shells to their config file
 var SHELL_SCRIPTS = map[string]fileMap{
 	"bash": {
 		Key:  "bash_profile.sh",
@@ -56,10 +56,28 @@ var SHELL_SCRIPTS = map[string]fileMap{
 		Key:  "zshrc.sh",
 		Path: "~/.zshrc",
 	},
-	"fish": {
-		Key:  "aws-sso.fish",
-		Path: getFishScript(),
-	},
+}
+
+type fishFileSpec struct {
+	Key  string // embedded path, e.g. "fish/aws-sso.fish"
+	Dir  string // "completions" or "functions"
+	Name string // target filename
+}
+
+// FISH_FILES defines the four files installed for fish shell support.
+// Paths are resolved lazily at call time via getFishBase() so that
+// XDG_CONFIG_HOME overrides work correctly in tests.
+var FISH_FILES = []fishFileSpec{
+	{Key: "fish/aws-sso.fish", Dir: "completions", Name: "aws-sso.fish"},
+	{Key: "fish/aws-sso-profile.fish", Dir: "functions", Name: "aws-sso-profile.fish"},
+	{Key: "fish/aws-sso-profile-comp.fish", Dir: "completions", Name: "aws-sso-profile.fish"},
+	{Key: "fish/aws-sso-clear.fish", Dir: "functions", Name: "aws-sso-clear.fish"},
+}
+
+// shellScript holds an embedded template's contents and its resolved target path.
+type shellScript struct {
+	contents []byte
+	path     string
 }
 
 // ConfigFiles returns a list of all the config files we might edit
@@ -69,33 +87,53 @@ func ConfigFiles() []string {
 	for _, v := range SHELL_SCRIPTS {
 		ret = append(ret, fileutils.GetHomePath(v.Path))
 	}
+
+	base := getFishBase()
+	for _, f := range FISH_FILES {
+		ret = append(ret, path.Join(base, f.Dir, f.Name))
+	}
+
 	return ret
 }
 
-// getScript takes a shell and returns the contents & path to the shell script
-func getScript(shell string) ([]byte, string, error) {
+// getScripts returns all (contents, resolved-path) pairs for a shell.
+// Handles shell auto-detection when shell == "".
+func getScripts(shell string) ([]shellScript, error) {
 	var err error
-	var bytes []byte
-	var shellFile fileMap
-	var ok bool
 
 	if shell == "" {
 		if shell, err = detectShell(); err != nil {
-			return bytes, "", err
+			return nil, err
 		}
 	}
 	log.Debug("detected our shell", "shell", shell)
 
-	if shellFile, ok = SHELL_SCRIPTS[shell]; !ok {
-		return bytes, "", fmt.Errorf("unsupported shell: %s", shell)
+	if shell == "fish" {
+		base := getFishBase()
+		var result []shellScript
+		for _, f := range FISH_FILES {
+			c, err := embedFiles.ReadFile(f.Key)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, shellScript{
+				contents: c,
+				path:     path.Join(base, f.Dir, f.Name),
+			})
+		}
+		return result, nil
 	}
 
-	path := fileutils.GetHomePath(shellFile.Path)
-	bytes, err = embedFiles.ReadFile(shellFile.Key)
-	if err != nil {
-		return bytes, "", err
+	shellFile, ok := SHELL_SCRIPTS[shell]
+	if !ok {
+		return nil, fmt.Errorf("unsupported shell: %s", shell)
 	}
-	return bytes, path, nil
+
+	c, err := embedFiles.ReadFile(shellFile.Key)
+	if err != nil {
+		return nil, err
+	}
+	return []shellScript{{contents: c, path: fileutils.GetHomePath(shellFile.Path)}}, nil
 }
 
 type SourceHelper struct {
@@ -114,7 +152,7 @@ func NewSourceHelper(getExe func() (string, error), output io.Writer) *SourceHel
 
 // SourceHelper can be used to generate the completions script for immediate sourcing in the active shell
 func (h SourceHelper) Generate(shell string) error {
-	c, _, err := getScript(shell)
+	scripts, err := getScripts(shell)
 	if err != nil {
 		return err
 	}
@@ -124,40 +162,66 @@ func (h SourceHelper) Generate(shell string) error {
 		return err
 	}
 
-	return printConfig(c, execPath, h.output)
+	for _, s := range scripts {
+		if err = printConfig(s.contents, execPath, h.output); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 var forceIt bool = false // used just for testing
 
 // InstallHelper installs any helper code into our shell startup script(s)
-func InstallHelper(shell string, path string) error {
-	c, defaultPath, err := getScript(shell)
+func InstallHelper(shell string, overridePath string) error {
+	scripts, err := getScripts(shell)
 	if err != nil {
 		return err
 	}
 
-	if path == "" {
-		err = installConfigFile(defaultPath, c, forceIt)
-	} else {
-		err = installConfigFile(path, c, forceIt)
+	for i, s := range scripts {
+		target := s.path
+		if overridePath != "" && i == 0 {
+			target = overridePath
+		}
+		if err = installConfigFile(target, s.contents, forceIt); err != nil {
+			return err
+		}
 	}
-
-	return err
+	return nil
 }
 
 // UninstallHelper removes any helper code from our shell startup script(s)
-func UninstallHelper(shell string, path string) error {
-	_, defaultPath, err := getScript(shell)
+func UninstallHelper(shell string, overridePath string) error {
+	resolved := shell
+	if resolved == "" {
+		var err error
+		if resolved, err = detectShell(); err != nil {
+			return err
+		}
+	}
+
+	scripts, err := getScripts(resolved)
 	if err != nil {
 		return err
 	}
 
-	if path == "" {
-		err = uninstallConfigFile(defaultPath)
-	} else {
-		err = uninstallConfigFile(path)
+	for i, s := range scripts {
+		target := s.path
+		if overridePath != "" && i == 0 {
+			target = overridePath
+		}
+		if resolved == "fish" {
+			if err := os.Remove(target); err != nil && !os.IsNotExist(err) { // nolint:gosec
+				log.Warn("unable to remove fish config", "file", target, "error", err.Error())
+			}
+		} else {
+			if err := uninstallConfigFile(target); err != nil {
+				log.Warn("unable to remove config", "file", target, "error", err.Error())
+			}
+		}
 	}
-	return err
+	return nil
 }
 
 // printConfig writes the given template to the output
@@ -242,12 +306,21 @@ func detectShell() (string, error) {
 	return shell, nil
 }
 
-// returns the location of our fish completion script
-func getFishScript() string {
+// getFishBase returns the base fish config directory, honouring XDG_CONFIG_HOME
+func getFishBase() string {
 	base := os.Getenv("XDG_CONFIG_HOME")
 	if base == "" {
 		base = fileutils.GetHomePath("~/.config")
 	}
+	return path.Join(base, "fish")
+}
 
-	return path.Join(base, "fish", "completions", "aws-sso.fish")
+// getFishCompletionPath returns the path for a fish completion file
+func getFishCompletionPath(name string) string {
+	return path.Join(getFishBase(), "completions", name)
+}
+
+// getFishFunctionPath returns the path for a fish function file
+func getFishFunctionPath(name string) string {
+	return path.Join(getFishBase(), "functions", name)
 }

--- a/internal/helper/helper.go
+++ b/internal/helper/helper.go
@@ -145,8 +145,8 @@ type SourceHelper struct {
 // to get the current executable path and an io.Writer to write the output to
 func NewSourceHelper(getExe func() (string, error), output io.Writer) *SourceHelper {
 	return &SourceHelper{
-		getExe: os.Executable,
-		output: os.Stdout,
+		getExe: getExe,
+		output: output,
 	}
 }
 
@@ -212,9 +212,7 @@ func UninstallHelper(shell string, overridePath string) error {
 			target = overridePath
 		}
 		if resolved == "fish" {
-			if err := os.Remove(target); err != nil && !os.IsNotExist(err) { // nolint:gosec
-				log.Warn("unable to remove fish config", "file", target, "error", err.Error())
-			}
+			removeFishFile(target)
 		} else {
 			if err := uninstallConfigFile(target); err != nil {
 				log.Warn("unable to remove config", "file", target, "error", err.Error())
@@ -323,4 +321,52 @@ func getFishCompletionPath(name string) string {
 // getFishFunctionPath returns the path for a fish function file
 func getFishFunctionPath(name string) string {
 	return path.Join(getFishBase(), "functions", name)
+}
+
+// removeFishFile removes the managed block from a fish config file.
+// If the file becomes empty after removal (normal case for dedicated fish
+// function/completion files), it is deleted. Any user content outside the
+// managed block is preserved by writing back the remainder.
+func removeFishFile(filePath string) {
+	content, err := os.ReadFile(filePath) // nolint:gosec
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Warn("unable to read fish config", "file", filePath, "error", err.Error())
+		}
+		return
+	}
+
+	trimmed := removeBlock(content, fileutils.CONFIG_PREFIX, fileutils.CONFIG_SUFFIX)
+	if len(bytes.TrimSpace(trimmed)) == 0 {
+		if err := os.Remove(filePath); err != nil && !os.IsNotExist(err) { // nolint:gosec
+			log.Warn("unable to remove fish config", "file", filePath, "error", err.Error())
+		}
+		return
+	}
+
+	if err := os.WriteFile(filePath, trimmed, 0600); err != nil { // nolint:gosec
+		log.Warn("unable to update fish config", "file", filePath, "error", err.Error())
+	}
+}
+
+// removeBlock strips every line from prefix to suffix (inclusive) from content.
+func removeBlock(content []byte, prefix, suffix string) []byte {
+	lines := bytes.Split(content, []byte("\n"))
+	result := make([][]byte, 0, len(lines))
+	inBlock := false
+	for _, line := range lines {
+		s := string(bytes.TrimRight(line, "\r"))
+		if s == prefix {
+			inBlock = true
+			continue
+		}
+		if s == suffix {
+			inBlock = false
+			continue
+		}
+		if !inBlock {
+			result = append(result, line)
+		}
+	}
+	return bytes.Join(result, []byte("\n"))
 }

--- a/internal/helper/helper_test.go
+++ b/internal/helper/helper_test.go
@@ -205,3 +205,128 @@ func TestFishFilesContent(t *testing.T) {
 	assert.Contains(t, combined, "function __complete_aws-sso")
 	assert.Contains(t, combined, "function __aws_sso_profile_complete")
 }
+
+// TestFishUninstallPreservesUserContent verifies that UninstallHelper for fish
+// removes only the managed block and preserves any user content outside it.
+func TestFishUninstallPreservesUserContent(t *testing.T) {
+	forceIt = true
+	defer func() { forceIt = false }()
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	require.NoError(t, InstallHelper("fish", ""))
+
+	fishBase := getFishBase()
+	profileFile := path.Join(fishBase, "functions", "aws-sso-profile.fish")
+	clearFile := path.Join(fishBase, "functions", "aws-sso-clear.fish")
+
+	// Append user content after the managed block in one file.
+	existing, err := os.ReadFile(profileFile)
+	require.NoError(t, err)
+	userContent := "# my custom addition\nset MY_FISH_VAR hello\n"
+	err = os.WriteFile(profileFile, append(existing, []byte(userContent)...), 0600)
+	require.NoError(t, err)
+
+	require.NoError(t, UninstallHelper("fish", ""))
+
+	// File with user content must survive and contain only the user addition.
+	remaining, readErr := os.ReadFile(profileFile)
+	require.NoError(t, readErr, "file with user content should not be deleted")
+	assert.Contains(t, string(remaining), "my custom addition")
+	assert.NotContains(t, string(remaining), "function aws-sso-profile")
+
+	// File without user content must be fully removed.
+	_, statErr := os.Stat(clearFile)
+	assert.True(t, os.IsNotExist(statErr), "file without user content should be removed")
+}
+
+// TestNewSourceHelperParams verifies that NewSourceHelper actually uses the
+// getExe and output arguments it receives.
+func TestNewSourceHelperParams(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	called := false
+	getExe := func() (string, error) {
+		called = true
+		return "/custom/aws-sso", nil
+	}
+	h := NewSourceHelper(getExe, &buf)
+	require.NoError(t, h.Generate("bash"))
+	assert.True(t, called, "getExe should have been called")
+	assert.Contains(t, buf.String(), "/custom/aws-sso")
+}
+
+// TestGetScriptsAutoDetect verifies that passing "" auto-detects the shell
+// without returning an error.
+func TestGetScriptsAutoDetect(t *testing.T) {
+	t.Parallel()
+	scripts, err := getScripts("")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, scripts)
+}
+
+// TestGenerateGetExeError covers the getExe error path in Generate.
+func TestGenerateGetExeError(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	h := &SourceHelper{
+		getExe: func() (string, error) { return "", errors.New("no exe") },
+		output: &buf,
+	}
+	err := h.Generate("bash")
+	assert.Error(t, err)
+}
+
+// TestInstallHelperUnsupportedShell covers the getScripts error return in InstallHelper.
+func TestInstallHelperUnsupportedShell(t *testing.T) {
+	t.Parallel()
+	err := InstallHelper("nushell", "")
+	assert.Error(t, err)
+}
+
+// failWriter is an io.Writer that always returns an error.
+type failWriter struct{}
+
+func (failWriter) Write(_ []byte) (int, error) { return 0, errors.New("write failed") }
+
+// TestPrintConfigWriteError covers the "no data written" path in printConfig.
+func TestPrintConfigWriteError(t *testing.T) {
+	t.Parallel()
+	scripts, err := getScripts("bash")
+	require.NoError(t, err)
+	err = printConfig(scripts[0].contents, "/usr/local/bin/aws-sso", failWriter{})
+	assert.Error(t, err)
+}
+
+// TestRemoveFishFileNonExistent covers the os.ReadFile error (IsNotExist) path.
+func TestRemoveFishFileNonExistent(t *testing.T) {
+	t.Parallel()
+	// Must not panic or log a warning — silent return on NotExist.
+	removeFishFile("/nonexistent/fish/file.fish")
+}
+
+// TestRemoveBlock validates the block-stripping helper used by removeFishFile.
+func TestRemoveBlock(t *testing.T) {
+	t.Parallel()
+	const prefix = "# BEGIN_AWS_SSO_CLI"
+	const suffix = "# END_AWS_SSO_CLI"
+
+	managed := []byte(prefix + "\ncontent line\n" + suffix + "\n")
+
+	// File is only the managed block → result is empty.
+	out := removeBlock(managed, prefix, suffix)
+	assert.Empty(t, bytes.TrimSpace(out))
+
+	// User content before the block is preserved.
+	withBefore := append([]byte("user before\n"), managed...)
+	out = removeBlock(withBefore, prefix, suffix)
+	assert.Contains(t, string(out), "user before")
+	assert.NotContains(t, string(out), "content line")
+
+	// User content after the block is preserved.
+	withAfter := append(managed, []byte("user after\n")...)
+	out = removeBlock(withAfter, prefix, suffix)
+	assert.Contains(t, string(out), "user after")
+	assert.NotContains(t, string(out), "content line")
+}

--- a/internal/helper/helper_test.go
+++ b/internal/helper/helper_test.go
@@ -15,36 +15,35 @@ import (
 
 func TestSourceHelper(t *testing.T) {
 	testcases := []struct {
-		shell          string
-		expectedError  error
-		expectedOutput []byte
+		shell           string
+		expectedError   error
+		expectedOutputs [][]byte
 	}{
 		{
 			shell: "bash",
-			expectedOutput: []byte(`
+			expectedOutputs: [][]byte{[]byte(`
 complete -F __aws_sso_profile_complete aws-sso-profile
 complete -C /bin/aws-sso-cli aws-sso
-`),
+`)},
 		},
 		{
 			shell: "zsh",
-			expectedOutput: []byte(`
+			expectedOutputs: [][]byte{[]byte(`
 compdef __aws_sso_profile_complete aws-sso-profile
 complete -C /bin/aws-sso-cli aws-sso
-`),
+`)},
 		},
 		{
 			shell: "fish",
-			expectedOutput: []byte(`
-function __complete_aws-sso
-    set -lx COMP_LINE (commandline -cp)
-    test -z (commandline -ct)
-    and set COMP_LINE "$COMP_LINE "
-    export __NO_ESCAPE_COLONS=1
-    /bin/aws-sso-cli
-end
-complete -f -c aws-sso -a "(__complete_aws-sso)"
-`),
+			expectedOutputs: [][]byte{
+				[]byte(`function __complete_aws-sso`),
+				[]byte(`complete -f -c aws-sso -a "(__complete_aws-sso)"`),
+				[]byte(`function aws-sso-profile`),
+				[]byte(`function __aws_sso_profile_complete`),
+				[]byte(`complete -f -c aws-sso-profile`),
+				[]byte(`function aws-sso-clear`),
+				[]byte(`/bin/aws-sso-cli`),
+			},
 		},
 		{
 			shell:         "nushell",
@@ -53,8 +52,6 @@ complete -f -c aws-sso -a "(__complete_aws-sso)"
 	}
 
 	for _, tc := range testcases {
-		tc := tc
-
 		t.Run(tc.shell, func(t *testing.T) {
 			t.Parallel()
 			var (
@@ -69,7 +66,9 @@ complete -f -c aws-sso -a "(__complete_aws-sso)"
 
 			err := h.Generate(tc.shell)
 			require.Equal(t, tc.expectedError, err)
-			require.Contains(t, output.String(), string(bytes.TrimLeftFunc(tc.expectedOutput, unicode.IsSpace)))
+			for _, expected := range tc.expectedOutputs {
+				require.Contains(t, output.String(), string(bytes.TrimLeftFunc(expected, unicode.IsSpace)))
+			}
 		})
 	}
 }
@@ -77,7 +76,7 @@ complete -f -c aws-sso -a "(__complete_aws-sso)"
 func TestConfigFiles(t *testing.T) {
 	t.Parallel()
 	files := ConfigFiles()
-	require.Len(t, files, 3)
+	require.Len(t, files, 6)
 }
 
 func TestNewSourceHelper(t *testing.T) {
@@ -89,10 +88,10 @@ func TestNewSourceHelper(t *testing.T) {
 	assert.NotNil(t, h)
 }
 
-func TestGetFishScript(t *testing.T) {
+func TestGetFishPaths(t *testing.T) {
 	t.Parallel()
-	f := getFishScript()
-	assert.Contains(t, f, path.Join("fish", "completions", "aws-sso.fish"))
+	assert.Contains(t, getFishCompletionPath("aws-sso.fish"), path.Join("fish", "completions", "aws-sso.fish"))
+	assert.Contains(t, getFishFunctionPath("aws-sso-profile.fish"), path.Join("fish", "functions", "aws-sso-profile.fish"))
 }
 
 func TestDetectShellBash(t *testing.T) {
@@ -119,8 +118,11 @@ func TestGenerate(t *testing.T) {
 }
 func TestPrintConfig(t *testing.T) {
 	t.Parallel()
-	c, p, err := getScript("bash")
+	scripts, err := getScripts("bash")
 	assert.NoError(t, err)
+	require.Len(t, scripts, 1)
+	c := scripts[0].contents
+	p := scripts[0].path
 	assert.NotEmpty(t, c)
 	assert.NotEmpty(t, p)
 	assert.Contains(t, string(c), "{{ .Executable }}") // this is a template
@@ -155,4 +157,51 @@ func TestInstallHelper(t *testing.T) {
 
 	err = UninstallHelper("bash", tempFile.Name())
 	assert.NoError(t, err)
+}
+
+func TestInstallFish(t *testing.T) {
+	forceIt = true
+	defer func() { forceIt = false }()
+
+	tmpDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmpDir)
+
+	err := InstallHelper("fish", "")
+	require.NoError(t, err)
+
+	fishBase := getFishBase()
+	expectedFiles := []string{
+		path.Join(fishBase, "completions", "aws-sso.fish"),
+		path.Join(fishBase, "functions", "aws-sso-profile.fish"),
+		path.Join(fishBase, "completions", "aws-sso-profile.fish"),
+		path.Join(fishBase, "functions", "aws-sso-clear.fish"),
+	}
+	for _, f := range expectedFiles {
+		info, statErr := os.Stat(f)
+		require.NoError(t, statErr, "expected file to exist: %s", f)
+		assert.Greater(t, info.Size(), int64(0))
+	}
+
+	err = UninstallHelper("fish", "")
+	require.NoError(t, err)
+	for _, f := range expectedFiles {
+		_, statErr := os.Stat(f)
+		assert.True(t, os.IsNotExist(statErr), "expected file to be removed: %s", f)
+	}
+}
+
+func TestFishFilesContent(t *testing.T) {
+	t.Parallel()
+	scripts, err := getScripts("fish")
+	require.NoError(t, err)
+	require.Len(t, scripts, 4)
+
+	combined := ""
+	for _, s := range scripts {
+		combined += string(s.contents)
+	}
+	assert.Contains(t, combined, "function aws-sso-profile")
+	assert.Contains(t, combined, "function aws-sso-clear")
+	assert.Contains(t, combined, "function __complete_aws-sso")
+	assert.Contains(t, combined, "function __aws_sso_profile_complete")
 }


### PR DESCRIPTION
Makes fish properly lazy load the helpers for aws-sso-profile and aws-sso-clear

Fixes: #1414