### PR TITLE
Don't include 1Password support on Linux w/o CGO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 ## [Unreleased]
 
+## [v2.3.1] -- 2026-06-20
+
+### Bugs
+
+* Remove 1Password support from Linux release binaries due to CGO requirement
+
 ## [v2.3.0] -- 2026-06-19
 
 ### New Features
@@ -944,7 +950,8 @@
 Initial release
 
 <!-- markdownlint-disable-next-line MD053 -->
-[Unreleased]: https://github.com/synfinatic/aws-sso-cli/compare/v2.3.0...main
+[Unreleased]: https://github.com/synfinatic/aws-sso-cli/compare/v2.3.1...main
+[v2.3.1]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v2.3.1
 [v2.3.0]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v2.3.0
 [v2.2.5]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v2.2.5
 [v2.2.4]: https://github.com/synfinatic/aws-sso-cli/releases/tag/v2.2.4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROJECT_VERSION        := 2.3.0
+PROJECT_VERSION        := 2.3.1
 DOCKER_REPO            := synfinatic
 PROJECT_NAME           := aws-sso
 DOCKER_PROJECT_NAME    := aws-sso-cli-ecs-server
@@ -18,6 +18,8 @@ PROJECT_DELTA             := $(shell DELTA_LINES=$$(git diff | wc -l); if [ $${D
 
 BUILDINFOSDET ?=
 PROGRAM_ARGS ?=
+# Set to 1 to enable CGO (required for 1Password support on Linux; produces glibc-linked binary)
+CGO_ENABLED ?= 0
 ifeq ($(PROJECT_TAG),)
 PROJECT_TAG               := NO-TAG
 endif
@@ -240,13 +242,13 @@ $(WINDOWS32_BIN): .build_files
 linux: $(LINUX_BIN)  ## Build Linux/x86_64 binary
 
 $(LINUX_BIN): .build_files
-	CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build $(GOBFLAGS) -ldflags='$(LDFLAGS)' -o $(LINUX_BIN) ./cmd/aws-sso/...
+	CGO_ENABLED=$(CGO_ENABLED) GOARCH=amd64 GOOS=linux go build $(GOBFLAGS) -ldflags='$(LDFLAGS)' -o $(LINUX_BIN) ./cmd/aws-sso/...
 	@echo "Created: $(LINUX_BIN)"
 
 linux-arm64: $(LINUXARM64_BIN)  ## Build Linux/arm64 binary
 
 $(LINUXARM64_BIN): .build_files
-	CGO_ENABLED=0 GOARCH=arm64 GOOS=linux go build $(GOBFLAGS) -ldflags='$(LDFLAGS)' -o $(LINUXARM64_BIN) ./cmd/aws-sso/...
+	CGO_ENABLED=$(CGO_ENABLED) GOARCH=arm64 GOOS=linux go build $(GOBFLAGS) -ldflags='$(LDFLAGS)' -o $(LINUXARM64_BIN) ./cmd/aws-sso/...
 	@echo "Created: $(LINUXARM64_BIN)"
 
 # macOS needs different build flags if you are cross-compiling because of the key chain

--- a/docs/config.md
+++ b/docs/config.md
@@ -725,6 +725,19 @@ app to be installed with **Settings → Developer → Integrate with other apps*
 desktop app required. Create a service account at 1password.com/developer-tools and export
 the token as `AWS_SSO_OP_SERVICE_ACCOUNT_TOKEN`. `Account` is not used.
 
+**Linux users:** The official pre-built Linux binaries are compiled with `CGO_ENABLED=0` for
+maximum portability across distributions. The `1password` SecureStore backend requires CGO and
+is **not available** in those binaries. To use 1Password on Linux you must build from source
+with CGO enabled:
+
+```bash
+make linux CGO_ENABLED=1
+```
+
+Note that a CGO-enabled binary dynamically links against glibc and may not run on all
+distributions (e.g. Alpine Linux uses musl). For arm64 you will also need a cross-compiler
+(`gcc-aarch64-linux-gnu`) installed.
+
 See the [1Password authentication guide](https://www.1password.dev/sdks#step-1-decide-how-you-want-to-authenticate)
 to help choose the right `AuthType` for your use case.
 

--- a/internal/storage/onepassword.go
+++ b/internal/storage/onepassword.go
@@ -1,3 +1,5 @@
+//go:build cgo || windows
+
 package storage
 
 /*
@@ -26,14 +28,6 @@ import (
 	"strings"
 
 	onepassword "github.com/1password/onepassword-sdk-go"
-)
-
-const (
-	OP_ITEM_TITLE   = "aws-sso-cli"
-	OP_FIELD_ID     = "data"
-	OP_AUTH_SERVICE = "service-account"
-	OP_AUTH_DESKTOP = "desktop"
-	ENV_OP_TOKEN    = "AWS_SSO_OP_SERVICE_ACCOUNT_TOKEN" // #nosec
 )
 
 // onePasswordItemsAPI is a subset of onepassword.ItemsAPI for testability.

--- a/internal/storage/onepassword_constants.go
+++ b/internal/storage/onepassword_constants.go
@@ -1,0 +1,27 @@
+package storage
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2026 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const (
+	OP_ITEM_TITLE   = "aws-sso-cli"
+	OP_FIELD_ID     = "data"
+	OP_AUTH_SERVICE = "service-account"
+	OP_AUTH_DESKTOP = "desktop"
+	ENV_OP_TOKEN    = "AWS_SSO_OP_SERVICE_ACCOUNT_TOKEN" // #nosec
+)

--- a/internal/storage/onepassword_nocgo.go
+++ b/internal/storage/onepassword_nocgo.go
@@ -1,0 +1,33 @@
+//go:build !cgo && !windows
+
+package storage
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2026 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"context"
+	"fmt"
+)
+
+// OpenOnePasswordStore is not supported in CGO-disabled builds because the
+// 1Password SDK requires CGO on Linux and Darwin.
+func OpenOnePasswordStore(_ context.Context, _, _, _ string) (SecureStorage, error) {
+	return nil, fmt.Errorf("1Password SecureStore is not available in this binary (built without CGO); " +
+		"rebuild from source with 'make linux CGO_ENABLED=1'")
+}

--- a/internal/storage/onepassword_nocgo_test.go
+++ b/internal/storage/onepassword_nocgo_test.go
@@ -1,0 +1,34 @@
+//go:build !cgo && !windows
+
+package storage
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2026 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenOnePasswordStoreNoCGO(t *testing.T) {
+	_, err := OpenOnePasswordStore(context.Background(), "desktop", "myvault", "me@example.com")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "CGO")
+}

--- a/internal/storage/onepassword_test.go
+++ b/internal/storage/onepassword_test.go
@@ -1,3 +1,5 @@
+//go:build cgo || windows
+
 package storage
 
 /*


### PR DESCRIPTION
- Linux 1Password support requires CGO
- We don't enable CGO for release binaries
- Document how to enable 1Password on Linux for users who wish to build themselves