### PR TITLE
Fix PKCE login connection-refused race by pre-binding the loopback callback listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 
 ## [Unreleased]
 
+### Bugs
+
+* Fix PKCE login intermittently failing with `ERR_CONNECTION_REFUSED` when the
+  browser redirects before the loopback callback server binds. The callback
+  listener is now bound before the browser opens and reused for the redirect, so
+  the kernel queues an instant redirect from a warm SSO session instead of
+  refusing the connection. #1441
+
 ## [v2.3.1] -- 2026-06-20
 
 ### Bugs

--- a/internal/awsmock/pkce_client.go
+++ b/internal/awsmock/pkce_client.go
@@ -31,13 +31,15 @@ import (
 
 // PKCECallbackClient wraps an oidc.Client and overrides StartPKCEAuthCodeFlow to
 // automatically deliver the browser redirect callback, enabling headless PKCE tests.
+// WaitForPKCECallback is the embedded client's real implementation, which owns and
+// closes the caller-supplied listener.
 type PKCECallbackClient struct {
 	oidc.Client
 	authCode string
 }
 
 // NewPKCECallbackClient wraps client so that StartPKCEAuthCodeFlow spawns a goroutine
-// that delivers the PKCE callback to the loopback listener after a short delay.
+// that delivers the PKCE callback to the loopback listener.
 func NewPKCECallbackClient(client oidc.Client, authCode string) *PKCECallbackClient {
 	return &PKCECallbackClient{Client: client, authCode: authCode}
 }
@@ -56,23 +58,20 @@ func (c *PKCECallbackClient) StartPKCEAuthCodeFlow(ctx context.Context, in oidc.
 
 	go func() {
 		callbackURL := fmt.Sprintf("%s?code=%s&state=%s", redirectURI, authCode, state)
-		httpClient := &http.Client{Timeout: 2 * time.Second}
-		// The callback listener is bound before StartPKCEAuthCodeFlow is called, so
-		// the kernel queues this request even before Serve() starts. Retry anyway
-		// as cheap insurance against transient scheduling delays.
-		for range 20 {
-			time.Sleep(25 * time.Millisecond)
-			req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodGet, callbackURL, nil) //nolint:gosec
-			if reqErr != nil {
-				return
-			}
-			resp, doErr := httpClient.Do(req)
-			if doErr != nil {
-				continue
-			}
-			_ = resp.Body.Close()
+		// Single immediate request, no retries: the callback listener is bound
+		// before StartPKCEAuthCodeFlow is called, so the kernel queues this
+		// connection until the server starts serving. If the pre-bind ever
+		// regresses, this request fails and the test times out.
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, callbackURL, nil) //nolint:gosec
+		if err != nil {
 			return
 		}
+		httpClient := &http.Client{Timeout: 2 * time.Second}
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return
+		}
+		_ = resp.Body.Close()
 	}()
 
 	return flow, nil

