### PR TITLE
Add `aws-sso login --force` to start a new SSO session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### Bugs
+
+* Remove `--no-config-check` and `--sts-refresh` from the documented `login` flags #1451
+
 ## [v2.3.2] -- 2026-07-29
 
 ### Bugs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 
 ## [Unreleased]
 
+### New Features
+
+* Add `aws-sso login --force` to start a new SSO session, resetting its duration #1455
+
 ### Bugs
 
 * Remove `--no-config-check` and `--sts-refresh` from the documented `login` flags #1451

--- a/cmd/aws-sso/helpers_e2e_test.go
+++ b/cmd/aws-sso/helpers_e2e_test.go
@@ -245,6 +245,34 @@ func preAuth(t *testing.T, setup *e2eSetup) {
 	require.NoError(t, err)
 }
 
+// preAuthExpired is like preAuth, but seeds an expired access token carrying
+// refreshToken so ValidAuthToken() attempts a silent refresh.
+func preAuthExpired(t *testing.T, setup *e2eSetup, refreshToken string) {
+	t.Helper()
+	ctx := context.Background()
+	key := AwsSSO.StoreKey()
+
+	err := setup.Store.SaveRegisterClientData(ctx, key, storage.RegisterClientData{
+		ClientId:              "test-client-id",
+		ClientSecret:          "test-client-secret",
+		ClientIdIssuedAt:      time.Now().Unix(),
+		ClientSecretExpiresAt: time.Now().Add(90 * 24 * time.Hour).Unix(),
+		GrantTypes: []storage.GrantType{
+			storage.GrantTypeDeviceCode,
+			storage.GrantTypeRefreshToken,
+		},
+	})
+	require.NoError(t, err)
+
+	err = setup.Store.SaveCreateTokenResponse(ctx, key, storage.CreateTokenResponse{
+		AccessToken:  "expired-access-token",
+		ExpiresAt:    time.Now().Add(-1 * time.Hour).Unix(),
+		RefreshToken: refreshToken,
+		TokenType:    "Bearer",
+	})
+	require.NoError(t, err)
+}
+
 // populateCache queues ListAccounts + ListAccountRoles mock responses and then
 // calls Cache.Refresh so the cache contains a known set of accounts and roles.
 // After this call, the Default SSO cache has:

