### PR TITLE
Warn when the ECS server's TLS cert is about to expire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   SHA-256 fingerprint so you can verify what you are trusting in your OS/runtime trust store
 * Add `login --force` to start a new SSO session, resetting its duration #1455
 * Add `ecs docker write-config`
+* The ECS Server now logs a warning whenever IAM role credentials are loaded if its
+  TLS cert has fewer than 5 days of validity left
 
 ### Bugs
 

--- a/docs/ecs-server.md
+++ b/docs/ecs-server.md
@@ -105,6 +105,9 @@ the leaf is close to expiring (30 days). If you need to force a brand new CA,
 run `--delete` followed by `--self-signed`, which does require repeating the
 trust steps everywhere.
 
+Once the leaf has fewer than 5 days of validity left, `aws-sso ecs server` logs a warning
+every time new IAM role credentials are loaded, as a reminder to rerun `--self-signed`.
+
 Once you have generated the CA/leaf certificate, future invocations of the aws-sso
 ECS Server will automatically disable HTTP and enable HTTPS unless the user specifies
 `--disable-ssl`.

--- a/internal/certutil/certutil.go
+++ b/internal/certutil/certutil.go
@@ -190,6 +190,15 @@ func Fingerprint(certPEM string) (string, error) {
 	return strings.Join(parts, ":"), nil
 }
 
+// Expiry returns the NotAfter time of a PEM-encoded certificate.
+func Expiry(certPEM string) (time.Time, error) {
+	cert, err := parseCertificate(certPEM)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return cert.NotAfter, nil
+}
+
 // singleHostIPRanges converts each IP into a single-host CIDR (/32 for IPv4,
 // /128 for IPv6) so DefaultIPs can double as the CA's PermittedIPRanges
 // without a separately maintained list.

--- a/internal/certutil/certutil_test.go
+++ b/internal/certutil/certutil_test.go
@@ -300,6 +300,36 @@ func TestGenerateLeaf_CAKeyNotECDSA(t *testing.T) {
 	assert.ErrorContains(t, err, "CA private key is not an ECDSA key")
 }
 
+func TestExpiry(t *testing.T) {
+	t.Parallel()
+
+	ca, err := GenerateCA()
+	require.NoError(t, err)
+
+	leaf, err := GenerateLeaf(ca)
+	require.NoError(t, err)
+
+	notAfter, err := Expiry(leaf.CertPEM)
+	require.NoError(t, err)
+
+	assert.WithinDuration(t, time.Now().Add(LeafValidity), notAfter, time.Minute)
+}
+
+func TestExpiry_InvalidPEM(t *testing.T) {
+	t.Parallel()
+
+	_, err := Expiry("not a pem block")
+	assert.ErrorContains(t, err, "unable to decode PEM certificate")
+}
+
+func TestExpiry_InvalidCertificateBytes(t *testing.T) {
+	t.Parallel()
+
+	badCertPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not a real cert")}))
+	_, err := Expiry(badCertPEM)
+	assert.ErrorContains(t, err, "unable to parse certificate")
+}
+
 func parsePEMCert(t *testing.T, certPEM string) *x509.Certificate {
 	t.Helper()
 	block, _ := pem.Decode([]byte(certPEM))

--- a/internal/ecs/server/default.go
+++ b/internal/ecs/server/default.go
@@ -65,6 +65,7 @@ func (p DefaultHandler) Put(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	p.ecs.warnIfCertExpiringSoon()
 	p.ecs.DefaultCreds = creds
 	ecs.OK(w)
 }

--- a/internal/ecs/server/server.go
+++ b/internal/ecs/server/server.go
@@ -27,11 +27,18 @@ import (
 	"path/filepath"
 
 	// "github.com/davecgh/go-spew/spew"
+	"time"
+
+	"github.com/synfinatic/aws-sso-cli/internal/certutil"
 	"github.com/synfinatic/aws-sso-cli/internal/ecs"
 	"github.com/synfinatic/aws-sso-cli/internal/logger"
 	"github.com/synfinatic/aws-sso-cli/internal/storage"
 	"github.com/synfinatic/flexlog"
 )
+
+// CertExpiryWarning is how far ahead of a TLS cert's expiration the ECS
+// server starts warning on every credential load.
+const CertExpiryWarning = 5 * 24 * time.Hour
 
 var log flexlog.FlexLogger
 
@@ -124,8 +131,29 @@ func (e *EcsServer) PutSlottedCreds(creds *ecs.ECSClientRequest) error {
 		return fmt.Errorf("expired creds")
 	}
 
+	e.warnIfCertExpiringSoon()
 	e.slottedCreds[creds.ProfileName] = creds
 	return nil
+}
+
+// warnIfCertExpiringSoon logs a warning if the server's TLS cert (if any)
+// expires within CertExpiryWarning.
+func (e *EcsServer) warnIfCertExpiringSoon() {
+	if e.certChain == "" {
+		return
+	}
+
+	notAfter, err := certutil.Expiry(e.certChain)
+	if err != nil {
+		log.Error("unable to check ECS server TLS cert expiry", "error", err.Error())
+		return
+	}
+
+	if remaining := time.Until(notAfter); remaining < CertExpiryWarning {
+		log.Warn("ECS server TLS cert is expiring soon",
+			"expires", notAfter.Format(time.RFC3339),
+			"hint", "run `aws-sso setup ecs ssl --self-signed` to rotate it")
+	}
 }
 
 // ListSlottedCreds returns the list of roles in our slots