--- a/internal/awsmock/pkce_client.go
+++ b/internal/awsmock/pkce_client.go
@@ -57,8 +57,9 @@ func (c *PKCECallbackClient) StartPKCEAuthCodeFlow(ctx context.Context, in oidc.
 	go func() {
 		callbackURL := fmt.Sprintf("%s?code=%s&state=%s", redirectURI, authCode, state)
 		httpClient := &http.Client{Timeout: 2 * time.Second}
-		// Retry until the loopback listener is ready (WaitForPKCECallback binds it just
-		// after StartPKCEAuthCodeFlow returns, so the first few attempts may fail on load).
+		// The callback listener is bound before StartPKCEAuthCodeFlow is called, so
+		// the kernel queues this request even before Serve() starts. Retry anyway
+		// as cheap insurance against transient scheduling delays.
 		for range 20 {
 			time.Sleep(25 * time.Millisecond)
 			req, reqErr := http.NewRequestWithContext(context.Background(), http.MethodGet, callbackURL, nil) //nolint:gosec

--- a/internal/sso/auth/awssso_auth.go
+++ b/internal/sso/auth/awssso_auth.go
@@ -391,15 +391,26 @@ func (as *AWSSSO) reauthenticateDeviceCode(ctx context.Context) error {
 }
 
 func (as *AWSSSO) reauthenticatePKCE(ctx context.Context) error {
-	// Find a free loopback port for the callback listener. RFC 8252 §7.3 recommends
-	// any available port rather than a fixed one to avoid bind conflicts.
+	// Bind the loopback callback listener up front. RFC 8252 §7.3 recommends any
+	// available port rather than a fixed one to avoid bind conflicts. Keeping the
+	// socket bound before the browser opens lets the kernel queue the redirect if
+	// it arrives before the callback server starts serving, avoiding a
+	// connection-refused race with warm SSO sessions that redirect instantly.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return fmt.Errorf("find free port for pkce callback: %w", err)
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
-	_ = ln.Close()
 	redirectURI := fmt.Sprintf("http://127.0.0.1:%d", port)
+
+	// WaitForPKCECallback takes ownership of the listener and closes it. Close it
+	// here only if we return before handing it off.
+	listenerHandedOff := false
+	defer func() {
+		if !listenerHandedOff {
+			_ = ln.Close()
+		}
+	}()
 
 	authEndpoint, err := as.pkceAuthorizationEndpoint()
 	if err != nil {
@@ -426,9 +437,11 @@ func (as *AWSSSO) reauthenticatePKCE(ctx context.Context) error {
 	pkceCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
+	listenerHandedOff = true
 	callback, err := as.oidcClient.WaitForPKCECallback(pkceCtx, oidc.WaitForPKCECallbackInput{
 		RedirectURI:   redirectURI,
 		ExpectedState: flow.State,
+		Listener:      ln,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to receive pkce callback: %w", err)

--- a/internal/sso/auth/awssso_auth_test.go
+++ b/internal/sso/auth/awssso_auth_test.go
@@ -21,6 +21,8 @@ package auth
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -823,6 +825,7 @@ type mockOIDCClient struct {
 	// captured inputs for assertions
 	startPKCEFlowInputs   []oidc.StartPKCEAuthCodeInput
 	waitForCallbackInputs []oidc.WaitForPKCECallbackInput
+	listenerDialErr       error
 	exchangePKCEInputs    []oidc.ExchangePKCEAuthCodeInput
 	exchangeRefreshInputs []oidc.ExchangeRefreshTokenInput
 	registerClientInputs  []oidc.RegisterClientInput
@@ -848,8 +851,14 @@ func (m *mockOIDCClient) StartPKCEAuthCodeFlow(_ context.Context, in oidc.StartP
 
 func (m *mockOIDCClient) WaitForPKCECallback(_ context.Context, in oidc.WaitForPKCECallbackInput) (oidc.PKCECallback, error) {
 	m.waitForCallbackInputs = append(m.waitForCallbackInputs, in)
-	// Match the real client's contract: take ownership of a supplied listener.
 	if in.Listener != nil {
+		// Prove the handed-off listener is accepting connections, then close it
+		// as the real implementation would.
+		conn, err := net.Dial("tcp", in.Listener.Addr().String())
+		m.listenerDialErr = err
+		if err == nil {
+			_ = conn.Close()
+		}
 		_ = in.Listener.Close()
 	}
 	return m.waitForCallbackResult, m.waitForCallbackErr
@@ -1042,9 +1051,16 @@ func TestReauthenticatePKCE(t *testing.T) {
 			assert.Equal(t, "test-verifier", in.CodeVerifier)
 		}
 
-		// verify state was forwarded to WaitForPKCECallback
+		// verify state and a pre-bound listener were forwarded to WaitForPKCECallback
 		if assert.Len(t, mock.waitForCallbackInputs, 1) {
-			assert.Equal(t, "test-state", mock.waitForCallbackInputs[0].ExpectedState)
+			in := mock.waitForCallbackInputs[0]
+			assert.Equal(t, "test-state", in.ExpectedState)
+			if assert.NotNil(t, in.Listener) {
+				u, err := url.Parse(in.RedirectURI)
+				assert.NoError(t, err)
+				assert.Equal(t, u.Host, in.Listener.Addr().String())
+			}
+			assert.NoError(t, mock.listenerDialErr)
 		}
 	})
 

--- a/internal/sso/auth/awssso_auth_test.go
+++ b/internal/sso/auth/awssso_auth_test.go
@@ -848,6 +848,10 @@ func (m *mockOIDCClient) StartPKCEAuthCodeFlow(_ context.Context, in oidc.StartP
 
 func (m *mockOIDCClient) WaitForPKCECallback(_ context.Context, in oidc.WaitForPKCECallbackInput) (oidc.PKCECallback, error) {
 	m.waitForCallbackInputs = append(m.waitForCallbackInputs, in)
+	// Match the real client's contract: take ownership of a supplied listener.
+	if in.Listener != nil {
+		_ = in.Listener.Close()
+	}
 	return m.waitForCallbackResult, m.waitForCallbackErr
 }
 

--- a/internal/sso/oidc/pkce.go
+++ b/internal/sso/oidc/pkce.go
@@ -101,6 +101,13 @@ func (c *AWSClient) ExchangePKCEAuthCode(ctx context.Context, in ExchangePKCEAut
 }
 
 func (c *AWSClient) WaitForPKCECallback(ctx context.Context, in WaitForPKCECallbackInput) (PKCECallback, error) {
+	// Take ownership of a caller-supplied listener immediately so it is closed
+	// on every return path, including validation errors below.
+	listener := in.Listener
+	if listener != nil {
+		defer listener.Close()
+	}
+
 	if in.RedirectURI == "" {
 		return PKCECallback{}, fmt.Errorf("redirect uri is required")
 	}
@@ -121,11 +128,17 @@ func (c *AWSClient) WaitForPKCECallback(ctx context.Context, in WaitForPKCECallb
 		path = "/"
 	}
 
-	listener, err := net.Listen("tcp", redirectURL.Host)
-	if err != nil {
-		return PKCECallback{}, fmt.Errorf("listen for pkce callback: %w", err)
+	// Prefer a listener supplied by the caller. Binding the loopback socket
+	// before the browser opens lets the kernel accept and queue the redirect
+	// even if it arrives before Serve() starts, avoiding a connection-refused
+	// race with warm SSO sessions that redirect instantly.
+	if listener == nil {
+		listener, err = net.Listen("tcp", redirectURL.Host)
+		if err != nil {
+			return PKCECallback{}, fmt.Errorf("listen for pkce callback: %w", err)
+		}
+		defer listener.Close()
 	}
-	defer listener.Close()
 
 	callbackCh := make(chan PKCECallback, 1)
 	errCh := make(chan error, 1)

--- a/internal/sso/oidc/pkce_test.go
+++ b/internal/sso/oidc/pkce_test.go
@@ -349,6 +349,34 @@ func TestWaitForPKCECallback(t *testing.T) {
 			t.Fatalf("timed out waiting for PKCE callback: %v", ctx.Err())
 		}
 	})
+
+	t.Run("closes supplied listener on invalid input", func(t *testing.T) {
+		client := NewAWSWithAPI(&mockOIDCAPI{})
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		assert.NoError(t, err)
+
+		_, err = client.WaitForPKCECallback(context.Background(), WaitForPKCECallbackInput{
+			RedirectURI: fmt.Sprintf("http://%s/", ln.Addr().String()),
+			Listener:    ln,
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "expected state is required")
+		assert.ErrorIs(t, ln.Close(), net.ErrClosed)
+	})
+
+	t.Run("errors when fallback bind fails", func(t *testing.T) {
+		client := NewAWSWithAPI(&mockOIDCAPI{})
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		assert.NoError(t, err)
+		defer ln.Close()
+
+		_, err = client.WaitForPKCECallback(context.Background(), WaitForPKCECallbackInput{
+			RedirectURI:   fmt.Sprintf("http://%s/", ln.Addr().String()),
+			ExpectedState: "state",
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "listen for pkce callback")
+	})
 }
 
 func TestValidatePKCEState(t *testing.T) {

--- a/internal/sso/oidc/pkce_test.go
+++ b/internal/sso/oidc/pkce_test.go
@@ -300,6 +300,55 @@ func TestWaitForPKCECallback(t *testing.T) {
 			t.Fatal("timed out waiting for context cancellation")
 		}
 	})
+
+	t.Run("uses caller supplied listener", func(t *testing.T) {
+		client := NewAWSWithAPI(&mockOIDCAPI{})
+		// Bind the callback listener up front and keep it open, as
+		// reauthenticatePKCE does to avoid the connection-refused race. The old
+		// close-then-rebind behavior would fail here with "address already in use"
+		// because the port is still held by this listener.
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		assert.NoError(t, err)
+		redirectURI := fmt.Sprintf("http://%s/", ln.Addr().String())
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		resultCh := make(chan PKCECallback, 1)
+		errCh := make(chan error, 1)
+		go func() {
+			callback, err := client.WaitForPKCECallback(ctx, WaitForPKCECallbackInput{
+				RedirectURI:   redirectURI,
+				ExpectedState: "pre-bound-state",
+				Listener:      ln,
+			})
+			if err != nil {
+				errCh <- err
+				return
+			}
+			resultCh <- callback
+		}()
+
+		waitForPKCEListener(t, redirectURI)
+
+		// Bounded client so a regression (rebinding the held port) fails fast
+		// instead of blocking on a socket whose server never starts.
+		httpClient := &http.Client{Timeout: 3 * time.Second}
+		resp, err := httpClient.Get(fmt.Sprintf("%s?code=pre-bound-code&state=pre-bound-state", redirectURI)) //nolint:noctx
+		assert.NoError(t, err)
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+
+		select {
+		case callback := <-resultCh:
+			assert.Equal(t, "pre-bound-code", callback.Code)
+		case err := <-errCh:
+			assert.NoError(t, err)
+		case <-ctx.Done():
+			t.Fatalf("timed out waiting for PKCE callback: %v", ctx.Err())
+		}
+	})
 }
 
 func TestValidatePKCEState(t *testing.T) {

--- a/internal/sso/oidc/types.go
+++ b/internal/sso/oidc/types.go
@@ -3,6 +3,7 @@ package oidc
 import (
 	"context"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/ssooidc"
@@ -119,6 +120,12 @@ type PKCEAuthCodeFlow struct {
 type WaitForPKCECallbackInput struct {
 	RedirectURI   string
 	ExpectedState string
+	// Listener, when non-nil, is used for the callback server instead of
+	// binding a new one. Supplying a listener that was bound before the browser
+	// was opened avoids a connection-refused race when the SSO redirect arrives
+	// before the callback server would otherwise bind its socket.
+	// WaitForPKCECallback takes ownership and closes it on all return paths.
+	Listener net.Listener
 }
 
 type PKCECallback struct {


### PR DESCRIPTION
Fixes #1441

`aws-sso login` with the `pkce` workflow reserves a loopback port, closes it, opens the browser, and only binds the callback server after the URL opener returns. If the Identity Center session is already authenticated, the redirect to `http://127.0.0.1:<port>` arrives during that gap and the browser gets `ERR_CONNECTION_REFUSED`. The reproduction and timing details are in the issue.

This change binds the listener once in `reauthenticatePKCE`, before the browser opens, and hands it to `WaitForPKCECallback` through a new optional `Listener` field on `WaitForPKCECallbackInput`. With the socket already bound, the kernel completes the handshake for an instant redirect and queues it until `Serve()` starts accepting. When the field is nil, `WaitForPKCECallback` binds the address itself exactly as before, so existing callers and tests are unaffected.

Ownership is explicit: `WaitForPKCECallback` takes ownership of a supplied listener and closes it on every return path, including validation errors. `reauthenticatePKCE` closes it only when it returns before the handoff. This also removes the small window where another local process could grab the freed port between the reservation and the re-bind.

Testing:

- New regression subtest `TestWaitForPKCECallback/uses caller supplied listener` drives the callback through a pre-bound listener. Reverting to close-then-rebind makes it fail with "address already in use" rather than hang, since the HTTP client is bounded.
- The e2e mock keeps its retry loop; only its comment changed, because the listener is now bound before `StartPKCEAuthCodeFlow` is called.
- `go build ./...`, `go vet`, and `go test ./internal/sso/oidc/... ./internal/sso/auth/...` all pass.
