### PR TITLE
ecs server: warn if --bind-ip isn't a TLS/SSRF-safe address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * Add `ecs docker write-secrets`
 * The ECS Server and `ecs load`/`list`/`profile`/`unload` now log a warning if the
   server's TLS cert has fewer than 5 days of validity left
+* `ecs server` now logs a warning at startup if `--bind-ip` is not `127.0.0.1`, `::1`, or
+  `169.254.170.2` -- TLS won't verify and AWS SDKs may silently drop the Bearer Token elsewhere
 
 ### Bugs
 

--- a/cmd/aws-sso/ecs_cmd_e2e_test.go
+++ b/cmd/aws-sso/ecs_cmd_e2e_test.go
@@ -27,12 +27,14 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/synfinatic/aws-sso-cli/internal/ecs/server"
+	testlogger "github.com/synfinatic/flexlog/test"
 	"golang.org/x/net/nettest"
 )
 
@@ -546,6 +548,46 @@ func TestE2EEcsServerRunWithAuth(t *testing.T) {
 	authResp.Body.Close()
 	assert.Equal(t, http.StatusNotFound, authResp.StatusCode,
 		"authenticated request should reach the credential handler (404: no creds loaded)")
+
+	cancel()
+	assert.NoError(t, <-done, "Run() should return nil on context cancellation")
+}
+
+// TestE2EEcsServerRunBindIPWarning exercises the --bind-ip startup warning in
+// EcsServerCmd.Run(): binding to an address outside the self-signed cert's SANs
+// (loopback, 169.254.170.2) logs a Warn before the server starts serving.
+func TestE2EEcsServerRunBindIPWarning(t *testing.T) {
+	setup := newE2ESetup(t)
+	tLogger := withTestLogger(t)
+
+	cctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	port := freePort(t)
+	ctx := &RunContext{
+		Cli:      &CLI{},
+		Settings: setup.Settings,
+		Store:    setup.Store,
+		Auth:     AUTH_SKIP,
+		Ctx:      cctx,
+	}
+	ctx.Cli.Ecs.Server = EcsServerCmd{
+		BindIP:      "0.0.0.0",
+		Port:        port,
+		DisableAuth: true,
+	}
+	cc := &ctx.Cli.Ecs.Server
+
+	done := make(chan error, 1)
+	go func() { done <- cc.Run(ctx) }()
+
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	require.NoError(t, waitForEcsServerUp("http", addr, "", 5*time.Second))
+
+	msg := testlogger.LogMessage{}
+	require.NoError(t, tLogger.GetNext(&msg))
+	assert.Equal(t, "WARN", strings.TrimSpace(msg.LevelStr))
+	assert.Contains(t, msg.Message, "0.0.0.0 is not localhost or 169.254.170.2")
 
 	cancel()
 	assert.NoError(t, <-done, "Run() should return nil on context cancellation")

--- a/cmd/aws-sso/ecs_server_cmd.go
+++ b/cmd/aws-sso/ecs_server_cmd.go
@@ -25,7 +25,9 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"slices"
 
+	"github.com/synfinatic/aws-sso-cli/internal/certutil"
 	"github.com/synfinatic/aws-sso-cli/internal/ecs"
 	"github.com/synfinatic/aws-sso-cli/internal/ecs/server"
 )
@@ -61,6 +63,15 @@ func (cc *EcsServerCmd) Run(ctx *RunContext) error {
 	l, err := net.Listen("tcp", fmt.Sprintf("%s:%d", bindIP, ctx.Cli.Ecs.Server.Port))
 	if err != nil {
 		return err
+	}
+
+	// The Docker entrypoint always binds 0.0.0.0 internally and relies on the container's
+	// network IP (e.g. 169.254.170.2, per docs/ecs-server.md) for the actual security
+	// properties, so this warning would just be noise there.
+	if !ctx.Cli.Ecs.Server.Docker {
+		if msg := bindIPWarning(bindIP); msg != "" {
+			log.Warn(msg)
+		}
 	}
 
 	var bearerToken, privateKey, certChain string
@@ -133,6 +144,23 @@ func (cc *EcsServerCmd) Run(ctx *RunContext) error {
 		return err
 	}
 	return nil
+}
+
+// bindIPWarning returns a non-empty warning message if bindIP is not one of the addresses
+// covered by the self-signed cert's SANs (certutil.DefaultIPs). TLS (if enabled) will fail to
+// verify for any other address, and compliant AWS SDKs silently drop the Bearer Token for
+// requests to a host outside that same fixed set, so binding elsewhere breaks both of
+// aws-sso's own protections.
+func bindIPWarning(bindIP string) string {
+	ip := net.ParseIP(bindIP)
+	if ip == nil {
+		return ""
+	}
+	if slices.ContainsFunc(certutil.DefaultIPs, ip.Equal) {
+		return ""
+	}
+	return fmt.Sprintf("--bind-ip %s is not localhost or 169.254.170.2: TLS (if configured) "+
+		"will not verify and AWS SDKs may silently drop the Bearer Token for this address", bindIP)
 }
 
 // setServerDefaultProfile resolves a profile name to credentials and injects them

