### PR TITLE
Split setup ecs ssl --delete, add --delete-ca, remove --disable-ssl flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@
 
 * Remove `setup ecs ssl --certificate`, `--private-key`, `--print`; only the internal
   self-signed CA (`--self-signed`) is supported now
+* `setup ecs ssl --delete` now only deletes the SSL leaf cert/key; add `setup ecs ssl
+  --delete-ca` to delete the CA, which requires the leaf to already be deleted
+* Remove `ecs server --disable-ssl`, `ecs docker start --disable-ssl`, and `ecs docker
+  write-config --disable-ssl` -- SSL is now controlled purely by whether a certificate
+  is stored (`setup ecs ssl --delete`/`--self-signed`)
 
 ## [v2.3.2] -- 2026-07-29
 

--- a/cmd/aws-sso/ecs_cmd_e2e_test.go
+++ b/cmd/aws-sso/ecs_cmd_e2e_test.go
@@ -409,7 +409,6 @@ func TestE2EEcsServerRun(t *testing.T) {
 		BindIP:      "127.0.0.1",
 		Port:        port,
 		DisableAuth: true,
-		DisableSSL:  true,
 	}
 	cc := &ctx.Cli.Ecs.Server
 
@@ -454,7 +453,6 @@ func TestE2EEcsServerRunWithDefault(t *testing.T) {
 		BindIP:      "127.0.0.1",
 		Port:        port,
 		DisableAuth: true,
-		DisableSSL:  true,
 		Default:     "123456789012:ReadOnly",
 	}
 	cc := &ctx.Cli.Ecs.Server
@@ -513,9 +511,8 @@ func TestE2EEcsServerRunWithAuth(t *testing.T) {
 		Ctx:      cctx,
 	}
 	ctx.Cli.Ecs.Server = EcsServerCmd{
-		BindIP:     "127.0.0.1",
-		Port:       port,
-		DisableSSL: true,
+		BindIP: "127.0.0.1",
+		Port:   port,
 		// DisableAuth is false: bearer token from store will be enforced.
 	}
 	cc := &ctx.Cli.Ecs.Server

