### PR TITLE
Rename ecs docker write-config to write-secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Add `setup ecs ssl --self-signed` to create a self-signed CA and leaf cert for the ECS Server,
   scoped so it can't sign for other hosts; prints the CA's SHA-256 fingerprint for verification
 * Add `login --force` to start a new SSO session, resetting its duration #1455
-* Add `ecs docker write-config`
+* Add `ecs docker write-secrets`
 * The ECS Server now logs a warning whenever IAM role credentials are loaded if its
   TLS cert has fewer than 5 days of validity left
 
@@ -32,7 +32,7 @@
   self-signed CA (`--self-signed`) is supported now
 * `setup ecs ssl --delete` now only deletes the SSL leaf cert/key; add `setup ecs ssl
   --delete-ca` to delete the CA, which requires the leaf to already be deleted
-* Remove `ecs server --disable-ssl`, `ecs docker start --disable-ssl`, and `ecs docker write-config
+* Remove `ecs server --disable-ssl`, `ecs docker start --disable-ssl`, and `ecs docker write-secrets
   --disable-ssl` -- SSL is now controlled by whether a certificate is stored
 
 ## [v2.3.2] -- 2026-07-29

--- a/cmd/aws-sso/ecs_docker_cmd.go
+++ b/cmd/aws-sso/ecs_docker_cmd.go
@@ -40,9 +40,9 @@ const (
 )
 
 type EcsDockerCmd struct {
-	Start       EcsDockerStartCmd       `kong:"cmd,help='Start the ECS Server in a Docker container'"`
-	Stop        EcsDockerStopCmd        `kong:"cmd,help='Stop the ECS Server Docker container'"`
-	WriteConfig EcsDockerWriteConfigCmd `kong:"cmd,help='Write the ECS security config file for use with Docker Compose or other non-aws-sso launchers'"`
+	Start        EcsDockerStartCmd        `kong:"cmd,help='Start the ECS Server in a Docker container'"`
+	Stop         EcsDockerStopCmd         `kong:"cmd,help='Stop the ECS Server Docker container'"`
+	WriteSecrets EcsDockerWriteSecretsCmd `kong:"cmd,help='Write the ECS security config file for use with Docker Compose or other non-aws-sso launchers'"`
 }
 
 type EcsDockerStartCmd struct {
@@ -198,12 +198,12 @@ func (cc *EcsDockerStartCmd) Run(ctx *RunContext) error {
 	return nil
 }
 
-type EcsDockerWriteConfigCmd struct {
+type EcsDockerWriteSecretsCmd struct {
 	DisableAuth bool `kong:"help='Do not include the HTTP Auth bearer token in the config file'"`
 }
 
 // AfterApply determines if SSO auth token is required
-func (e EcsDockerWriteConfigCmd) AfterApply(runCtx *RunContext) error {
+func (e EcsDockerWriteSecretsCmd) AfterApply(runCtx *RunContext) error {
 	runCtx.Auth = AUTH_SKIP
 	return nil
 }
@@ -213,7 +213,7 @@ func (e EcsDockerWriteConfigCmd) AfterApply(runCtx *RunContext) error {
 // starting or managing a container. This lets tools that own the container lifecycle
 // themselves, like `docker compose`, still provision the bearer token / SSL material
 // that `EcsDockerStartCmd` would otherwise write just before starting the container.
-func (cc *EcsDockerWriteConfigCmd) Run(ctx *RunContext) error {
+func (cc *EcsDockerWriteSecretsCmd) Run(ctx *RunContext) error {
 	var privateKey, certChain, bearerToken string
 	var err error
 

--- a/cmd/aws-sso/ecs_docker_cmd_test.go
+++ b/cmd/aws-sso/ecs_docker_cmd_test.go
@@ -155,14 +155,14 @@ func TestLoadProfileToEcsServerNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "nonexistent-profile")
 }
 
-func TestEcsDockerWriteConfigCmdAfterApply(t *testing.T) {
+func TestEcsDockerWriteSecretsCmdAfterApply(t *testing.T) {
 	runCtx := &RunContext{}
-	err := EcsDockerWriteConfigCmd{}.AfterApply(runCtx)
+	err := EcsDockerWriteSecretsCmd{}.AfterApply(runCtx)
 	require.NoError(t, err)
 	assert.Equal(t, AUTH_SKIP, runCtx.Auth)
 }
 
-func TestEcsDockerWriteConfigCmdRun(t *testing.T) {
+func TestEcsDockerWriteSecretsCmdRun(t *testing.T) {
 	home := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(home, ".config", "aws-sso"), 0700))
 	t.Setenv("HOME", home)
@@ -175,7 +175,7 @@ func TestEcsDockerWriteConfigCmdRun(t *testing.T) {
 	require.NoError(t, store.SaveEcsSslKeyPair(context.Background(), []byte(keyPEM), []byte(certPEM)))
 
 	ctx := &RunContext{Store: store}
-	cc := &EcsDockerWriteConfigCmd{}
+	cc := &EcsDockerWriteSecretsCmd{}
 	require.NoError(t, cc.Run(ctx))
 
 	path := filepath.Join(home, ".aws-sso", "mnt", "docker-ecs")
@@ -189,11 +189,11 @@ func TestEcsDockerWriteConfigCmdRun(t *testing.T) {
 	assert.Equal(t, certPEM, sec.CertChain)
 }
 
-// TestEcsDockerWriteConfigCmdRunDisableAuth verifies --disable-auth omits the
+// TestEcsDockerWriteSecretsCmdRunDisableAuth verifies --disable-auth omits the
 // bearer token from the written config, while the SSL cert/key already in the
 // store is still written unconditionally: SSL is no longer independently
 // toggleable here, only controlled by whether a cert is stored.
-func TestEcsDockerWriteConfigCmdRunDisableAuth(t *testing.T) {
+func TestEcsDockerWriteSecretsCmdRunDisableAuth(t *testing.T) {
 	home := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(home, ".config", "aws-sso"), 0700))
 	t.Setenv("HOME", home)
@@ -206,7 +206,7 @@ func TestEcsDockerWriteConfigCmdRunDisableAuth(t *testing.T) {
 	require.NoError(t, store.SaveEcsSslKeyPair(context.Background(), []byte(keyPEM), []byte(certPEM)))
 
 	ctx := &RunContext{Store: store}
-	cc := &EcsDockerWriteConfigCmd{DisableAuth: true}
+	cc := &EcsDockerWriteSecretsCmd{DisableAuth: true}
 	require.NoError(t, cc.Run(ctx))
 
 	path := filepath.Join(home, ".aws-sso", "mnt", "docker-ecs")

--- a/docs/ecs-commands.md
+++ b/docs/ecs-commands.md
@@ -61,7 +61,7 @@ Stops the ECS Server Docker container.
 
 ---
 
-### ecs docker write-config
+### ecs docker write-secrets
 
 Writes the bearer token and/or SSL certificate/private key from the SecureStore
 to the security config file (`~/.aws-sso/mnt/docker-ecs`) read by the ECS Server

--- a/docs/ecs-server.md
+++ b/docs/ecs-server.md
@@ -527,19 +527,19 @@ profile name if it contains special characters).
 Unlike `aws-sso ecs docker start`, `docker compose` does not automatically provision
 your configured bearer token or SSL certificate/key into the container. If you have
 either configured (via `aws-sso setup ecs auth` and/or `aws-sso setup ecs ssl`), run
-`aws-sso ecs docker write-config` before every `docker compose up` to write whatever is
+`aws-sso ecs docker write-secrets` before every `docker compose up` to write whatever is
 currently in the SecureStore to `~/.aws-sso/mnt/docker-ecs`, which the container reads
 on startup and then deletes. This example intentionally has no SSL certificate
 configured (see [Why SSL is not needed here](#why-ssl-is-not-needed-here) below) — if
 you previously ran `--self-signed`, run `aws-sso setup ecs ssl --delete` first so
-`write-config` has no certificate to pick up.
+`write-secrets` has no certificate to pick up.
 Otherwise the container starts with HTTP Auth disabled, and any client (including
 `aws-sso ecs list`) that still sends a bearer token from a previously configured
 SecureStore will be rejected with a `403 Forbidden`.
 
 ```bash
 export AWS_SSO_ECS_TOKEN='<the token you passed to aws-sso setup ecs auth>'