--- a/cmd/aws-sso/ecs_server_cmd_test.go
+++ b/cmd/aws-sso/ecs_server_cmd_test.go
@@ -58,6 +58,32 @@ func TestEcsServerCmdAfterApply(t *testing.T) {
 	}
 }
 
+func TestBindIPWarning(t *testing.T) {
+	tests := []struct {
+		name   string
+		bindIP string
+		want   bool // true if a non-empty warning is expected
+	}{
+		{name: "loopback v4 is safe", bindIP: "127.0.0.1", want: false},
+		{name: "loopback v6 is safe", bindIP: "::1", want: false},
+		{name: "ecs credentials IP is safe", bindIP: "169.254.170.2", want: false},
+		{name: "all-interfaces is unsafe", bindIP: "0.0.0.0", want: true},
+		{name: "LAN IP is unsafe", bindIP: "192.168.1.50", want: true},
+		{name: "eks pod identity IP is unsafe", bindIP: "169.254.170.23", want: true},
+		{name: "unparseable bindIP is ignored", bindIP: "not-an-ip", want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := bindIPWarning(tt.bindIP)
+			if tt.want {
+				assert.NotEmpty(t, got)
+			} else {
+				assert.Empty(t, got)
+			}
+		})
+	}
+}
+
 func TestSetServerDefaultProfileNotFound(t *testing.T) {
 	// Build a RunContext with an empty SSO cache so GetRoleByProfile returns "not found".
 	c := &ssocache.Cache{SSO: map[string]*ssocache.SSOCache{}}

--- a/docs/ecs-server.md
+++ b/docs/ecs-server.md
@@ -48,7 +48,7 @@ possible to limit who can fetch AWS IAM security tokens from the service.
 
 For multi-user systems where the network/root user is not trusted,
 `aws-sso setup ecs ssl --self-signed` (see below) makes SSL/TLS practical to enable for
-most AWS SDKs, but Python/the AWS CLI [cannot easily trust a private CA for this endpoint](
+most AWS SDKs, but the Python Boto SDK/AWS CLI [cannot easily trust a private CA for this endpoint](
 https://github.com/boto/boto3/issues/4188).
 
 ## Starting the ECS Server
@@ -60,6 +60,13 @@ The server runs in the foreground to make it easy to start via systemd and Docke
 Will start the server on `localhost:4144`.   For security purposes, the `aws-sso`
 ECS Server will default listen on localhost (127.0.0.1) port 4144.  You may select
 an alternative IP/port via the `--bind-ip` and `--port` flags.
+
+**Note:** `aws-sso ecs server` logs a warning at startup if `--bind-ip` is anything other than
+`127.0.0.1`, `::1`, or `169.254.170.2`, the only addresses covered by the self-signed cert's
+SANs (see [ECS Server SSL Certificate](#ecs-server-ssl-certificate)) and by the AWS SDKs'
+SSRF-related allow-list for sending the Bearer Token (see
+[docs/ecs-threats.md](ecs-threats.md#ssrf-mitigation-built-into-the-aws-sdks)). Binding elsewhere
+means TLS won't verify and the Bearer Token may be silently dropped by the connecting SDK.
 
 ### Running the ECS Server in the background
 
@@ -80,7 +87,8 @@ Together, they allow using the `aws-sso` ECS Server on multi-user systems in a
 secure manner.
 
 **Important:** Failure to configure HTTP Authentication _and_ SSL/TLS encryption
-risks exposing your AWS IAM authentication tokens to other users on the system.
+risks exposing your AWS IAM authentication tokens to other users on the system or
+when traversing untrusted network links.
 
 ### ECS Server SSL Certificate
 
@@ -117,10 +125,8 @@ force HTTP while a certificate is stored — run `aws-sso setup ecs ssl --delete
 to disable SSL/TLS instead (see [Deleting the certificate](#deleting-the-certificate)
 below).
 
-**Note:** `aws-sso` provides no command to export the CA private key — `--print-ca` prints only the
-certificate. How well the key itself is protected is down to your
-[secure store](config.md): the OS keychain and 1Password backends encrypt it, while the
-`json` store keeps it in plaintext like everything else it holds.
+**Note:** `aws-sso` provides no command to export the CA private key; `--print-ca` prints only the
+certificate.  The CA private key is kept securely in the [secure store](config.md#securestore--jsonstore).
 
 See [Trusting the CA](#trusting-the-ca) below for how to trust this certificate in your OS and
 in each AWS SDK runtime.
@@ -152,15 +158,14 @@ See [Untrusting the CA](#untrusting-the-ca) below, and note the fingerprint prin
 
 ### Trusting the CA
 
-First export the local CA certificate to a file (see above):
+First export the local CA certificate to a file:
 
 ```bash
 aws-sso setup ecs ssl --print-ca > /tmp/ecs-ca.pem
 ```
 
 The CA is reused (not regenerated) every time you rerun `--self-signed`, so you only need to
-export and trust it once per machine/runtime below — only `--delete`, `--delete-ca`, and then
-`--self-signed` will require repeating these steps.
+export and trust it once per machine/runtime below.
 
 `--self-signed` prints the CA's SHA-256 fingerprint on every run. Compare it with the fingerprint
 your OS or runtime trust store shows for `aws-sso-cli ECS Server CA` to confirm you trusted the
@@ -605,6 +610,10 @@ services:
       AWS_CONTAINER_CREDENTIALS_FULL_URI: http://169.254.170.2:4144
       # must match the token stored via `aws-sso setup ecs auth`.  Omit this (and run
       # `write-secrets --disable-auth`) only if you are not using HTTP Auth.
+      # Note that this exposes the bearer token via `docker inspect`.  For additional security
+      # consider passing in the bearer token via a mount or via docker compose secrets
+      # and AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE
+      # https://docs.docker.com/compose/how-tos/use-secrets/
       AWS_CONTAINER_AUTHORIZATION_TOKEN: "Bearer ${AWS_SSO_ECS_TOKEN}"
     networks:
       aws-sso-ecs: {}

--- a/docs/ecs-threats.md
+++ b/docs/ecs-threats.md
@@ -2,8 +2,8 @@
 
 ## Problem Description
 
-The AWS SDK supports fetching the IAM Credentials used for making calls to the AWS API
-the HTTP endpoint defined by the [AWS_CONTAINER_CREDENTIALS_FULL_URI](
+The AWS SDK supports fetching the IAM Credentials used for making calls to the AWS API via the
+HTTP endpoint defined by the [AWS_CONTAINER_CREDENTIALS_FULL_URI](
 https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html)
 environment variable.
 
@@ -11,126 +11,68 @@ This connection will expose the AWS API credentials for one or more IAM Roles an
 be secured as much as possible.  Unfortunately, the
 [AWS SDK only supports public Certificates of Authority](
 https://github.com/aws/aws-sdk/issues/774) to enable users to run their own local service
-which impliments this API on `localhost`.
+which implements this API on `localhost`.
 
 But [public CA's will not create certificates for localhost](
-https://letsencrypt.org/docs/certificates-for-localhost/).
+https://letsencrypt.org/docs/certificates-for-localhost/), nor for `169.254.170.2` (the
+special ECS credentials IP, see below).
 
-## Solution
+### SSRF mitigation built into the AWS SDKs
 
-**Note:** `aws-sso setup ecs ssl --self-signed` (see [docs/ecs-server.md](
-ecs-server.md#ecs-server-ssl-certificate)) already implements a simpler alternative to the
-hosted CSR-signing service proposed below: a private CA generated and stored locally, with
-no account, API key, or public DNS registration required. It works for every AWS SDK except
-Python/the AWS CLI, which is tracked upstream at
-[aws/aws-cli#9016](https://github.com/aws/aws-cli/issues/9016). The hosted service below
-remains a possible future option for zero-touch trust distribution across multiple users or
-machines, which `--self-signed`'s per-machine private CA does not solve.
+Because `AWS_CONTAINER_CREDENTIALS_FULL_URI` can be pointed at an arbitrary URL, a
+misconfigured or compromised environment could leak the `AWS_CONTAINER_AUTHORIZATION_TOKEN`
+bearer token to a host the attacker controls. To close this off, AWS SDKs (botocore, the Go SDK,
+Java v2, JS v3, etc.) only attach the `Authorization` header when the URI's host is one of a
+fixed allow-list:
 
-In order to support `aws-sso` users who wish to run their own endpoint for
-`AWS_CONTAINER_CREDENTIALS_FULL_URI`, we need to create a new public web service which:
+* `169.254.170.2`, the real ECS Task Metadata/Credentials endpoint
+* `169.254.170.23`, the EKS Pod Identity agent
+* `fd00:ec2::23`, the IPv6 equivalent of the above
+* any loopback address (`127.0.0.0/8`, `::1`)
 
----
-Scenario: A user wishes to create an account
+The first two are AWS-specific addresses within `169.254.0.0/16`, the IPv4 link-local block
+reserved by [RFC 3927](https://www.rfc-editor.org/rfc/rfc3927): not routable off the local
+link, which is why the SDKs trust that block enough to send the bearer token there.
 
-* Given: A new user who has never enabled SSL before
-* When: The user chooses a unique username and password
-  * And: Provides a valid email address
-* Then: The service creates an account for the user
+`169.254.170.23`/`fd00:ec2::23` (EKS Pod Identity) are out of scope for `aws-sso`: it only
+emulates the ECS Task Metadata/Credentials endpoint, not the EKS Pod Identity agent, and neither
+address is covered by the self-signed cert's SANs (below). `aws-sso`'s own supported set is
+narrower than the full SDK allow-list: just loopback (`127.0.0.1`/`::1`) and `169.254.170.2`.
 
-Note: I generally need to think about the onboarding workflow so this may change.
+If the host doesn't match, most SDKs still make the request but silently drop the
+`Authorization` header rather than refusing outright, so pointing an SDK's
+`AWS_CONTAINER_CREDENTIALS_FULL_URI` at a non-allow-listed host doesn't leak the bearer token,
+but it also means the ECS Server's HTTP Authentication silently stops working: requests will
+fail with a `403`/`401` that looks like a config error rather than a network error. This is
+why `aws-sso ecs server` defaults to binding `127.0.0.1`, and why the Docker workflow (see
+[Why SSL is not needed here](ecs-server.md#why-ssl-is-not-needed-here)) assigns the container
+`169.254.170.2` instead of an arbitrary bridge IP, since both are on the allow-list, so the bearer
+token still gets sent. Binding anywhere else works for fetching credentials over plain HTTP,
+but silently disables Bearer token auth and can't be covered by the self-signed cert either.
+`aws-sso ecs server` logs a warning at startup if `--bind-ip` is set to anything other than
+loopback or `169.254.170.2` for exactly this reason. See `docs/ecs-server.md` for the actual
+`--bind-ip`/`--self-signed` configuration.
 
----
-Scenario: A user wishes to register a FQDN for a SSL certificate
+## Solution (implemented)
 
-* Given: A valid user who has logged in
-* When: The user chooses a _unique hostname_ for `aws-sso-cli.org`
-* Then: Service creates a DNS A record for _hostname.aws-sso-cli.org_ pointing to `127.0.0.1`
-  * And: The user runs the command locally: `aws-sso setup ecs cert fqdn <fqdn>`
+`aws-sso setup ecs ssl --self-signed` (see [docs/ecs-server.md](
+ecs-server.md#ecs-server-ssl-certificate)) generates a private CA and a leaf certificate,
+stored in the SecureStore, covering `localhost`, `127.0.0.1`, `::1`, and `169.254.170.2`. This
+requires no account, API key, or public DNS registration, and is the actual solution in use
+today. It works well for every AWS SDK except Python/the AWS CLI, which is tracked upstream at
+[aws/aws-cli#9016](https://github.com/aws/aws-cli/issues/9016).
 
----
-Scenario: A user wishes to enable CSR signing for the ECS Server certificates
-
-* Given: A valid user who has logged in
-* When: The user asks for a new API Key via the web interface
-* Then: Web service generates a new API key for the user
-  * And: The user runs the command locally `aws-sso setup ecs cert api-key <api key>`
-
----
-Scenario: A user wishes to get a signed certificate from the web service
-
-* Given: A valid API key for a user has been configured
-* When: The user runs `aws-sso setup ecs cert sign-csr`
-* Then: A new private key / certificate signing request will be generated locally
-  * And: The private key will be stored in the SecureStore
-  * And: The CSR will be uploaded to the webservice, using the configured API key for authentication
-
----
-Scenario: A user has requested a signed certificate from the web service
-
-* Given: The user has run `aws-sso setup ecs cert sign-csr`
-* When: The service validates the API key is assigned to the FQDN in the CSR
-* Then: The service asks Let's Encrypt to sign the CSR via ACME DNS-01
-  * And: Let's Encrypt signs the CSR
-  * And: Service returns the signed Certificate to the user.
-
----
-Scenario: A user has their own CA they'd like to use to sign the certificate
-
-* Given: The user does not wish to use the public web service to manage their certificate
-* When: A user runs `aws-sso setup ecs cert export-csr`
-* Then: A new private key / certificate signing request will be generated locally
-  * And: The private key will be stored in the SecureStore
-  * And: The CSR will be written to a file
-
----
-Scenario: A user has signed the CSR with their own CA
-
-* Given: The user has exported a CSR and has had it signed by a CA
-* When: The user runs `aws-sso setup ecs cert load <file>`
-* Then: `aws-sso` will store the certificate for the ECS Server
-
----
-Scenario: A user wishes to use ECS Server in SSL mode
-
-* Given: `aws-sso` has a valid private key and certificate configured
-* When: The user runs the command `aws-sso ecs docker start`
-* Then: The ECS Server runs locally
-  * And: Uses the configured SSL private key/certificate
-  * And: Uses the configured Bearer Token
-
----
-Scenario: A user wishes to use the ECS Server in SSL mode
-
-* Given: The user is locally running the ECS Server in SSL Mode
-  * And: The user has configured a Bearer Token for the AWS SDK
-  * And: The user has loaded one or more AWS API credentials via `aws-sso ecs load ...`
-* When: The user has defined `AWS_CREDENTIALS_FULL_URI=https://<fqdn>:4144` in the current shell
-  * And: The AWS SDK attempts to connect to the ECS Server via `127.0.0.1:4144` to retrive the AWS API credentials
-* Then: The connection to retrieve the AWS API credentials will be e2e encrypted
-  * And: The AWS SDK will use SSL to verify the identity of the ECS Server
-  * And: The ECS Server will use the Bearer Token to verify the identiy of the AWS SDK
-  * And: The ECS Server will provide the requested API credentials
-  * And: The AWS SDK will use the provided AWS API credentials in its request
-
----
-Scenario: A user wishes to use the AWS SDK on a remote host
-
-* Given: The user is locally running the ECS Server in SSL Mode
-  * And: The user has configured a Bearer Token for the AWS SDK
-  * And: The user has loaded one or more AWS API credentials via `aws-sso ecs load ...`
-* When: The user runs `ssh -R 4144:localhost:4144 <host>`
-  * And: The user has defined `AWS_CREDENTIALS_FULL_URI=https://<fqdn>:4144` in the remote shell
-  * And: The AWS SDK attempts to connect to the ECS Server via `127.0.0.1:4144` to retrive the AWS API credentials
-* Then: The connection will be proxied by ssh to the users local system where the ECS Server is running
-  * And: The AWS SDK will use SSL to verify the identity of the ECS Server
-  * And: The ECS Server will use the Bearer Token to verify the identiy of the AWS SDK
-  * And: The ECS Server will provide the requested API credentials
-  * And: The AWS SDK will use the provided AWS API credentials in its request
-
----
+An earlier draft of this document proposed a hosted CSR-signing web service (user accounts,
+per-user DNS records under `aws-sso-cli.org`, ACME DNS-01 signing via Let's Encrypt) as an
+alternative to running a private CA. That was never built, and the self-signed CA above covers
+the practical need. It remains a hypothetical future option only for zero-touch trust
+distribution across multiple users/machines, which a per-machine private CA doesn't solve, and not
+something currently planned.
 
 ## Attacks
+
+The threat model below covers the two mechanisms `aws-sso ecs server` actually implements: SSL/TLS
+(via the self-signed CA above) and HTTP Authentication (Bearer token).
 
 ### Attacker has root on the box running aws-sso ECS Server
 
@@ -171,35 +113,25 @@ traffic, they can obtain the Bearer Token or AWS API credentials.
     warning the user can ignore, which closes this attack even without SSL.
 * With SSL: No attack; traffic is e2e encrypted and authenticated.
 
-### Attacker can posion DNS or /etc/hosts
+### Attacker can poison DNS or /etc/hosts
 
 * Without SSL: Attacker can MITM the connection and get access to the Bearer Token
     and AWS API credentials.
   * Mitigate: aws-sso can inspect DNS to ensure IP address is correct
 * With SSL: Just a DoS because AWS SDK validates SSL cert before sending the Bearer Token
 
-### Attacker can DoS the certificate signing service
+### Attacker-controlled host tries to leak the Bearer Token via `AWS_CONTAINER_CREDENTIALS_FULL_URI`
 
-* Attacker can prevent users from getting updated certificates when they expire.
-  * Mitigations:
-    * Consider configurable endpoints
-    * Use CloudFlare
-
-### Attacker can exploit the certificate signing service
-
-* Attacker can issue their own certificate for hostname.aws-sso-cli.org
-* Attacker can update DNS and point hostname.aws-sso-cli.org at a different IP than 127.0.0.1
-  * Mitigate: aws-sso client can validate DNS record is valid
-* Attacker can inject bad data and modify the database of users
-* Attacker can steal API Key of users to sign CSRs
-  * Mitigate: use public key auth to mitigate
-* Lookup "click jacking" -- run Burp scanner
+* No attack: modern AWS SDKs only send the `Authorization` header (Bearer Token) when the
+  target host is `169.254.170.2`, `169.254.170.23`, `fd00:ec2::23`, or loopback (see the
+  SSRF mitigation section above). An attacker-controlled `FULL_URI` pointed elsewhere gets no
+  token.
+  * Caveat: this protection lives in the SDK, not in `aws-sso`, and was only added to some SDKs
+    in 2023-2024, so an outdated SDK version may not enforce it. See `docs/ecs-server.md` for the
+    minimum botocore version note.
 
 ## Suggestions
 
-* Examine need for certificate revocation for users.
-* Look into a private/public cert method of API Key for authentication so people can't dump my database
-and issue certs for anyone.
-* Add extensive logging since we're low traffic and anything interesting will show up easily
-* Use Burp scanner/suite to do a pen test
-* Examine what free security options CloudFlare & Fly.io? provide
+* Add extensive logging since we're low traffic and anything interesting will show up easily.
+* Consider certificate revocation if multi-machine/multi-user trust distribution is ever
+  revisited.


### PR DESCRIPTION
## Summary

* Add a startup warning in `aws-sso ecs server` when `--bind-ip` is anything other than
  `127.0.0.1`, `::1`, or `169.254.170.2` -- the only addresses covered by the self-signed
  cert's SANs and by the AWS SDKs' SSRF-related allow-list for sending the Bearer Token.
  Binding elsewhere means TLS won't verify and the Bearer Token may be silently dropped by
  the connecting SDK. Skipped for `--docker` mode, which always binds `0.0.0.0` internally by
  design and relies on the container's assigned network IP instead.
* Massively trim `docs/ecs-threats.md`: the "hosted CSR-signing web service" it proposed as a
  future solution was never built (no code references it) and is now superseded by the
  self-signed CA already documented in `docs/ecs-server.md`. Replaced with a short note on the
  SSRF mitigation and the IP allow-list AWS SDKs use for `AWS_CONTAINER_CREDENTIALS_FULL_URI`,
  including that EKS Pod Identity addresses (`169.254.170.23`/`fd00:ec2::23`) are out of scope
  since `aws-sso` doesn't emulate that agent.
* Document the new warning in `docs/ecs-server.md` and add a `CHANGELOG.md` entry.

## Test plan

- [x] `TestBindIPWarning` added first, confirmed failing (`undefined: bindIPWarning`), then
  implementation added and test passes
- [x] `make unittest` passes across all packages
- [x] `gofmt -s` clean on touched files