### PR TITLE
ecs: add 'docker write-config' command for Docker Compose users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 ### New Features
 
 * Add `aws-sso login --force` to start a new SSO session, resetting its duration #1455
+* Add `aws-sso ecs docker write-config`
 
 ### Bugs
 
 * Remove `--no-config-check` and `--sts-refresh` from the documented `login` flags #1451
+* Fix documentation / examples related to using the ECS server with Docker Compose #1462
 
 ## [v2.3.2] -- 2026-07-29
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN make
 
 # Stage 2: Final stage
 FROM alpine:latest
+RUN apk --no-cache add curl
 
 WORKDIR /app
 # Copy the built binary from the previous stage
@@ -19,4 +20,5 @@ COPY --from=builder /app/dist/aws-sso .
 # Set the entrypoint for the container
 EXPOSE 4144
 
+HEALTHCHECK --interval=1s --timeout=1s --start-period=1s --retries=90 CMD curl -f http://localhost:4144/healthcheck || exit 1
 ENTRYPOINT ["./aws-sso", "ecs", "server", "--docker"]

--- a/cmd/aws-sso/ecs_docker_cmd.go
+++ b/cmd/aws-sso/ecs_docker_cmd.go
@@ -40,8 +40,9 @@ const (
 )
 
 type EcsDockerCmd struct {
-	Start EcsDockerStartCmd `kong:"cmd,help='Start the ECS Server in a Docker container'"`
-	Stop  EcsDockerStopCmd  `kong:"cmd,help='Stop the ECS Server Docker container'"`
+	Start       EcsDockerStartCmd       `kong:"cmd,help='Start the ECS Server in a Docker container'"`
+	Stop        EcsDockerStopCmd        `kong:"cmd,help='Stop the ECS Server Docker container'"`
+	WriteConfig EcsDockerWriteConfigCmd `kong:"cmd,help='Write the ECS security config file for use with Docker Compose or other non-aws-sso launchers'"`
 }
 
 type EcsDockerStartCmd struct {
@@ -197,6 +198,49 @@ func (cc *EcsDockerStartCmd) Run(ctx *RunContext) error {
 			return err
 		}
 	}
+	return nil
+}
+
+type EcsDockerWriteConfigCmd struct {
+	DisableAuth bool `kong:"help='Do not include the HTTP Auth bearer token in the config file'"`
+	DisableSSL  bool `kong:"help='Do not include the SSL cert/key in the config file'"`
+}
+
+// AfterApply determines if SSO auth token is required
+func (e EcsDockerWriteConfigCmd) AfterApply(runCtx *RunContext) error {
+	runCtx.Auth = AUTH_SKIP
+	return nil
+}
+
+// Run writes the security config file consumed by the `--docker` entrypoint
+// (`ecs.CONTAINER_NAMED_FILE`, bind-mounted from `ecs.HOST_NAMED_FILE_FMT`) without
+// starting or managing a container. This lets tools that own the container lifecycle
+// themselves, like `docker compose`, still provision the bearer token / SSL material
+// that `EcsDockerStartCmd` would otherwise write just before starting the container.
+func (cc *EcsDockerWriteConfigCmd) Run(ctx *RunContext) error {
+	var privateKey, certChain, bearerToken string
+	var err error
+
+	if !cc.DisableSSL {
+		if privateKey, err = ctx.Store.GetEcsSslKey(); err != nil {
+			return err
+		}
+		if certChain, err = ctx.Store.GetEcsSslCert(); err != nil {
+			return err
+		}
+	}
+
+	if !cc.DisableAuth {
+		if bearerToken, err = ctx.Store.GetEcsBearerToken(); err != nil {
+			return err
+		}
+	}
+
+	if err = writeAndCloseSecurityFile(privateKey, certChain, bearerToken); err != nil {
+		return err
+	}
+
+	log.Info("Wrote ECS security config", "path", ecs.SecurityFilePath(ecs.WRITE_ONLY))
 	return nil
 }
 

--- a/cmd/aws-sso/ecs_docker_cmd_test.go
+++ b/cmd/aws-sso/ecs_docker_cmd_test.go
@@ -19,17 +19,55 @@ package main
  */
 
 import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/synfinatic/aws-sso-cli/internal/ecs"
 	ssocache "github.com/synfinatic/aws-sso-cli/internal/sso/cache"