-aws-sso ecs docker write-config
+aws-sso ecs docker write-secrets
 docker compose up &
 aws-sso ecs load ...
 ```
@@ -563,7 +563,7 @@ it), the container serves HTTPS instead, and `myapp` would have to use
 address_ -- which no public CA will issue.
 
 ```yaml
-# Run `aws-sso ecs docker write-config` before every `docker compose up` to provision
+# Run `aws-sso ecs docker write-secrets` before every `docker compose up` to provision
 # the bearer token into ${HOME}/.aws-sso/mnt/docker-ecs (deleted by the container after
 # it reads it), otherwise this starts with HTTP Auth disabled and any client still
 # sending a configured bearer token will get a 403.
@@ -584,7 +584,7 @@ services:
         ipv4_address: "169.254.170.2"
       default: {}
     volumes:
-      # necessary for the container to read the security config written by write-config
+      # necessary for the container to read the security config written by write-secrets
       - ${HOME}/.aws-sso/mnt:/app/.aws-sso/mnt
     ports:
       # necessary for local management
@@ -601,7 +601,7 @@ services:
     environment:
       AWS_CONTAINER_CREDENTIALS_FULL_URI: http://169.254.170.2:4144
       # must match the token stored via `aws-sso setup ecs auth`.  Omit this (and run
-      # `write-config --disable-auth`) only if you are not using HTTP Auth.
+      # `write-secrets --disable-auth`) only if you are not using HTTP Auth.
       AWS_CONTAINER_AUTHORIZATION_TOKEN: "Bearer ${AWS_SSO_ECS_TOKEN}"
     networks:
       aws-sso-ecs: {}


### PR DESCRIPTION
## Summary
- Renames the `ecs docker write-config` subcommand to `ecs docker write-secrets` — the command writes the bearer token and TLS key/cert, not general config, so `write-secrets` better describes its purpose
- Still `Unreleased`, so no back-compat alias/deprecation path is needed

## Test plan
- [x] `make unittest` — `cmd/aws-sso` package passes
- [x] `make lint` — 0 issues
- [x] `gofmt -s -l` clean on edited Go files
- [x] `go mod tidy` — no diff
- [x] `./dist/aws-sso ecs docker --help` shows `write-secrets`, `write-config` is gone
- [x] Repo-wide grep for `write-config`/`WriteConfig` returns zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qSsDJSwk8TzRTDG5KYQmU