### PR TITLE
Fix ECS server healthcheck with SSL, and harden the SSH + Docker Compose docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 * Fix documentation / examples related to using the ECS server with Docker Compose #1462
 * Document `ssh -o ExitOnForwardFailure=yes` to prevent another user on the remote host from
   hijacking the forwarded ECS server port
+* Fix the ECS server container healthcheck failing when SSL/TLS is enabled, which left the
+  container permanently unhealthy and blocked `depends_on: service_healthy`
+* Fix the Docker Compose example provisioning an SSL cert while connecting over `http://`,
+  and show the bearer token being passed to the client container
 
 ## [v2.3.2] -- 2026-07-29
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,9 @@ COPY --from=builder /app/dist/aws-sso .
 # Set the entrypoint for the container
 EXPOSE 4144
 
-HEALTHCHECK --interval=1s --timeout=1s --start-period=1s --retries=90 CMD curl -f http://localhost:4144/healthcheck || exit 1
+# The server listens over HTTPS when an SSL cert/key is configured, so try TLS first and
+# fall back to plaintext.  -k is safe here: this only ever talks to the loopback
+# interface inside the container.
+HEALTHCHECK --interval=1s --timeout=2s --start-period=1s --retries=90 \
+  CMD curl -fsk https://localhost:4144/healthcheck || curl -fs http://localhost:4144/healthcheck || exit 1
 ENTRYPOINT ["./aws-sso", "ecs", "server", "--docker"]

--- a/docs/ecs-server.md
+++ b/docs/ecs-server.md
@@ -309,24 +309,41 @@ profile name if it contains special characters).
 Unlike `aws-sso ecs docker start`, `docker compose` does not automatically provision
 your configured bearer token or SSL certificate/key into the container. If you have
 either configured (via `aws-sso setup ecs auth` and/or `aws-sso setup ecs ssl`), run
-`aws-sso ecs docker write-config` before every `docker compose up` to write them to
-`~/.aws-sso/mnt/docker-ecs`, which the container reads on startup and then deletes.
+`aws-sso ecs docker write-config --disable-ssl` before every `docker compose up` to write the
+bearer token to `~/.aws-sso/mnt/docker-ecs`, which the container reads on startup and then
+deletes.  See [Why SSL is not needed here](#why-ssl-is-not-needed-here) below for why this
+example skips the certificate.
 Otherwise the container starts with HTTP Auth disabled, and any client (including
 `aws-sso ecs list`) that still sends a bearer token from a previously configured
 SecureStore will be rejected with a `403 Forbidden`.
 
 ```bash
-aws-sso ecs docker write-config
+export AWS_SSO_ECS_TOKEN='<the token you passed to aws-sso setup ecs auth>'
+aws-sso ecs docker write-config --disable-ssl
 docker compose up &
 aws-sso ecs load ...
 ```
 
+The example below reads `AWS_SSO_ECS_TOKEN` from your shell rather than hard coding the bearer
+token into `compose.yaml`, so the secret does not end up in version control.
+
+#### Why SSL is not needed here
+
+`169.254.170.2` is the address AWS uses for the real ECS credential endpoint, so every AWS SDK
+and the AWS CLI accept it over **plain HTTP**, the same way they accept `127.0.0.1`.  Assigning
+that address to the `aws-sso` container gets you a working setup without an SSL certificate,
+which is otherwise [difficult to obtain](#ecs-server-ssl-certificate) for a local endpoint.
+Credentials stay on the Docker bridge network and access is controlled by the bearer token.
+
+If you leave off `--disable-ssl` while you have a certificate loaded, the container serves HTTPS
+instead, and `myapp` would have to use `https://169.254.170.2:4144` with a certificate the AWS
+SDK trusts _for that IP address_ -- which no public CA will issue.
+
 ```yaml
-# Run `aws-sso ecs docker write-config` before every `docker compose up` to
-# provision the bearer token / SSL cert+key into ${HOME}/.aws-sso/mnt/docker-ecs
-# (deleted by the container after it reads it), otherwise this starts with
-# HTTP Auth disabled and any client still sending a configured bearer token
-# will get a 403.
+# Run `aws-sso ecs docker write-config --disable-ssl` before every `docker compose up`
+# to provision the bearer token into ${HOME}/.aws-sso/mnt/docker-ecs (deleted by the
+# container after it reads it), otherwise this starts with HTTP Auth disabled and any
+# client still sending a configured bearer token will get a 403.
 networks:
   aws-sso-ecs:
     driver: bridge
@@ -341,10 +358,10 @@ services:
     networks:
       aws-sso-ecs:
         # This special IP address is recognized by the AWS SDKs and AWS CLI
-        ipv4_address: "169.254.170.2" 
+        ipv4_address: "169.254.170.2"
       default: {}
     volumes:
-      # necessary for the container to read the bearer token and SSL cert+key from the host
+      # necessary for the container to read the security config written by write-config
       - ${HOME}/.aws-sso/mnt:/app/.aws-sso/mnt
     ports:
       # necessary for local management
@@ -360,6 +377,9 @@ services:
         condition: service_healthy
     environment:
       AWS_CONTAINER_CREDENTIALS_FULL_URI: http://169.254.170.2:4144
+      # must match the token stored via `aws-sso setup ecs auth`.  Omit this (and run
+      # `write-config --disable-auth`) only if you are not using HTTP Auth.
+      AWS_CONTAINER_AUTHORIZATION_TOKEN: "Bearer ${AWS_SSO_ECS_TOKEN}"
     networks:
       aws-sso-ecs: {}
       default: {}


### PR DESCRIPTION
Two related pieces of cleanup around the ECS Server, one of which is a real bug.

## Fix the container healthcheck when SSL is enabled

`Dockerfile` hardcoded `curl -f http://localhost:4144/healthcheck`. When an SSL cert/key is configured the server listens over HTTPS (`ecs_server_cmd.go:117`), so the healthcheck fails every time, the container never reports healthy, and `depends_on: condition: service_healthy` in the documented Compose example blocks until it gives up.

`aws-sso ecs docker start` was insulated because `waitForEcsHealthcheck` does its own host-side check with the cert chain, but the container still showed unhealthy in `docker ps`.

Now tries TLS first and falls back to plaintext, so it works in either mode. `-k` is safe here — it only ever talks to loopback inside the container. Timeout bumped to 2s since it may make two attempts.

`/healthcheck` already bypasses auth (`server.go:92-96`, covered by `TestHealthCheckBypassesAuth`), so a bearer token was never affected — only SSL.

## Fix the Docker Compose example

- The docs said to run `aws-sso ecs docker write-config`, which provisions the SSL cert/key from the SecureStore, and then connect over `http://169.254.170.2:4144`. Those contradict for anyone who has run `aws-sso setup ecs ssl`. The flow now documents `write-config --disable-ssl` consistently across the prose, the bash block, and the embedded YAML header comment (all three disagreed).
- Added a **Why SSL is not needed here** section: `169.254.170.2` is the address AWS uses for the real ECS credential endpoint, so every AWS SDK and the AWS CLI accept it over plain HTTP. That makes this the one deployment where you get the security properties without needing a certificate at all — worth stating deliberately rather than leaving as a happy accident.
- The `myapp` container never set `AWS_CONTAINER_AUTHORIZATION_TOKEN`, so the example only worked with HTTP Auth disabled — precisely the 403 the paragraph above it warns about. It now passes the token via `${AWS_SSO_ECS_TOKEN}` from the shell, keeping the secret out of the compose file.