--- a/cmd/aws-sso/ecs_docker_cmd.go
+++ b/cmd/aws-sso/ecs_docker_cmd.go
@@ -47,7 +47,6 @@ type EcsDockerCmd struct {
 
 type EcsDockerStartCmd struct {
 	DisableAuth bool   `kong:"help='Disable HTTP Auth for the ECS Docker Server'"`
-	DisableSSL  bool   `kong:"help='Disable SSL/TLS for the ECS Docker Server'"`
 	BindIP      string `kong:"help='Host IP address to bind to the ECS Server',default='127.0.0.1'"`
 	Port        string `kong:"help='Host port to bind to the ECS Server',default='4144'"`
 	Image       string `kong:"help='ECS Server docker image',default='synfinatic/aws-sso-cli-ecs-server'"`
@@ -74,15 +73,13 @@ func (cc *EcsDockerStartCmd) Run(ctx *RunContext) error {
 
 	var privateKey, certChain, bearerToken string
 
-	if !ctx.Cli.Ecs.Docker.Start.DisableSSL {
-		privateKey, err = ctx.Store.GetEcsSslKey()
-		if err != nil {
-			return err
-		}
-		certChain, err = ctx.Store.GetEcsSslCert()
-		if err != nil {
-			return err
-		}
+	privateKey, err = ctx.Store.GetEcsSslKey()
+	if err != nil {
+		return err
+	}
+	certChain, err = ctx.Store.GetEcsSslCert()
+	if err != nil {
+		return err
 	}
 
 	if !ctx.Cli.Ecs.Docker.Start.DisableAuth {
@@ -174,7 +171,7 @@ func (cc *EcsDockerStartCmd) Run(ctx *RunContext) error {
 		// Use http when no cert chain is configured — the server requires both privateKey
 		// and certChain to enable TLS; certChain alone is not sufficient.
 		proto := "http"
-		if !cc.DisableSSL && privateKey != "" && certChain != "" {
+		if privateKey != "" && certChain != "" {
 			proto = "https"
 		}
 		serverAddr := fmt.Sprintf("%s:%s", cc.BindIP, cc.Port)
@@ -203,7 +200,6 @@ func (cc *EcsDockerStartCmd) Run(ctx *RunContext) error {
 
 type EcsDockerWriteConfigCmd struct {
 	DisableAuth bool `kong:"help='Do not include the HTTP Auth bearer token in the config file'"`
-	DisableSSL  bool `kong:"help='Do not include the SSL cert/key in the config file'"`
 }
 
 // AfterApply determines if SSO auth token is required
@@ -221,13 +217,11 @@ func (cc *EcsDockerWriteConfigCmd) Run(ctx *RunContext) error {
 	var privateKey, certChain, bearerToken string
 	var err error
 
-	if !cc.DisableSSL {
-		if privateKey, err = ctx.Store.GetEcsSslKey(); err != nil {
-			return err
-		}
-		if certChain, err = ctx.Store.GetEcsSslCert(); err != nil {
-			return err
-		}
+	if privateKey, err = ctx.Store.GetEcsSslKey(); err != nil {
+		return err
+	}
+	if certChain, err = ctx.Store.GetEcsSslCert(); err != nil {
+		return err
 	}
 
 	if !cc.DisableAuth {

--- a/cmd/aws-sso/ecs_docker_cmd_test.go
+++ b/cmd/aws-sso/ecs_docker_cmd_test.go
@@ -189,7 +189,11 @@ func TestEcsDockerWriteConfigCmdRun(t *testing.T) {
 	assert.Equal(t, certPEM, sec.CertChain)
 }
 
-func TestEcsDockerWriteConfigCmdRunDisabled(t *testing.T) {
+// TestEcsDockerWriteConfigCmdRunDisableAuth verifies --disable-auth omits the
+// bearer token from the written config, while the SSL cert/key already in the
+// store is still written unconditionally: SSL is no longer independently
+// toggleable here, only controlled by whether a cert is stored.
+func TestEcsDockerWriteConfigCmdRunDisableAuth(t *testing.T) {
 	home := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(home, ".config", "aws-sso"), 0700))
 	t.Setenv("HOME", home)
@@ -202,7 +206,7 @@ func TestEcsDockerWriteConfigCmdRunDisabled(t *testing.T) {
 	require.NoError(t, store.SaveEcsSslKeyPair(context.Background(), []byte(keyPEM), []byte(certPEM)))
 
 	ctx := &RunContext{Store: store}
-	cc := &EcsDockerWriteConfigCmd{DisableAuth: true, DisableSSL: true}
+	cc := &EcsDockerWriteConfigCmd{DisableAuth: true}
 	require.NoError(t, cc.Run(ctx))
 
 	path := filepath.Join(home, ".aws-sso", "mnt", "docker-ecs")
@@ -212,6 +216,6 @@ func TestEcsDockerWriteConfigCmdRunDisabled(t *testing.T) {
 	sec := &ecs.ECSSecurity{}
 	require.NoError(t, json.Unmarshal(data, sec))
 	assert.Empty(t, sec.BearerToken)
-	assert.Empty(t, sec.PrivateKey)
-	assert.Empty(t, sec.CertChain)
+	assert.Equal(t, keyPEM, sec.PrivateKey)
+	assert.Equal(t, certPEM, sec.CertChain)
 }

--- a/cmd/aws-sso/ecs_server_cmd.go
+++ b/cmd/aws-sso/ecs_server_cmd.go
@@ -37,7 +37,6 @@ type EcsServerCmd struct {
 	// hidden flags are for internal use only when running in a docker container
 	Docker      bool `kong:"hidden"`
 	DisableAuth bool `kong:"help='Disable HTTP Auth for the ECS Server'"`
-	DisableSSL  bool `kong:"help='Disable SSL/TLS for the ECS Server'"`
 }
 
 // AfterApply determines if SSO auth token is required
@@ -98,12 +97,6 @@ func (cc *EcsServerCmd) Run(ctx *RunContext) error {
 		}
 	}
 
-	// Disable SSL, even if configure
-	if ctx.Cli.Ecs.Server.DisableSSL {
-		privateKey = ""
-		certChain = ""
-	}
-
 	if ctx.Cli.Ecs.Server.DisableAuth {
 		bearerToken = ""
 	}
@@ -116,7 +109,7 @@ func (cc *EcsServerCmd) Run(ctx *RunContext) error {
 
 	if privateKey != "" && certChain != "" {
 		log.Info("SSL/TLS: enabled")
-	} else if !ctx.Cli.Ecs.Server.DisableSSL {
+	} else {
 		log.Warn("SSL/TLS: disabled.  Use 'aws-sso setup ecs ssl' to enable")
 	}
 

--- a/cmd/aws-sso/setup_cmd.go
+++ b/cmd/aws-sso/setup_cmd.go
@@ -71,7 +71,8 @@ func (cc *EcsAuthCmd) Run(ctx *RunContext) error {
 const EcsCaTrustDocsURL = "https://github.com/synfinatic/aws-sso-cli/blob/main/docs/ecs-server.md#trusting-the-ca"
 
 type EcsSSLCmd struct {
-	Delete     bool `kong:"short=d,help='Disable SSL and delete the current SSL cert/key and CA',xor='flag'"`
+	Delete     bool `kong:"short=d,help='Delete the current SSL leaf cert/key',xor='flag'"`
+	DeleteCa   bool `kong:"help='Delete the local CA (requires the SSL cert to already be deleted)',xor='flag'"`
 	PrintCa    bool `kong:"help='Print the local self-signed CA certificate in PEM format',xor='flag'"`
 	SelfSigned bool `kong:"help='Generate (or reuse) a local CA and issue a new leaf certificate for the ECS Server',xor='flag'"`
 }
@@ -85,10 +86,10 @@ func (e EcsSSLCmd) AfterApply(runCtx *RunContext) error {
 func (cc *EcsSSLCmd) Run(ctx *RunContext) error {
 	switch {
 	case cc.Delete:
-		if err := ctx.Store.DeleteEcsSslKeyPair(ctx.Ctx); err != nil {
-			return err
-		}
-		return ctx.Store.DeleteEcsCaKeyPair(ctx.Ctx)
+		return ctx.Store.DeleteEcsSslKeyPair(ctx.Ctx)
+
+	case cc.DeleteCa:
+		return cc.runDeleteCa(ctx)
 
 	case cc.PrintCa:
 		caCert, err := ctx.Store.GetEcsCaCert()
@@ -107,8 +108,23 @@ func (cc *EcsSSLCmd) Run(ctx *RunContext) error {
 		return cc.runSelfSigned(ctx)
 
 	default:
-		return fmt.Errorf("must specify one of --delete, --print-ca, or --self-signed")
+		return fmt.Errorf("must specify one of --delete, --delete-ca, --print-ca, or --self-signed")
 	}
+}
+
+// runDeleteCa deletes the local CA, but only once the leaf cert it signed has
+// already been deleted. Deleting the CA out from under a live leaf can't be
+// undone, so requiring the leaf to go first forces that destructive step to be
+// explicit rather than implicit.
+func (cc *EcsSSLCmd) runDeleteCa(ctx *RunContext) error {
+	sslCert, err := ctx.Store.GetEcsSslCert()
+	if err != nil {
+		return err
+	}
+	if sslCert != "" {
+		return fmt.Errorf("the SSL cert must be deleted first; run 'aws-sso setup ecs ssl --delete' before --delete-ca")
+	}
+	return ctx.Store.DeleteEcsCaKeyPair(ctx.Ctx)
 }
 
 // runSelfSigned reuses the existing local CA (generating one if none exists

--- a/cmd/aws-sso/setup_cmd_e2e_test.go
+++ b/cmd/aws-sso/setup_cmd_e2e_test.go
@@ -49,7 +49,8 @@ func isolateHomeForCaExport(t *testing.T) string {
 }
 
 // TestE2ESetupEcsSSL_SelfSigned exercises the full `setup ecs ssl --self-signed`
-// lifecycle: generate, rerun (CA reused, leaf rotates), --print, --print-ca, and --delete.
+// lifecycle: generate, rerun (CA reused, leaf rotates), --print-ca, --delete
+// (leaf only), and --delete-ca (leaf must already be gone).
 func TestE2ESetupEcsSSL_SelfSigned(t *testing.T) {
 	isolateHomeForCaExport(t)
 
@@ -85,16 +86,23 @@ func TestE2ESetupEcsSSL_SelfSigned(t *testing.T) {
 	assert.Equal(t, caCert2, caOutput,
 		"--print-ca should print the CA certificate PEM and nothing else, not even a trailing newline")
 
-	// --- Delete: --delete clears both CA and leaf ---
+	// --- Delete: --delete clears only the leaf, CA stays intact ---
 	require.NoError(t, (&EcsSSLCmd{Delete: true}).Run(ctx))
 
-	afterCA, err := setup.Store.GetEcsCaCert()
+	afterDeleteCA, err := setup.Store.GetEcsCaCert()
 	require.NoError(t, err)
-	assert.Empty(t, afterCA)
+	assert.NotEmpty(t, afterDeleteCA, "--delete must not remove the CA")
 
-	afterLeaf, err := setup.Store.GetEcsSslCert()
+	afterDeleteLeaf, err := setup.Store.GetEcsSslCert()
 	require.NoError(t, err)
-	assert.Empty(t, afterLeaf)
+	assert.Empty(t, afterDeleteLeaf)
+
+	// --- Delete CA: --delete-ca now succeeds since the leaf is already gone ---
+	require.NoError(t, (&EcsSSLCmd{DeleteCa: true}).Run(ctx))
+
+	afterDeleteCaCA, err := setup.Store.GetEcsCaCert()
+	require.NoError(t, err)
+	assert.Empty(t, afterDeleteCaCA)
 }
 
 // TestE2EEcsServerSSL_SelfSigned_ChainOfTrust proves real chain-of-trust (not

--- a/cmd/aws-sso/setup_cmd_test.go
+++ b/cmd/aws-sso/setup_cmd_test.go
@@ -29,6 +29,7 @@ type errStore struct {
 	saveEcsCaKeyPairErr    error
 	saveEcsSslKeyPairErr   error
 	deleteEcsSslKeyPairErr error
+	deleteEcsCaKeyPairErr  error
 }
 
 func (e *errStore) GetEcsSslCert() (string, error) {
@@ -71,6 +72,13 @@ func (e *errStore) DeleteEcsSslKeyPair(ctx context.Context) error {
 		return e.deleteEcsSslKeyPairErr
 	}
 	return e.SecureStorage.DeleteEcsSslKeyPair(ctx)
+}
+
+func (e *errStore) DeleteEcsCaKeyPair(ctx context.Context) error {
+	if e.deleteEcsCaKeyPairErr != nil {
+		return e.deleteEcsCaKeyPairErr
+	}
+	return e.SecureStorage.DeleteEcsCaKeyPair(ctx)
 }
 
 // captureTestStdout runs fn with os.Stdout redirected and returns everything
@@ -134,7 +142,7 @@ func TestEcsSSLCmdRun_NoFlagSet(t *testing.T) {
 	cmd := &EcsSSLCmd{}
 	err := cmd.Run(ctx)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "must specify one of --delete, --print-ca, or --self-signed")
+	assert.Contains(t, err.Error(), "must specify one of --delete, --delete-ca, --print-ca, or --self-signed")
 }
 
 func newSelfSignedTestCtx(t *testing.T) *RunContext {
@@ -211,18 +219,62 @@ func TestEcsSSLCmdRun_SelfSigned_RerunReusesCA(t *testing.T) {
 	assert.NotEqual(t, leafCert1, leafCert2, "leaf certificate should rotate on rerun")
 }
 
-func TestEcsSSLCmdRun_Delete_ClearsCaAndLeaf(t *testing.T) {
+func TestEcsSSLCmdRun_Delete_ClearsLeafOnly(t *testing.T) {
 	ctx := newSelfSignedTestCtx(t)
 	require.NoError(t, (&EcsSSLCmd{SelfSigned: true}).Run(ctx))
 	require.NoError(t, (&EcsSSLCmd{Delete: true}).Run(ctx))
 
+	// --delete must not touch the CA: rotating/removing the leaf shouldn't
+	// force every client to re-trust a new CA.
 	caCert, err := ctx.Store.GetEcsCaCert()
 	require.NoError(t, err)
-	assert.Empty(t, caCert)
+	assert.NotEmpty(t, caCert)
 
 	leafCert, err := ctx.Store.GetEcsSslCert()
 	require.NoError(t, err)
 	assert.Empty(t, leafCert)
+}
+
+func TestEcsSSLCmdRun_DeleteCa_RequiresLeafDeletedFirst(t *testing.T) {
+	ctx := newSelfSignedTestCtx(t)
+	require.NoError(t, (&EcsSSLCmd{SelfSigned: true}).Run(ctx))
+
+	err := (&EcsSSLCmd{DeleteCa: true}).Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--delete")
+
+	// Nothing should have been deleted.
+	caCert, err := ctx.Store.GetEcsCaCert()
+	require.NoError(t, err)
+	assert.NotEmpty(t, caCert)
+}
+
+func TestEcsSSLCmdRun_DeleteCa_Succeeds(t *testing.T) {
+	ctx := newSelfSignedTestCtx(t)
+	require.NoError(t, (&EcsSSLCmd{SelfSigned: true}).Run(ctx))
+	require.NoError(t, (&EcsSSLCmd{Delete: true}).Run(ctx))
+	require.NoError(t, (&EcsSSLCmd{DeleteCa: true}).Run(ctx))
+
+	caCert, err := ctx.Store.GetEcsCaCert()
+	require.NoError(t, err)
+	assert.Empty(t, caCert)
+}
+
+func TestEcsSSLCmdRun_DeleteCa_GetSslCertError(t *testing.T) {
+	ctx := newSelfSignedTestCtx(t)
+	ctx.Store = &errStore{SecureStorage: ctx.Store, getEcsSslCertErr: errors.New("boom")}
+	err := (&EcsSSLCmd{DeleteCa: true}).Run(ctx)
+	assert.ErrorContains(t, err, "boom")
+}
+
+func TestEcsSSLCmdRun_DeleteCa_DeleteError(t *testing.T) {
+	ctx := newSelfSignedTestCtx(t)
+	require.NoError(t, (&EcsSSLCmd{SelfSigned: true}).Run(ctx))
+	require.NoError(t, (&EcsSSLCmd{Delete: true}).Run(ctx))
+
+	ctx.Store = &errStore{SecureStorage: ctx.Store, deleteEcsCaKeyPairErr: errors.New("boom")}
+	err := (&EcsSSLCmd{DeleteCa: true}).Run(ctx)
+	assert.ErrorContains(t, err, "boom")
 }
 
 func TestEcsSSLCmdRun_PrintCa_NoCa(t *testing.T) {

--- a/docs/ecs-commands.md
+++ b/docs/ecs-commands.md
@@ -32,11 +32,12 @@ Flags:
 * `--self-signed` -- Generate (or reuse) a local CA and issue a new leaf certificate for the ECS
   Server (recommended)
 * `--print-ca` -- Print the local self-signed CA certificate in PEM format
-* `--delete` -- Disables SSL and deletes both the SSL certificate/key and the local CA from the
-  Secure Store
+* `--delete` -- Deletes the current SSL leaf certificate/key from the Secure Store
+* `--delete-ca` -- Deletes the local CA from the Secure Store; requires the SSL leaf
+  certificate/key to already be deleted with `--delete`
 
 To force regeneration of a brand new CA (requiring re-trusting on every client), run
-`--delete` followed by `--self-signed`.
+`--delete`, then `--delete-ca`, then `--self-signed`.
 
 ---
 
@@ -47,7 +48,6 @@ Starts the ECS Server in a Docker container.
 Flags:
 
 * `--disable-auth` -- Disables HTTP Auth, even if a bearer token is available
-* `--disable-ssl` -- Disables SSL/TLS, even if a certificate and private key are available.
 * `--bind-ip` -- IP address to bind the service to.  (default 127.0.0.1)
 * `--port` -- Port to listen on.  (default 4144)
 * `--image` -- Docker image to use.  (default `synfinatic/aws-sso-cli-ecs-version`)
@@ -74,7 +74,6 @@ once read, so re-run this command before every `docker compose up`.
 Flags:
 
 * `--disable-auth` -- Do not include the HTTP Auth bearer token in the config file
-* `--disable-ssl` -- Do not include the SSL cert/key in the config file
 
 ---
 
@@ -125,7 +124,6 @@ Starts the ECS Server in the foreground.
 Flags:
 
 * `--disable-auth` -- Disables HTTP Authentication, even if a Bearer Token is available
-* `--disable-ssl` -- Disables SSL/TLS, even if a certificate and private key are available
 
 ---
 

--- a/docs/ecs-server.md
+++ b/docs/ecs-server.md
@@ -102,15 +102,17 @@ same place `aws-sso ecs server` reads the leaf cert/key from.
 Rerunning `--self-signed` reuses the existing CA and only issues a new leaf, so
 after the first run you never need to re-trust anything — just rerun it whenever
 the leaf is close to expiring (30 days). If you need to force a brand new CA,
-run `--delete` followed by `--self-signed`, which does require repeating the
-trust steps everywhere.
+run `--delete`, then `--delete-ca`, then `--self-signed`, which does require
+repeating the trust steps everywhere.
 
 Once the leaf has fewer than 5 days of validity left, `aws-sso ecs server` logs a warning
 every time new IAM role credentials are loaded, as a reminder to rerun `--self-signed`.
 
 Once you have generated the CA/leaf certificate, future invocations of the aws-sso
-ECS Server will automatically disable HTTP and enable HTTPS unless the user specifies
-`--disable-ssl`.
+ECS Server will automatically disable HTTP and enable HTTPS. There is no flag to
+force HTTP while a certificate is stored — run `aws-sso setup ecs ssl --delete`
+to disable SSL/TLS instead (see [Deleting the certificate](#deleting-the-certificate)
+below).
 
 **Note:** `aws-sso` provides no command to export the CA private key — `--print-ca` prints only the
 certificate. How well the key itself is protected is down to your
@@ -120,15 +122,26 @@ certificate. How well the key itself is protected is down to your
 See [Trusting the CA](#trusting-the-ca) below for how to trust this certificate in your OS and
 in each AWS SDK runtime.
 
-### Deleting the CA
+### Deleting the certificate
 
-To remove both the CA and the leaf certificate/key from the secure store:
+To remove just the leaf certificate/key from the secure store, leaving the CA intact:
 
 ```bash
 aws-sso setup ecs ssl --delete
 ```
 
-This will automatically disable HTTPS and re-enable HTTP for the ECS Server.
+This will automatically disable HTTPS and re-enable HTTP for the ECS Server. Since the
+CA is untouched, rerunning `--self-signed` afterward reissues a leaf from the same CA
+and nothing needs to be re-trusted.
+
+### Deleting the CA
+
+The CA can only be deleted once the leaf certificate/key is already gone (run
+`--delete` first, above):
+
+```bash
+aws-sso setup ecs ssl --delete-ca
+```
 
 This only removes the CA from the secure store — anything you trusted it in keeps trusting it.
 See [Untrusting the CA](#untrusting-the-ca) below, and note the fingerprint printed by
@@ -143,8 +156,8 @@ aws-sso setup ecs ssl --print-ca > /tmp/ecs-ca.pem
 ```
 
 The CA is reused (not regenerated) every time you rerun `--self-signed`, so you only need to
-export and trust it once per machine/runtime below — only `--delete` followed by `--self-signed`
-will require repeating these steps.
+export and trust it once per machine/runtime below — only `--delete`, `--delete-ca`, and then
+`--self-signed` will require repeating these steps.
 
 `--self-signed` prints the CA's SHA-256 fingerprint on every run. Compare it with the fingerprint
 your OS or runtime trust store shows for `aws-sso-cli ECS Server CA` to confirm you trusted the
@@ -298,15 +311,16 @@ certutil -addstore -user Root %USERPROFILE%\ecs-ca.pem
 
 ### Untrusting the CA
 
-`aws-sso setup ecs ssl --delete` removes the CA from the secure store, but nothing outside
+`aws-sso setup ecs ssl --delete-ca` removes the CA from the secure store, but nothing outside
 `aws-sso` learns about that — every copy you installed above stays trusted. Since forcing a new CA
-means `--delete` followed by `--self-signed`, rotating without removing the old root leaves a dead
-trusted CA behind each time, so undo the steps above before generating a replacement.
+means `--delete`, `--delete-ca`, and then `--self-signed`, rotating without removing the old root
+leaves a dead trusted CA behind each time, so undo the steps above before generating a
+replacement.
 
 Every generated CA shares the common name `aws-sso-cli ECS Server CA`, so if several have already
 accumulated, use the SHA-256 fingerprint to tell them apart. `--self-signed` prints it, and
 `openssl x509 -in /tmp/ecs-ca.pem -noout -fingerprint -sha256` reads it back from an exported
-copy — but do that _before_ `--delete`, which leaves you with no way to work out which stored
+copy — but do that _before_ `--delete-ca`, which leaves you with no way to work out which stored
 certificate was which.
 
 **macOS** — `-t` removes the trust setting as well as the certificate itself:
@@ -513,17 +527,19 @@ profile name if it contains special characters).
 Unlike `aws-sso ecs docker start`, `docker compose` does not automatically provision
 your configured bearer token or SSL certificate/key into the container. If you have
 either configured (via `aws-sso setup ecs auth` and/or `aws-sso setup ecs ssl`), run
-`aws-sso ecs docker write-config --disable-ssl` before every `docker compose up` to write the
-bearer token to `~/.aws-sso/mnt/docker-ecs`, which the container reads on startup and then
-deletes.  See [Why SSL is not needed here](#why-ssl-is-not-needed-here) below for why this
-example skips the certificate.
+`aws-sso ecs docker write-config` before every `docker compose up` to write whatever is
+currently in the SecureStore to `~/.aws-sso/mnt/docker-ecs`, which the container reads
+on startup and then deletes. This example intentionally has no SSL certificate
+configured (see [Why SSL is not needed here](#why-ssl-is-not-needed-here) below) — if
+you previously ran `--self-signed`, run `aws-sso setup ecs ssl --delete` first so
+`write-config` has no certificate to pick up.
 Otherwise the container starts with HTTP Auth disabled, and any client (including
 `aws-sso ecs list`) that still sends a bearer token from a previously configured
 SecureStore will be rejected with a `403 Forbidden`.
 
 ```bash
 export AWS_SSO_ECS_TOKEN='<the token you passed to aws-sso setup ecs auth>'
-aws-sso ecs docker write-config --disable-ssl
+aws-sso ecs docker write-config
 docker compose up &
 aws-sso ecs load ...
 ```
@@ -541,15 +557,16 @@ which is otherwise more setup than needed for a local endpoint (see
 already include `169.254.170.2`).
 Credentials stay on the Docker bridge network and access is controlled by the bearer token.
 
-If you leave off `--disable-ssl` while you have a certificate loaded, the container serves HTTPS
-instead, and `myapp` would have to use `https://169.254.170.2:4144` with a certificate the AWS
-SDK trusts _for that IP address_ -- which no public CA will issue.
+If you still have a certificate loaded (run `aws-sso setup ecs ssl --delete` to remove
+it), the container serves HTTPS instead, and `myapp` would have to use
+`https://169.254.170.2:4144` with a certificate the AWS SDK trusts _for that IP
+address_ -- which no public CA will issue.
 
 ```yaml
-# Run `aws-sso ecs docker write-config --disable-ssl` before every `docker compose up`
-# to provision the bearer token into ${HOME}/.aws-sso/mnt/docker-ecs (deleted by the
-# container after it reads it), otherwise this starts with HTTP Auth disabled and any
-# client still sending a configured bearer token will get a 403.
+# Run `aws-sso ecs docker write-config` before every `docker compose up` to provision
+# the bearer token into ${HOME}/.aws-sso/mnt/docker-ecs (deleted by the container after
+# it reads it), otherwise this starts with HTTP Auth disabled and any client still
+# sending a configured bearer token will get a 403.
 networks:
   aws-sso-ecs:
     driver: bridge


### PR DESCRIPTION
## Summary
- `setup ecs ssl --delete` now only deletes the SSL leaf cert/key; the CA is preserved so `--self-signed` can reissue a leaf without anyone needing to re-trust anything.
- Added `setup ecs ssl --delete-ca` to delete the CA, gated on the leaf cert already being deleted (`--delete` first) so the destructive, unrecoverable step is always explicit.
- Removed the now-redundant `--disable-ssl` flags from `ecs server`, `ecs docker start`, and `ecs docker write-config` -- SSL is controlled purely by whether a cert is stored, restoring a single source of truth for "is SSL on" across all commands.
- Updated `docs/ecs-commands.md` and `docs/ecs-server.md` (CA rotation instructions, Docker Compose example) and added CHANGELOG entries.

## Test plan
- [x] `make unittest` / `go test ./...`
- [x] `make e2e` / `go test -tags e2etests ./...`
- [x] `make lint`, `gofmt -s -l .`, `go mod tidy` (no diff)
- [x] Manual CLI lifecycle test (`--self-signed` -> `--delete` -> `--print-ca` -> `--delete-ca` -> `--print-ca` (fails) -> `--self-signed` -> `--delete-ca` without deleting leaf first (fails with expected error))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CTduufKifrXxXyGo8WP3Vt