### PR TITLE
fix: preserve final line of config files lacking a trailing newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Bugs
+
+* Preserve final line of config files lacking a trailing newline #1419
+
 ## [v2.2.5] - 2026-06-13
 
 ### Bugs

--- a/internal/fileutils/fileedit.go
+++ b/internal/fileutils/fileedit.go
@@ -165,15 +165,36 @@ func (f *FileEdit) GenerateNewFile(configFile string) ([]byte, error) {
 	}
 
 	endOfFile := false
+	needsNewline := false // true when last unmanaged line had no trailing newline
 	if err != nil && err != io.EOF {
 		return []byte{}, err
 	} else if err == io.EOF {
-		// Reached EOF before finding our CONFIG_PREFIX
+		// Reached EOF before finding our CONFIG_PREFIX.
+		// ReadString returns the final partial line together with io.EOF when the
+		// file has no trailing newline. Write it unless it is the prefix marker
+		// (with or without a trailing newline) to avoid duplicating the marker.
+		if line != "" && line != fmt.Sprintf("%s\n", f.Prefix) && line != f.Prefix {
+			if _, wErr := output.WriteString(line); wErr != nil {
+				return []byte{}, wErr
+			}
+			needsNewline = true
+		}
 		endOfFile = true
 	}
 
-	// write our template out
-	if err = f.Template.Execute(&output, f.InputVars); err != nil {
+	// Buffer the template so we can insert a newline separator when the previous
+	// unmanaged content ended without a newline (which would otherwise cause the
+	// managed block to be concatenated onto the last unmanaged line).
+	var templateBuf bytes.Buffer
+	if err = f.Template.Execute(&templateBuf, f.InputVars); err != nil {
+		return []byte{}, err
+	}
+	if needsNewline && templateBuf.Len() > 0 {
+		if _, wErr := output.WriteString("\n"); wErr != nil {
+			return []byte{}, wErr
+		}
+	}
+	if _, err = output.Write(templateBuf.Bytes()); err != nil {
 		return []byte{}, err
 	}
 
@@ -194,7 +215,13 @@ func (f *FileEdit) GenerateNewFile(configFile string) ([]byte, error) {
 				}
 				line, err = r.ReadString('\n')
 			}
-			if err != io.EOF {
+			// If the file had no trailing newline, ReadString returns the final
+			// partial line together with io.EOF, so we must write it here.
+			if err == io.EOF && line != "" {
+				if _, wErr := output.WriteString(line); wErr != nil {
+					return []byte{}, wErr
+				}
+			} else if err != io.EOF {
 				return []byte{}, err
 			}
 		}

--- a/internal/fileutils/fileedit_test.go
+++ b/internal/fileutils/fileedit_test.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"text/template"
 
@@ -205,6 +206,67 @@ func TestGenerateNewFile(t *testing.T) {
 	fe, _ := NewFileEdit(template, "", vars)
 	_, err := fe.GenerateNewFile("/this/directory/really/should/not/exist")
 	assert.Error(t, err)
+}
+
+func TestGenerateNewFileNoTrailingNewline(t *testing.T) {
+	t.Parallel()
+	var tmpl = "{{ .Test }}"
+	var vars = map[string]string{"Test": "managed"}
+
+	fe, err := NewFileEdit(tmpl, "sso", vars)
+	require.NoError(t, err)
+
+	// File with content before the managed block and no trailing newline.
+	// The last line must survive, and the managed block must start on its own line.
+	t.Run("no managed block, no trailing newline", func(t *testing.T) {
+		t.Parallel()
+		tfile, err := os.CreateTemp("", "")
+		require.NoError(t, err)
+		defer os.Remove(tfile.Name())
+
+		_, err = tfile.WriteString("line one\nline two")
+		require.NoError(t, err)
+		tfile.Close()
+
+		out, err := fe.GenerateNewFile(tfile.Name())
+		require.NoError(t, err)
+
+		s := string(out)
+		assert.Contains(t, s, "line one\n")
+		// Managed block must start on a new line, not be concatenated onto "line two"
+		prefix := fmt.Sprintf("%s_%s", CONFIG_PREFIX, "sso")
+		assert.Contains(t, s, "line two\n"+prefix)
+		assert.Contains(t, s, "managed")
+	})
+
+	// File with a managed block followed by unmanaged content with no trailing newline.
+	// The final tail line must be preserved as the last bytes, with no trailing newline added.
+	t.Run("managed block present, unmanaged tail has no trailing newline", func(t *testing.T) {
+		t.Parallel()
+		tfile, err := os.CreateTemp("", "")
+		require.NoError(t, err)
+		defer os.Remove(tfile.Name())
+
+		prefix := fmt.Sprintf("%s_%s", CONFIG_PREFIX, "sso")
+		suffix := fmt.Sprintf("%s_%s", CONFIG_SUFFIX, "sso")
+		content := fmt.Sprintf("before\n%s\nold content\n%s\nafter no newline", prefix, suffix)
+		_, err = tfile.WriteString(content)
+		require.NoError(t, err)
+		tfile.Close()
+
+		out, err := fe.GenerateNewFile(tfile.Name())
+		require.NoError(t, err)
+
+		s := string(out)
+		assert.Contains(t, s, "before\n")
+		assert.Contains(t, s, "managed")
+		assert.NotContains(t, s, "old content")
+		// Tail line must be present and the output must not gain a trailing newline
+		assert.True(t, len(out) > 0 && out[len(out)-1] != '\n',
+			"output must not end with a newline")
+		assert.True(t, strings.HasSuffix(s, "after no newline"),
+			"output must end with the unmanaged tail line")
+	})
 }
 
 func promptYes(a, b string) (bool, error) {


### PR DESCRIPTION
GenerateNewFile dropped the last line of a file when it had no trailing newline, because bufio.Reader.ReadString returns a partial line with io.EOF together, and both copy loops exited before writing it.

Fixes #1419