### PR TITLE
Fix docs/website to use correct command option

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -85,7 +85,7 @@ source_profile = NameOfAwsSsoCliProfile
 ```
 
 And generate the necessary AWS SSO CLI profile entries via
-[aws-sso config-profiles](commands.md#config-profiles) command.
+[aws-sso setup profiles](commands.md#setup-profiles) command.
 
 ### How does AWS SSO CLI manage the $AWS\_DEFAULT\_REGION / $AWS\_REGION?
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -461,8 +461,8 @@ https://docs.aws.amazon.com/singlesignon/latest/userguide/howtosessionduration.h
 
 #### ConfigProfilesBinaryPath
 
-Override execution path for `aws-sso` when generating named AWS profiles via the
-[config-profiles](commands.md#config-profiles).
+Override execution path for `aws-sso` when generating named AWS profiles via
+[aws-sso setup profiles](commands.md#setup-profiles).
 
 #### ProfileFormat
 


### PR DESCRIPTION
`aws-sso config-profiles` is no longer supported, and I think it's confusing AIs that think this is still an option.

(it looks like there is a CHANGELOG that mentions deprecated commands, but it's not published on the website; that might help users and AIs pick up the changes over different versions)

**NOTE:** docs/demos.md also has an asciicast under section _Using the `config-profiles` command and `$AWS_PROFILE`_ which uses the deprecated command; I recommend you re-record that section to update that doc with the new command