### PR TITLE
Fix nil-pointer panic risk and XDG_CONFIG_HOME test-isolation gap

### DIFF
--- a/cmd/aws-sso/ecs_docker_cmd_test.go
+++ b/cmd/aws-sso/ecs_docker_cmd_test.go
@@ -166,6 +166,7 @@ func TestEcsDockerWriteSecretsCmdRun(t *testing.T) {
 	home := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(home, ".config", "aws-sso"), 0700))
 	t.Setenv("HOME", home)
+	unsetEnvForTest(t, "XDG_CONFIG_HOME")
 
 	store, err := storage.OpenJsonStore(context.Background(), filepath.Join(home, "store.json"))
 	require.NoError(t, err)
@@ -197,6 +198,7 @@ func TestEcsDockerWriteSecretsCmdRunDisableAuth(t *testing.T) {
 	home := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(home, ".config", "aws-sso"), 0700))
 	t.Setenv("HOME", home)
+	unsetEnvForTest(t, "XDG_CONFIG_HOME")
 
 	store, err := storage.OpenJsonStore(context.Background(), filepath.Join(home, "store.json"))
 	require.NoError(t, err)

--- a/cmd/aws-sso/exec_cmd_test.go
+++ b/cmd/aws-sso/exec_cmd_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // unsetEnvForTest unsets key for the duration of the test, restoring it afterward.
@@ -139,7 +140,7 @@ func TestCheckAwsEnvironment(t *testing.T) {
 		}
 		t.Setenv("AWS_ACCESS_KEY_ID", "AKIATEST")
 		err := checkAwsEnvironment()
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "AWS_ACCESS_KEY_ID")
 	})
 
@@ -149,7 +150,7 @@ func TestCheckAwsEnvironment(t *testing.T) {
 		}
 		t.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
 		err := checkAwsEnvironment()
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "AWS_SECRET_ACCESS_KEY")
 	})
 
@@ -159,7 +160,7 @@ func TestCheckAwsEnvironment(t *testing.T) {
 		}
 		t.Setenv("AWS_PROFILE", "myprofile")
 		err := checkAwsEnvironment()
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "AWS_PROFILE")
 	})
 }

--- a/cmd/aws-sso/setup_cmd_e2e_test.go
+++ b/cmd/aws-sso/setup_cmd_e2e_test.go
@@ -45,6 +45,7 @@ func isolateHomeForCaExport(t *testing.T) string {
 	home := t.TempDir()
 	require.NoError(t, os.MkdirAll(filepath.Join(home, ".config", "aws-sso"), 0700))
 	t.Setenv("HOME", home)
+	unsetEnvForTest(t, "XDG_CONFIG_HOME")
 	return home
 }
 

--- a/cmd/aws-sso/setup_cmd_test.go
+++ b/cmd/aws-sso/setup_cmd_test.go
@@ -149,6 +149,10 @@ func newSelfSignedTestCtx(t *testing.T) *RunContext {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	// CI runners export a real XDG_CONFIG_HOME (e.g. /home/runner/.config), which
+	// config.ConfigDir() prefers over $HOME, so it must be cleared or this test's
+	// $HOME override leaks outside its isolated tmp dir.
+	unsetEnvForTest(t, "XDG_CONFIG_HOME")
 	// FlockFile() derives its path from config.ConfigDir(), which in turn
 	// resolves against $HOME; the lock file's parent directory must exist
 	// before any SecureStorage Save*/Delete* call runs.
@@ -415,6 +419,7 @@ func TestEcsSSLCmdRun_SelfSigned_GenerateLeafError(t *testing.T) {
 func TestEcsSSLCmdRun_SelfSigned_DoesNotWriteCaFile(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	unsetEnvForTest(t, "XDG_CONFIG_HOME")
 	require.NoError(t, os.MkdirAll(filepath.Join(home, ".config", "aws-sso"), 0700))
 	store := openTestStore(t)
 	ctx := &RunContext{


### PR DESCRIPTION
## Summary

- `assert.Error(t, err)` immediately followed by `err.Error()` panics the whole test binary if `err` ever comes back nil (soft assertion, then unconditional dereference). Switched the three such cases in `exec_cmd_test.go` to `require.Error`.
- Several tests override `$HOME` via `t.Setenv` without clearing `XDG_CONFIG_HOME`. `config.ConfigDir()` prefers `XDG_CONFIG_HOME` over `$HOME`, and CI runners export a real one (e.g. `/home/runner/.config`), so those tests' storage lock/config paths could resolve outside their isolated tmp dir on CI. Cleared `XDG_CONFIG_HOME` alongside the `$HOME` override in each affected test (`ecs_docker_cmd_test.go`, `setup_cmd_e2e_test.go`, `setup_cmd_test.go`), reusing the existing `unsetEnvForTest` helper.

This recreates the fix from PR #1470's commit `f375ef5`, which can't be merged as-is since #1470 was broken up and rewritten and no longer touches these files — the same bug patterns exist here independently, in different files.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./cmd/aws-sso/...` (targeted + full package)
- [x] `go test -tags e2etests ./cmd/aws-sso/... -run TestE2ESetupEcsSSL_SelfSigned`
- [x] `make test` (vet + unittest + lint, all clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qSsDJSwk8TzRTDG5KYQmU