### PR TITLE
Remove flaky/unnecessary time.Sleep() calls from tests

### DIFF
--- a/cmd/aws-sso/main_test.go
+++ b/cmd/aws-sso/main_test.go
@@ -72,16 +72,19 @@ func TestAccountIDUnmarshalText(t *testing.T) {
 // channel) stop() is a no-op for the exit path.
 func TestWatchSignalsCleanStopDoesNotExit(t *testing.T) {
 	orig := osExit
-	var exited int32
-	osExit = func(int) { atomic.StoreInt32(&exited, 1) }
+	exitCalled := make(chan struct{})
+	osExit = func(int) { close(exitCalled) }
 	t.Cleanup(func() { osExit = orig })
 
 	_, stop := watchSignals()
-	stop()                             // normal, successful-exit path
-	time.Sleep(100 * time.Millisecond) // give the goroutine time to (wrongly) fire
+	stop() // normal, successful-exit path
 
-	assert.Equal(t, int32(0), atomic.LoadInt32(&exited),
-		"a clean stop() must not call os.Exit -- would break credential_process")
+	select {
+	case <-exitCalled:
+		t.Fatal("a clean stop() must not call os.Exit -- would break credential_process")
+	case <-time.After(100 * time.Millisecond):
+		// the goroutine had its chance to (wrongly) fire and didn't -- pass
+	}
 }
 
 // TestHardExitOnSignalExitsOnSignal verifies the intended behaviour from #1379: an actual

--- a/internal/sso/oidc/pkce_test.go
+++ b/internal/sso/oidc/pkce_test.go
@@ -183,7 +183,7 @@ func TestWaitForPKCECallback(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		client := NewAWSWithAPI(&mockOIDCAPI{})
-		redirectURI := testPKCERedirectURI(t)
+		ln, redirectURI := testPKCEListener(t)
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
@@ -193,6 +193,7 @@ func TestWaitForPKCECallback(t *testing.T) {
 			callback, err := client.WaitForPKCECallback(ctx, WaitForPKCECallbackInput{
 				RedirectURI:   redirectURI,
 				ExpectedState: "expected-state",
+				Listener:      ln,
 			})
 			if err != nil {
 				errCh <- err
@@ -200,8 +201,6 @@ func TestWaitForPKCECallback(t *testing.T) {
 			}
 			resultCh <- callback
 		}()
-
-		waitForPKCEListener(t, redirectURI)
 
 		resp, err := http.Get(fmt.Sprintf("%s?code=auth-code&state=expected-state", redirectURI))
 		assert.NoError(t, err)
@@ -233,12 +232,10 @@ func TestWaitForPKCECallback(t *testing.T) {
 
 	t.Run("redirect uri without path exercises default path", func(t *testing.T) {
 		client := NewAWSWithAPI(&mockOIDCAPI{})
-		// Allocate a free port, then use a redirect URI with no path so path defaults to "/"
+		// Redirect URI with no path so path defaults to "/"
 		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		assert.NoError(t, err)
-		port := ln.Addr().(*net.TCPAddr).Port
-		_ = ln.Close()
-		redirectURI := fmt.Sprintf("http://127.0.0.1:%d", port)
+		redirectURI := fmt.Sprintf("http://%s", ln.Addr().String())
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
@@ -249,6 +246,7 @@ func TestWaitForPKCECallback(t *testing.T) {
 			callback, err := client.WaitForPKCECallback(ctx, WaitForPKCECallbackInput{
 				RedirectURI:   redirectURI,
 				ExpectedState: "my-state",
+				Listener:      ln,
 			})
 			if err != nil {
 				errCh <- err
@@ -256,8 +254,6 @@ func TestWaitForPKCECallback(t *testing.T) {
 			}
 			resultCh <- callback
 		}()
-
-		waitForPKCEListener(t, redirectURI+"/")
 
 		resp, err := http.Get(fmt.Sprintf("%s/?code=my-code&state=my-state", redirectURI))
 		assert.NoError(t, err)
@@ -277,7 +273,7 @@ func TestWaitForPKCECallback(t *testing.T) {
 
 	t.Run("context canceled before callback", func(t *testing.T) {
 		client := NewAWSWithAPI(&mockOIDCAPI{})
-		redirectURI := testPKCERedirectURI(t)
+		ln, redirectURI := testPKCEListener(t)
 		ctx, cancel := context.WithCancel(context.Background())
 
 		errCh := make(chan error, 1)
@@ -285,11 +281,11 @@ func TestWaitForPKCECallback(t *testing.T) {
 			_, err := client.WaitForPKCECallback(ctx, WaitForPKCECallbackInput{
 				RedirectURI:   redirectURI,
 				ExpectedState: "expected-state",
+				Listener:      ln,
 			})
 			errCh <- err
 		}()
 
-		waitForPKCEListener(t, redirectURI)
 		cancel()
 
 		select {
@@ -328,8 +324,6 @@ func TestWaitForPKCECallback(t *testing.T) {
 			}
 			resultCh <- callback
 		}()
-
-		waitForPKCEListener(t, redirectURI)
 
 		// Bounded client so a regression (rebinding the held port) fails fast
 		// instead of blocking on a socket whose server never starts.
@@ -395,31 +389,15 @@ func TestValidatePKCEState(t *testing.T) {
 	assert.Contains(t, err.Error(), "state mismatch")
 }
 
-func testPKCERedirectURI(t *testing.T) string {
+// testPKCEListener binds a TCP listener synchronously and returns it along with the
+// callback redirect URI derived from its address, so the caller can pass it into
+// WaitForPKCECallbackInput.Listener -- the port is guaranteed open before any request
+// is issued, with no need to poll for the server to start.
+func testPKCEListener(t *testing.T) (net.Listener, string) {
 	t.Helper()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	assert.NoError(t, err)
-	addr := listener.Addr().String()
-	_ = listener.Close()
-	return fmt.Sprintf("http://%s/callback", addr)
-}
-
-func waitForPKCEListener(t *testing.T, redirectURI string) {
-	t.Helper()
-	u, err := url.Parse(redirectURI)
-	assert.NoError(t, err)
-
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		conn, dialErr := net.DialTimeout("tcp", u.Host, 50*time.Millisecond)
-		if dialErr == nil {
-			_ = conn.Close()
-			return
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	t.Fatalf("pkce listener did not start for %s", redirectURI)
+	return listener, fmt.Sprintf("http://%s/callback", listener.Addr().String())
 }
 
 // pkceCallbackError starts a WaitForPKCECallback listener, sends an HTTP GET with
@@ -427,7 +405,7 @@ func waitForPKCEListener(t *testing.T, redirectURI string) {
 func pkceCallbackError(t *testing.T, expectedState, query string) error {
 	t.Helper()
 	client := NewAWSWithAPI(&mockOIDCAPI{})
-	redirectURI := testPKCERedirectURI(t)
+	ln, redirectURI := testPKCEListener(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -436,11 +414,10 @@ func pkceCallbackError(t *testing.T, expectedState, query string) error {
 		_, err := client.WaitForPKCECallback(ctx, WaitForPKCECallbackInput{
 			RedirectURI:   redirectURI,
 			ExpectedState: expectedState,
+			Listener:      ln,
 		})
 		errCh <- err
 	}()
-
-	waitForPKCEListener(t, redirectURI)
 
 	resp, err := http.Get(redirectURI + query) //nolint:noctx
 	assert.NoError(t, err)

--- a/internal/storage/flock_test.go
+++ b/internal/storage/flock_test.go
@@ -63,9 +63,8 @@ func TestFlockBlockerWithCtx(t *testing.T) {
 	})
 
 	t.Run("expired deadline returns error wrapping context.DeadlineExceeded", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Millisecond))
 		defer cancel()
-		time.Sleep(5 * time.Millisecond)
 		blocker := FlockBlockerWithCtx(ctx)
 		err := blocker()
 		assert.Error(t, err)


### PR DESCRIPTION
## Summary
- `internal/storage/flock_test.go`: replace a 1ms-timeout context + 5ms sleep with an already-expired `context.WithDeadline`, so the deadline-exceeded assertion is instant and fully deterministic.
- `internal/sso/oidc/pkce_test.go`: replace the bind-close-reopen + poll-with-sleep helper (`testPKCERedirectURI` + `waitForPKCEListener`) with a single `testPKCEListener` helper that binds synchronously and passes the listener via the existing `WaitForPKCECallbackInput.Listener` field -- the same pattern one subtest already used, and the same race the test file's own comment flagged ("address already in use").
- `cmd/aws-sso/main_test.go`: `TestWatchSignalsCleanStopDoesNotExit` now uses a channel + `select` instead of sleep-then-check-a-flag, so a real regression fails immediately instead of only after a fixed 100ms elapses.

No production code changed -- test-only reliability/speed improvements.

## Test plan
- [x] `go test ./internal/storage/... -run TestFlockBlockerWithCtx -count=3`
- [x] `go test ./internal/sso/oidc/... -run TestWaitForPKCECallback -count=5` (repeated to check for new flakiness)
- [x] `go test ./cmd/aws-sso/... -run 'TestWatchSignalsCleanStopDoesNotExit|TestHardExitOnSignal' -count=3`
- [x] `make test` (vet + unittest + lint + homebrew + tidy + fmt) all green

https://claude.ai/code/session_013qSsDJSwk8TzRTDG5KYQmU