+	"github.com/synfinatic/aws-sso-cli/internal/storage"
 )
+
+// genTestCertPEM creates a throwaway ECDSA P-256 self-signed certificate/key
+// pair in PEM form, valid enough to pass SaveEcsSslKeyPair's x509 validation.
+func genTestCertPEM(t *testing.T) (certPEM, keyPEM string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	certPEM = string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	keyPEM = string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}))
+	return
+}
 
 func TestEcsDockerStartCmdAfterApply(t *testing.T) {
 	tests := []struct {
@@ -115,4 +153,65 @@ func TestLoadProfileToEcsServerNotFound(t *testing.T) {
 	err := loadProfileToEcsServer(ctx, "nonexistent-profile", "localhost:4144")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "nonexistent-profile")
+}
+
+func TestEcsDockerWriteConfigCmdAfterApply(t *testing.T) {
+	runCtx := &RunContext{}
+	err := EcsDockerWriteConfigCmd{}.AfterApply(runCtx)
+	require.NoError(t, err)
+	assert.Equal(t, AUTH_SKIP, runCtx.Auth)
+}
+
+func TestEcsDockerWriteConfigCmdRun(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".config", "aws-sso"), 0700))
+	t.Setenv("HOME", home)
+
+	store, err := storage.OpenJsonStore(context.Background(), filepath.Join(home, "store.json"))
+	require.NoError(t, err)
+
+	certPEM, keyPEM := genTestCertPEM(t)
+	require.NoError(t, store.SaveEcsBearerToken(context.Background(), "s3cr3t"))
+	require.NoError(t, store.SaveEcsSslKeyPair(context.Background(), []byte(keyPEM), []byte(certPEM)))
+
+	ctx := &RunContext{Store: store}
+	cc := &EcsDockerWriteConfigCmd{}
+	require.NoError(t, cc.Run(ctx))
+
+	path := filepath.Join(home, ".aws-sso", "mnt", "docker-ecs")
+	data, err := os.ReadFile(path) // nolint:gosec
+	require.NoError(t, err)
+
+	sec := &ecs.ECSSecurity{}
+	require.NoError(t, json.Unmarshal(data, sec))
+	assert.Equal(t, "s3cr3t", sec.BearerToken)
+	assert.Equal(t, keyPEM, sec.PrivateKey)
+	assert.Equal(t, certPEM, sec.CertChain)
+}
+
+func TestEcsDockerWriteConfigCmdRunDisabled(t *testing.T) {
+	home := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".config", "aws-sso"), 0700))
+	t.Setenv("HOME", home)
+
+	store, err := storage.OpenJsonStore(context.Background(), filepath.Join(home, "store.json"))
+	require.NoError(t, err)
+
+	certPEM, keyPEM := genTestCertPEM(t)
+	require.NoError(t, store.SaveEcsBearerToken(context.Background(), "s3cr3t"))
+	require.NoError(t, store.SaveEcsSslKeyPair(context.Background(), []byte(keyPEM), []byte(certPEM)))
+
+	ctx := &RunContext{Store: store}
+	cc := &EcsDockerWriteConfigCmd{DisableAuth: true, DisableSSL: true}
+	require.NoError(t, cc.Run(ctx))
+
+	path := filepath.Join(home, ".aws-sso", "mnt", "docker-ecs")
+	data, err := os.ReadFile(path) // nolint:gosec
+	require.NoError(t, err)
+
+	sec := &ecs.ECSSecurity{}
+	require.NoError(t, json.Unmarshal(data, sec))
+	assert.Empty(t, sec.BearerToken)
+	assert.Empty(t, sec.PrivateKey)
+	assert.Empty(t, sec.CertChain)
 }

--- a/docs/ecs-commands.md
+++ b/docs/ecs-commands.md
@@ -60,6 +60,23 @@ Stops the ECS Server Docker container.
 
 ---
 