--- a/cmd/aws-sso/login_cmd.go
+++ b/cmd/aws-sso/login_cmd.go
@@ -26,6 +26,7 @@ import (
 type LoginCmd struct {
 	UrlAction string `kong:"short='u',help='How to handle URLs [clip|exec|open|print|printurl|granted-containers|open-url-in-container|ansi-osc52] (default: open)',predictor='urlAction'"`
 	Threads   int    `kong:"help='Override number of threads for talking to AWS',default=${DEFAULT_THREADS}"`
+	Force     bool   `kong:"short='f',help='End the current SSO session and start a new one, resetting the session duration'"`
 }
 
 // AfterApply determines if SSO auth token is required
@@ -39,10 +40,8 @@ func (cc *LoginCmd) Run(ctx *RunContext) error {
 	return nil
 }
 
-// checkAuth craetes a singleton AWSSO object and checks to see if
-// we have a valid SSO authentication token.  If this is false, then
-// we need to call doAuth()
-func checkAuth(ctx *RunContext) bool {
+// initAwsSSO creates the singleton AWSSSO object if it does not exist yet
+func initAwsSSO(ctx *RunContext) *ssoauth.AWSSSO {
 	if AwsSSO == nil {
 		s, err := ctx.Settings.GetSelectedSSO(ctx.Cli.SSO)
 		if err != nil {
@@ -52,12 +51,49 @@ func checkAuth(ctx *RunContext) bool {
 		AwsSSO = ssoauth.NewAWSSSO(s, ctx.Store)
 	}
 
-	return AwsSSO.ValidAuthToken(ctx.Ctx)
+	return AwsSSO
+}
+
+// checkAuth creates a singleton AWSSO object and checks to see if
+// we have a valid SSO authentication token.  If this is false, then
+// we need to call doAuth()
+func checkAuth(ctx *RunContext) bool {
+	return initAwsSSO(ctx).ValidAuthToken(ctx.Ctx)
+}
+
+// endCurrentSession invalidates the current SSO sign-in session.  AWS reuses an
+// active session and the new token inherits its expiry, so the session must be
+// ended for the login which follows to reset the session duration.  STS
+// credentials are left alone: IAM role sessions outlive the SSO session.
+func endCurrentSession(ctx *RunContext, as *ssoauth.AWSSSO) {
+	// Logout needs a valid AccessToken, so refresh an expired one first
+	if !as.ValidAuthToken(ctx.Ctx) {
+		log.Debug("no valid SSO token to log out with")
+		return
+	}
+
+	if err := as.Logout(ctx.Ctx); err != nil {
+		// not fatal: we fall back to re-authenticating into the existing session
+		log.Warn("unable to end the current SSO session; the new token may inherit its expiry",
+			"error", err.Error())
+		return
+	}
+
+	// don't leave behind a token that looks valid locally but is dead server side
+	if err := ctx.Store.DeleteCreateTokenResponse(ctx.Ctx, as.StoreKey()); err != nil {
+		log.Debug("unable to delete invalidated token", "error", err.Error())
+	}
+
+	log.Debug("Ended the current SSO session", "storeKey", as.StoreKey())
 }
 
 // doAuth creates a singleton AWSSO object post authentication
 func doAuth(ctx *RunContext) {
-	if checkAuth(ctx) {
+	as := initAwsSSO(ctx)
+
+	if ctx.Cli.Login.Force {
+		endCurrentSession(ctx, as)
+	} else if checkAuth(ctx) {
 		// nothing to do here
 		log.Info("You are already logged in. :)")
 		return

--- a/cmd/aws-sso/login_e2e_test.go
+++ b/cmd/aws-sso/login_e2e_test.go
@@ -84,6 +84,258 @@ func TestE2ELogin_DeviceCode(t *testing.T) {
 	assert.False(t, ctr.Expired(), "token should not be expired after login")
 }
 
+// TestE2ELogin_AlreadyValidIsNoop verifies the default behaviour: with a valid
+// token in the store, login makes no AWS calls and leaves the token alone.
+// No mock responses are queued, so any AWS call would fail the test.
+func TestE2ELogin_AlreadyValidIsNoop(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.Login = LoginCmd{UrlAction: "print", Threads: 1}
+
+	cmd := &LoginCmd{}
+	require.NoError(t, cmd.Run(ctx))
+
+	var ctr storage.CreateTokenResponse
+	require.NoError(t, setup.Store.GetCreateTokenResponse(AwsSSO.StoreKey(), &ctr))
+	assert.Equal(t, "test-access-token", ctr.AccessToken, "token should be untouched")
+}
+
+// TestE2ELogin_Force verifies --force ends the current session before re-authenticating.
+func TestE2ELogin_Force(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+
+	setup.Server.SSO.QueueLogout()
+	setup.Server.SSOOIDC.QueueDeviceAuth(awsmock.DeviceAuthResponse{
+		DeviceCode:              "device-code",
+		UserCode:                "CODE-1234",
+		VerificationURI:         "https://verify.example.com",
+		VerificationURIComplete: "https://verify.example.com?user_code=CODE-1234",
+		ExpiresIn:               600,
+		Interval:                0,
+	})
+	setup.Server.SSOOIDC.QueueCreateToken(awsmock.OIDCTokenResponse{
+		AccessToken:  "forced-access-token",
+		ExpiresIn:    28800,
+		RefreshToken: "forced-refresh-token",
+		TokenType:    "Bearer",
+	})
+
+	// login refreshes the role cache after authenticating.
+	setup.Server.SSO.QueueListAccounts(awsmock.ListAccountsResponse{
+		AccountList: []awsmock.AccountInfo{
+			{AccountID: "123456789012", AccountName: "TestAccount", EmailAddress: "admin@example.com"},
+		},
+	})
+	setup.Server.SSO.QueueListAccountRoles(awsmock.ListAccountRolesResponse{
+		RoleList: []awsmock.RoleInfo{
+			{AccountID: "123456789012", RoleName: "ReadOnly"},
+		},
+	})
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.Login = LoginCmd{UrlAction: "print", Threads: 1, Force: true}
+
+	cmd := &LoginCmd{}
+	require.NoError(t, cmd.Run(ctx))
+
+	assert.Equal(t, 1, setup.Server.SSO.LogoutCalls())
+
+	var ctr storage.CreateTokenResponse
+	require.NoError(t, setup.Store.GetCreateTokenResponse(AwsSSO.StoreKey(), &ctr))
+	assert.Equal(t, "forced-access-token", ctr.AccessToken, "--force must replace the valid token")
+	assert.False(t, ctr.Expired())
+}
+
+// TestE2ELogin_ForceLogoutFailureStillLogsIn verifies a failed Logout is not fatal.
+func TestE2ELogin_ForceLogoutFailureStillLogsIn(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+
+	// No QueueLogout(), so the mock answers Logout with an error.
+	setup.Server.SSOOIDC.QueueDeviceAuth(awsmock.DeviceAuthResponse{
+		DeviceCode:              "device-code",
+		UserCode:                "CODE-1234",
+		VerificationURI:         "https://verify.example.com",
+		VerificationURIComplete: "https://verify.example.com?user_code=CODE-1234",
+		ExpiresIn:               600,
+		Interval:                0,
+	})
+	setup.Server.SSOOIDC.QueueCreateToken(awsmock.OIDCTokenResponse{
+		AccessToken:  "forced-access-token",
+		ExpiresIn:    3600,
+		RefreshToken: "forced-refresh-token",
+		TokenType:    "Bearer",
+	})
+	setup.Server.SSO.QueueListAccounts(awsmock.ListAccountsResponse{
+		AccountList: []awsmock.AccountInfo{
+			{AccountID: "123456789012", AccountName: "TestAccount", EmailAddress: "admin@example.com"},
+		},
+	})
+	setup.Server.SSO.QueueListAccountRoles(awsmock.ListAccountRolesResponse{
+		RoleList: []awsmock.RoleInfo{
+			{AccountID: "123456789012", RoleName: "ReadOnly"},
+		},
+	})
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.Login = LoginCmd{UrlAction: "print", Threads: 1, Force: true}
+
+	cmd := &LoginCmd{}
+	require.NoError(t, cmd.Run(ctx))
+
+	var ctr storage.CreateTokenResponse
+	require.NoError(t, setup.Store.GetCreateTokenResponse(AwsSSO.StoreKey(), &ctr))
+	assert.Equal(t, "forced-access-token", ctr.AccessToken)
+}
+
+// TestE2ELogin_ForceRenewsExpiredTokenToLogOut verifies that an expired token is
+// refreshed first, since Logout requires a valid AccessToken.
+func TestE2ELogin_ForceRenewsExpiredTokenToLogOut(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuthExpired(t, setup, "seeded-refresh-token")
+
+	setup.Server.SSOOIDC.QueueCreateToken(awsmock.OIDCTokenResponse{
+		AccessToken:  "refreshed-access-token",
+		ExpiresIn:    3600,
+		RefreshToken: "rotated-refresh-token",
+		TokenType:    "Bearer",
+	})
+	setup.Server.SSO.QueueLogout()
+	setup.Server.SSOOIDC.QueueDeviceAuth(awsmock.DeviceAuthResponse{
+		DeviceCode:              "device-code",
+		UserCode:                "CODE-1234",
+		VerificationURI:         "https://verify.example.com",
+		VerificationURIComplete: "https://verify.example.com?user_code=CODE-1234",
+		ExpiresIn:               600,
+		Interval:                0,
+	})
+	setup.Server.SSOOIDC.QueueCreateToken(awsmock.OIDCTokenResponse{
+		AccessToken:  "forced-access-token",
+		ExpiresIn:    3600,
+		RefreshToken: "forced-refresh-token",
+		TokenType:    "Bearer",
+	})
+	setup.Server.SSO.QueueListAccounts(awsmock.ListAccountsResponse{
+		AccountList: []awsmock.AccountInfo{
+			{AccountID: "123456789012", AccountName: "TestAccount", EmailAddress: "admin@example.com"},
+		},
+	})
+	setup.Server.SSO.QueueListAccountRoles(awsmock.ListAccountRolesResponse{
+		RoleList: []awsmock.RoleInfo{
+			{AccountID: "123456789012", RoleName: "ReadOnly"},
+		},
+	})
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.Login = LoginCmd{UrlAction: "print", Threads: 1, Force: true}
+
+	cmd := &LoginCmd{}
+	require.NoError(t, cmd.Run(ctx))
+
+	assert.Equal(t, []string{
+		string(storage.GrantTypeRefreshToken),
+		string(storage.GrantTypeDeviceCode),
+	}, setup.Server.SSOOIDC.TokenGrants())
+	assert.Equal(t, 1, setup.Server.SSO.LogoutCalls())
+
+	var ctr storage.CreateTokenResponse
+	require.NoError(t, setup.Store.GetCreateTokenResponse(AwsSSO.StoreKey(), &ctr))
+	assert.Equal(t, "forced-access-token", ctr.AccessToken)
+}
+
+// TestE2ELogin_ForceWithNoTokenSkipsLogout verifies --force skips the logout when
+// there is no session to end.
+func TestE2ELogin_ForceWithNoTokenSkipsLogout(t *testing.T) {
+	setup := newE2ESetup(t)
+	// deliberately no preAuth(): the store is empty
+
+	setup.Server.SSOOIDC.QueueRegisterClient(awsmock.RegisterClientResponse{
+		ClientID:              "test-client-id",
+		ClientSecret:          "test-client-secret",
+		ClientIDIssuedAt:      time.Now().Unix(),
+		ClientSecretExpiresAt: time.Now().Add(30 * 24 * time.Hour).Unix(),
+	})
+	setup.Server.SSOOIDC.QueueDeviceAuth(awsmock.DeviceAuthResponse{
+		DeviceCode:              "device-code",
+		UserCode:                "CODE-1234",
+		VerificationURI:         "https://verify.example.com",
+		VerificationURIComplete: "https://verify.example.com?user_code=CODE-1234",
+		ExpiresIn:               600,
+		Interval:                0,
+	})
+	setup.Server.SSOOIDC.QueueCreateToken(awsmock.OIDCTokenResponse{
+		AccessToken:  "forced-access-token",
+		ExpiresIn:    3600,
+		RefreshToken: "forced-refresh-token",
+		TokenType:    "Bearer",
+	})
+	setup.Server.SSO.QueueListAccounts(awsmock.ListAccountsResponse{
+		AccountList: []awsmock.AccountInfo{
+			{AccountID: "123456789012", AccountName: "TestAccount", EmailAddress: "admin@example.com"},
+		},
+	})
+	setup.Server.SSO.QueueListAccountRoles(awsmock.ListAccountRolesResponse{
+		RoleList: []awsmock.RoleInfo{
+			{AccountID: "123456789012", RoleName: "ReadOnly"},
+		},
+	})
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.Login = LoginCmd{UrlAction: "print", Threads: 1, Force: true}
+
+	cmd := &LoginCmd{}
+	require.NoError(t, cmd.Run(ctx))
+
+	assert.Equal(t, 0, setup.Server.SSO.LogoutCalls())
+
+	var ctr storage.CreateTokenResponse
+	require.NoError(t, setup.Store.GetCreateTokenResponse(AwsSSO.StoreKey(), &ctr))
+	assert.Equal(t, "forced-access-token", ctr.AccessToken)
+}
+
+// TestE2ELogin_NoForceNeverLogsOut verifies an ordinary login never ends the session.
+func TestE2ELogin_NoForceNeverLogsOut(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuth(t, setup)
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.Login = LoginCmd{UrlAction: "print", Threads: 1}
+
+	cmd := &LoginCmd{}
+	require.NoError(t, cmd.Run(ctx))
+
+	assert.Equal(t, 0, setup.Server.SSO.LogoutCalls())
+}
+
+// TestE2ELogin_ExpiredUsesSilentRefresh verifies an expired token is renewed silently
+// without --force.  No DeviceAuth is queued, so a browser flow would fail the test.
+func TestE2ELogin_ExpiredUsesSilentRefresh(t *testing.T) {
+	setup := newE2ESetup(t)
+	preAuthExpired(t, setup, "seeded-refresh-token")
+
+	setup.Server.SSOOIDC.QueueCreateToken(awsmock.OIDCTokenResponse{
+		AccessToken:  "refreshed-access-token",
+		ExpiresIn:    3600,
+		RefreshToken: "rotated-refresh-token",
+		TokenType:    "Bearer",
+	})
+
+	ctx := newRunContext(setup, AUTH_SKIP)
+	ctx.Cli.Login = LoginCmd{UrlAction: "print", Threads: 1}
+
+	cmd := &LoginCmd{}
+	require.NoError(t, cmd.Run(ctx))
+
+	assert.Equal(t, []string{string(storage.GrantTypeRefreshToken)}, setup.Server.SSOOIDC.TokenGrants())
+
+	var ctr storage.CreateTokenResponse
+	require.NoError(t, setup.Store.GetCreateTokenResponse(AwsSSO.StoreKey(), &ctr))
+	assert.Equal(t, "refreshed-access-token", ctr.AccessToken)
+}
+
 // TestE2ELogin_PKCE exercises the PKCE authorization-code flow via LoginCmd.Run.
 // PKCECallbackClient auto-delivers the browser redirect so no user interaction is needed.
 func TestE2ELogin_PKCE(t *testing.T) {

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -290,9 +290,7 @@ per the [CacheRefresh](config.md#cacherefresh) setting.
 
 Flags:
 
-* `--no-config-check` -- Disable automatic updating of `~/.aws/config`
 * `--url-action`, `-u` -- How to handle URLs for your SSO provider
-* `--sts-refresh` -- Force refresh of STS Token Credentials
 * `--threads <int>` -- Number of threads to use with AWS (default: 5)
 
 ---

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -292,6 +292,8 @@ Flags:
 
 * `--url-action`, `-u` -- How to handle URLs for your SSO provider
 * `--threads <int>` -- Number of threads to use with AWS (default: 5)
+* `--force`, `-f` -- End the current SSO session and start a new one, resetting the
+    session duration.  Unlike `logout`, cached STS credentials are left in place.
 
 ---
 

--- a/internal/awsmock/sso.go
+++ b/internal/awsmock/sso.go
@@ -71,6 +71,14 @@ type SSOHandler struct {
 	listAccountRolesQ []queueItem
 	getRoleCredsQ     []queueItem
 	logoutQ           []queueItem
+	logoutCalls       int
+}
+
+// LogoutCalls returns how many Logout requests were received.
+func (h *SSOHandler) LogoutCalls() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.logoutCalls
 }
 
 // QueueListAccounts enqueues a ListAccounts response.
@@ -123,11 +131,13 @@ func (h *SSOHandler) handleGetRoleCredentials(w http.ResponseWriter, r *http.Req
 }
 
 func (h *SSOHandler) handleLogout(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodDelete {
+	// The SSO Portal API defines Logout as POST /logout.
+	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 	h.mu.Lock()
+	h.logoutCalls++
 	item, found := dequeue(&h.logoutQ)
 	h.mu.Unlock()
 	writeQueueItem(w, item, found)

--- a/internal/awsmock/ssooidc.go
+++ b/internal/awsmock/ssooidc.go
@@ -21,6 +21,7 @@ package awsmock
  */
 
 import (
+	"encoding/json"
 	"net/http"
 	"sync"
 )
@@ -61,6 +62,14 @@ type SSOOIDCHandler struct {
 	registerQ   []queueItem
 	deviceAuthQ []queueItem
 	tokenQ      []queueItem
+	tokenGrants []string
+}
+
+// TokenGrants returns the grantType of every CreateToken request received, in order.
+func (h *SSOOIDCHandler) TokenGrants() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.tokenGrants...)
 }
 
 // QueueRegisterClient enqueues a successful RegisterClient response.
@@ -118,7 +127,14 @@ func (h *SSOOIDCHandler) handleToken(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
+	// an undecodable body records an empty grant type; the queue drives the response
+	var body struct {
+		GrantType string `json:"grantType"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&body)
+
 	h.mu.Lock()
+	h.tokenGrants = append(h.tokenGrants, body.GrantType)
 	item, found := dequeue(&h.tokenQ)
 	h.mu.Unlock()
 	writeQueueItem(w, item, found)


### PR DESCRIPTION
Implements the `--force` flag proposed in #1455.

> **Note:** rewritten since the first version. The original approach — just re-authenticating
> while the session was live — does not reset the session clock. #1455 has been updated too.

## Motivation

`login` is a no-op with a valid token, and renews an expired one silently for as long as the
Identity Center session lasts. Once that session hits its configured duration, no refresh can
extend it and long-running tools (`k9s`, `kubectl`, background agents) fail until the user
signs in again. `--force` resets that clock ahead of time.

Re-authenticating alone doesn't do it. Per
[the AWS docs](https://docs.aws.amazon.com/sdkref/latest/guide/understanding-sso.html):

> If you already have an active session, the AWS CLI command reuses the existing session and
> will expire whenever the existing session expires.

Confirmed against a real Identity Center: the browser returned without prompting and the
session still expired at its original time. So `--force` must end the session first —
[Logout](https://docs.aws.amazon.com/singlesignon/latest/PortalAPIReference/API_Logout.html)
invalidates it server side.

## Implementation

Two commits.

**`docs: remove non-existent flags from the login command`** (`Refs: #1451`) — `docs/commands.md`
listed `--no-config-check` and `--sts-refresh` under `login`; neither is defined on `LoginCmd`.
Both are real on other commands, so only the two `login` entries are removed. Independent of
the rest of this PR.

**`feat: add login --force to start a new SSO session`** — `Force bool` on `LoginCmd`;
`initAwsSSO()` split out of `checkAuth()`; new `endCurrentSession()` logs out, drops the
invalidated token, then falls through to the normal auth path.

Three points for review:

* `Logout` needs a valid AccessToken, so on an expired token `--force` refreshes first, then
  logs out, then authenticates.
* A failed `Logout` is not fatal — we fall back to re-authenticating into the existing
  session, which is what plain `login` would have done.
* STS credentials are deliberately not flushed, unlike `logout`. IAM role sessions outlive the
  SSO session, so tools holding credentials keep working across the re-login. This is the main
  advantage over `logout && login`.

Also fixes `awsmock`'s Logout handler, which required `DELETE`; the Portal API defines
`POST /logout`. `QueueLogout()` had no callers, so nothing had caught it.

`AutoLogin` is unaffected — it reaches `doAuth()` with a zero-valued `LoginCmd`.

## Tests

`SSOHandler` counts `Logout` requests and `SSOOIDCHandler` records each `CreateToken`
grantType, so the tests assert which exchanges happened rather than just the resulting token.

* `TestE2ELogin_Force` — one `Logout`, then replacement.
* `TestE2ELogin_ForceRenewsExpiredTokenToLogOut` — `refresh_token` then `device_code`, one
  `Logout` between.
* `TestE2ELogin_ForceLogoutFailureStillLogsIn` — `Logout` fails, login completes.
* `TestE2ELogin_ForceWithNoTokenSkipsLogout` — nothing to end, no `Logout` attempted.
* `TestE2ELogin_NoForceNeverLogsOut` — plain `login` never ends the session.
* `TestE2ELogin_ExpiredUsesSilentRefresh` — default path still renews silently.

`make unittest`, `make e2e`, `make lint`, `make` all pass.

Caveat: no mock test can prove AWS really starts a new session. The real-world signal is that
`login --force` now prompts in the browser instead of returning instantly.

## Notes

Happy to adjust anything — including dropping the docs commit if you'd rather resolve #1451 by
restoring `--sts-refresh` to `login` instead.