--- a/internal/ecs/server/server_test.go
+++ b/internal/ecs/server/server_test.go
@@ -20,19 +20,53 @@ package server
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"fmt"
+	"math/big"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/synfinatic/aws-sso-cli/internal/certutil"
 	"github.com/synfinatic/aws-sso-cli/internal/ecs"
 	"github.com/synfinatic/aws-sso-cli/internal/ecs/client"
 	"github.com/synfinatic/aws-sso-cli/internal/storage"
+	testlogger "github.com/synfinatic/flexlog/test"
 	"golang.org/x/net/nettest"
 )
+
+// selfSignedCertPEM generates a self-signed leaf cert PEM with the given
+// NotAfter, for exercising warnIfCertExpiringSoon without waiting on
+// certutil's fixed LeafValidity.
+func selfSignedCertPEM(t *testing.T, notAfter time.Time) string {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     notAfter,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
+}
 
 func newRequest(now time.Time) *ecs.ECSClientRequest {
 	return &ecs.ECSClientRequest{
@@ -192,4 +226,121 @@ func TestServerWithSSL(t *testing.T) {
 	assert.NoError(t, err)
 	// nothing was loaded yet, so 404
 	assert.Equal(t, http.StatusNotFound, res.StatusCode)
+}
+
+func withTestLogger(t *testing.T) *testlogger.TestLogger {
+	t.Helper()
+
+	tLogger := testlogger.NewTestLogger("DEBUG")
+	oldLogger := log.Copy()
+	log = tLogger
+	t.Cleanup(func() {
+		log = oldLogger
+		tLogger.Close()
+	})
+	return tLogger
+}
+
+func TestWarnIfCertExpiringSoon_NoCert(t *testing.T) {
+	tLogger := withTestLogger(t)
+
+	es := &EcsServer{}
+	es.warnIfCertExpiringSoon()
+
+	msg := testlogger.LogMessage{}
+	assert.Error(t, tLogger.GetNext(&msg), "no log messages expected when no cert is configured")
+}
+
+func TestWarnIfCertExpiringSoon_FarFromExpiry(t *testing.T) {
+	tLogger := withTestLogger(t)
+
+	ca, err := certutil.GenerateCA()
+	require.NoError(t, err)
+	leaf, err := certutil.GenerateLeaf(ca)
+	require.NoError(t, err)
+
+	es := &EcsServer{certChain: leaf.CertPEM}
+	es.warnIfCertExpiringSoon()
+
+	msg := testlogger.LogMessage{}
+	assert.Error(t, tLogger.GetNext(&msg), "no log messages expected for a cert that isn't close to expiry")
+}
+
+func TestWarnIfCertExpiringSoon_NearExpiry(t *testing.T) {
+	tLogger := withTestLogger(t)
+
+	certPEM := selfSignedCertPEM(t, time.Now().Add(2*24*time.Hour))
+	es := &EcsServer{certChain: certPEM}
+	es.warnIfCertExpiringSoon()
+
+	msg := testlogger.LogMessage{}
+	require.NoError(t, tLogger.GetNext(&msg))
+	assert.Equal(t, "WARN", strings.TrimSpace(msg.LevelStr))
+	assert.Contains(t, msg.Message, "expiring soon")
+}
+
+func TestWarnIfCertExpiringSoon_InvalidCert(t *testing.T) {
+	tLogger := withTestLogger(t)
+
+	es := &EcsServer{certChain: "not a pem block"}
+	es.warnIfCertExpiringSoon()
+
+	msg := testlogger.LogMessage{}
+	require.NoError(t, tLogger.GetNext(&msg))
+	assert.Equal(t, "ERROR", strings.TrimSpace(msg.LevelStr))
+}
+
+func TestDefaultHandlerPut_WarnsOnNearExpiryCert(t *testing.T) {
+	tLogger := withTestLogger(t)
+
+	certPEM := selfSignedCertPEM(t, time.Now().Add(2*24*time.Hour))
+	dh := DefaultHandler{
+		ecs: &EcsServer{
+			certChain: certPEM,
+			DefaultCreds: &ecs.ECSClientRequest{
+				Creds: &storage.RoleCredentials{},
+			},
+		},
+	}
+	ts := httptest.NewServer(&dh)
+	defer ts.Close()
+
+	cr := ecs.ECSClientRequest{
+		ProfileName: "TestProfileName",
+		Creds: &storage.RoleCredentials{
+			AccountId:       1111111,
+			RoleName:        "myrole",
+			AccessKeyId:     "AccessKeyId",
+			SecretAccessKey: "SecretAccessKey",
+			SessionToken:    "SessionToken",
+			Expiration:      time.Now().Add(90 * time.Second).UnixMilli(),
+		},
+	}
+	url := fmt.Sprintf("%s%s", ts.URL, ecs.DEFAULT_ROUTE)
+	resp, err := submitRequest(t, url, cr)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	msg := testlogger.LogMessage{}
+	require.NoError(t, tLogger.GetNext(&msg))
+	assert.Equal(t, "WARN", strings.TrimSpace(msg.LevelStr))
+	assert.Contains(t, msg.Message, "expiring soon")
+}
+
+func TestPutSlottedCreds_WarnsOnNearExpiryCert(t *testing.T) {
+	tLogger := withTestLogger(t)
+
+	certPEM := selfSignedCertPEM(t, time.Now().Add(2*24*time.Hour))
+	es := &EcsServer{
+		certChain:    certPEM,
+		slottedCreds: map[string]*ecs.ECSClientRequest{},
+	}
+
+	err := es.PutSlottedCreds(newRequest(time.Now().Add(90 * time.Second)))
+	require.NoError(t, err)
+
+	msg := testlogger.LogMessage{}
+	require.NoError(t, tLogger.GetNext(&msg))
+	assert.Equal(t, "WARN", strings.TrimSpace(msg.LevelStr))
+	assert.Contains(t, msg.Message, "expiring soon")
 }


### PR DESCRIPTION
## Summary
- Log a warning any time IAM role credentials are loaded into the ECS server (`DefaultHandler.Put`, `PutSlottedCreds`) if the TLS leaf cert has fewer than 5 days of validity left
- Add `certutil.Expiry()` to read a PEM cert's `NotAfter`, reusing the existing `parseCertificate` helper
- Update `docs/ecs-server.md` and `CHANGELOG.md`

## Test plan
- [x] `make test` (vet, unittest, lint, fmt/tidy, build) passes
- [x] New unit tests in `internal/certutil/certutil_test.go` (`Expiry`, malformed PEM)
- [x] New unit tests in `internal/ecs/server/server_test.go` covering no-cert / far-from-expiry / near-expiry / invalid-cert, plus end-to-end coverage through `DefaultHandler.Put` and `PutSlottedCreds`

## Known limitation
`aws-sso ecs server --default <profile>` loads the initial credentials directly into `EcsServer.DefaultCreds` at startup (`setServerDefaultProfile` in `cmd/aws-sso/ecs_server_cmd.go`), bypassing this check — that path does not yet emit the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTduufKifrXxXyGo8WP3Vt