+### ecs docker write-config
+
+Writes the bearer token and/or SSL certificate/private key from the SecureStore
+to the security config file (`~/.aws-sso/mnt/docker-ecs`) read by the ECS Server
+Docker image on startup, without starting or managing a container itself. Use
+this when launching the ECS Server container via `docker compose` or another
+tool instead of `ecs docker start`, so the container still picks up your
+configured HTTP Auth and/or TLS material. The file is deleted by the container
+once read, so re-run this command before every `docker compose up`.
+
+Flags:
+
+* `--disable-auth` -- Do not include the HTTP Auth bearer token in the config file
+* `--disable-ssl` -- Do not include the SSL cert/key in the config file
+
+---
+
 ### ecs list
 
 List the AWS Profiles stored in the ECS Server.

--- a/docs/ecs-server.md
+++ b/docs/ecs-server.md
@@ -306,27 +306,63 @@ profile name if it contains special characters).
 
 ### Docker Compose example
 
-```yaml
-services:
-  aws-sso:
-    image: synfinatic/aws-sso-cli-ecs-server
-    healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:4144/healthcheck"]
-      interval: 30s
-      timeout: 5s
-      retries: 3
-      start_period: 10s
+Unlike `aws-sso ecs docker start`, `docker compose` does not automatically provision
+your configured bearer token or SSL certificate/key into the container. If you have
+either configured (via `aws-sso setup ecs auth` and/or `aws-sso setup ecs ssl`), run
+`aws-sso ecs docker write-config` before every `docker compose up` to write them to
+`~/.aws-sso/mnt/docker-ecs`, which the container reads on startup and then deletes.
+Otherwise the container starts with HTTP Auth disabled, and any client (including
+`aws-sso ecs list`) that still sends a bearer token from a previously configured
+SecureStore will be rejected with a `403 Forbidden`.
+
+```bash
+aws-sso ecs docker write-config
+docker compose up &
+aws-sso ecs load ...
 ```
 
-Other services that depend on valid credentials can declare `depends_on` with a
-`service_healthy` condition:
-
 ```yaml
+# Run `aws-sso ecs docker write-config` before every `docker compose up` to
+# provision the bearer token / SSL cert+key into ${HOME}/.aws-sso/mnt/docker-ecs
+# (deleted by the container after it reads it), otherwise this starts with
+# HTTP Auth disabled and any client still sending a configured bearer token
+# will get a 403.
+networks:
+  aws-sso-ecs:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: "169.254.170.0/24"
+          gateway: "169.254.170.1"
+
+services:
+  aws-sso:
+    image: synfinatic/aws-sso-cli-ecs-server:latest
+    networks:
+      aws-sso-ecs:
+        # This special IP address is recognized by the AWS SDKs and AWS CLI
+        ipv4_address: "169.254.170.2" 
+      default: {}
+    volumes:
+      # necessary for the container to read the bearer token and SSL cert+key from the host
+      - ${HOME}/.aws-sso/mnt:/app/.aws-sso/mnt
+    ports:
+      # necessary for local management
+      - "127.0.0.1:4144:4144"
+
   myapp:
-    image: myapp
+    image: amazon/aws-cli # replace with your service
+    entrypoint: ""
+    command: /usr/local/bin/aws sts get-caller-identity
     depends_on:
       aws-sso:
+        # ensures this container doesn't start until credentials have been loaded in the ecs server
         condition: service_healthy
+    environment:
+      AWS_CONTAINER_CREDENTIALS_FULL_URI: http://169.254.170.2:4144
+    networks:
+      aws-sso-ecs: {}
+      default: {}
 ```
 
 ## Errors


### PR DESCRIPTION
## Summary
- Add `aws-sso ecs docker write-config`, which writes the bearer token / SSL cert+key from the SecureStore to the ECS Server's security config file (`~/.aws-sso/mnt/docker-ecs`) without starting or managing a container itself.
- Unlike `ecs docker start`, plain `docker compose up` never provisions this file, so a Compose-launched ECS Server container silently starts with HTTP Auth disabled — while a client (e.g. `aws-sso ecs list`) that still has a bearer token configured gets rejected with `403 Forbidden`. This command lets Compose users provision it themselves as a pre-step.
- Update `docs/ecs-commands.md` and the Docker Compose example in `docs/ecs-server.md` to document the new command and the failure mode it fixes.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/aws-sso/...` (new `TestEcsDockerWriteConfigCmd*` tests pass)
- [x] `go vet ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B4uuvA4ryDkQxtwuV4G2o3