### PR TITLE
ecs client: warn locally when the server's TLS leaf cert is expiring soon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
   scoped so it can't sign for other hosts; prints the CA's SHA-256 fingerprint for verification
 * Add `login --force` to start a new SSO session, resetting its duration #1455
 * Add `ecs docker write-secrets`
-* The ECS Server now logs a warning whenever IAM role credentials are loaded if its
-  TLS cert has fewer than 5 days of validity left
+* The ECS Server and `ecs load`/`list`/`profile`/`unload` now log a warning if the
+  server's TLS cert has fewer than 5 days of validity left
 
 ### Bugs
 

--- a/cmd/aws-sso/ecs_client_cmd.go
+++ b/cmd/aws-sso/ecs_client_cmd.go
@@ -23,9 +23,11 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/synfinatic/aws-sso-cli/internal/awsparse"
+	"github.com/synfinatic/aws-sso-cli/internal/certutil"
 	"github.com/synfinatic/aws-sso-cli/internal/ecs"
 	"github.com/synfinatic/aws-sso-cli/internal/ecs/client"
 	"github.com/synfinatic/gotable"
@@ -187,9 +189,32 @@ func newClient(server string, ctx *RunContext) *client.ECSClient {
 	if err != nil {
 		log.Fatal("Unable to get ECS SSL cert", "error", err.Error())
 	}
+	warnIfCertExpiringSoon(certChain)
+
 	bearerToken, err := ctx.Store.GetEcsBearerToken()
 	if err != nil {
 		log.Fatal("Unable to get ECS bearer token", "error", err)
 	}
 	return client.NewECSClient(server, bearerToken, certChain)
+}
+
+// warnIfCertExpiringSoon logs a warning if the ECS server's TLS cert (if any)
+// expires within certutil.CertExpiryWarning, so users driving the server via
+// the aws-sso client see the same reminder the server itself logs.
+func warnIfCertExpiringSoon(certChain string) {
+	if certChain == "" {
+		return
+	}
+
+	soon, notAfter, err := certutil.ExpiringSoon(certChain)
+	if err != nil {
+		log.Error("unable to check ECS server TLS cert expiry", "error", err.Error())
+		return
+	}
+
+	if soon {
+		log.Warn("ECS server TLS cert is expiring soon",
+			"expires", notAfter.Format(time.RFC3339),
+			"hint", "run `aws-sso setup ecs ssl --self-signed` to rotate it")
+	}
 }

--- a/cmd/aws-sso/ecs_client_cmd_test.go
+++ b/cmd/aws-sso/ecs_client_cmd_test.go
@@ -1,0 +1,117 @@
+package main
+
+/*
+ * AWS SSO CLI
+ * Copyright (c) 2021-2026 Aaron Turner  <synfinatic at gmail dot com>
+ *
+ * This program is free software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or with the authors permission any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/synfinatic/aws-sso-cli/internal/certutil"
+	testlogger "github.com/synfinatic/flexlog/test"
+)
+
+// selfSignedCertPEM generates a self-signed leaf cert PEM with the given
+// NotAfter, for exercising warnIfCertExpiringSoon without waiting on
+// certutil's fixed LeafValidity.
+func selfSignedCertPEM(t *testing.T, notAfter time.Time) string {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     notAfter,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
+}
+
+func withTestLogger(t *testing.T) *testlogger.TestLogger {
+	t.Helper()
+
+	tLogger := testlogger.NewTestLogger("DEBUG")
+	oldLogger := log.Copy()
+	log = tLogger
+	t.Cleanup(func() {
+		log = oldLogger
+		tLogger.Close()
+	})
+	return tLogger
+}
+
+func TestWarnIfCertExpiringSoon_NoCert(t *testing.T) {
+	tLogger := withTestLogger(t)
+
+	warnIfCertExpiringSoon("")
+
+	msg := testlogger.LogMessage{}
+	assert.Error(t, tLogger.GetNext(&msg), "no log messages expected when no cert is configured")
+}
+
+func TestWarnIfCertExpiringSoon_FarFromExpiry(t *testing.T) {
+	tLogger := withTestLogger(t)
+
+	ca, err := certutil.GenerateCA()
+	require.NoError(t, err)
+	leaf, err := certutil.GenerateLeaf(ca)
+	require.NoError(t, err)
+
+	warnIfCertExpiringSoon(leaf.CertPEM)
+
+	msg := testlogger.LogMessage{}
+	assert.Error(t, tLogger.GetNext(&msg), "no log messages expected for a cert that isn't close to expiry")
+}
+
+func TestWarnIfCertExpiringSoon_NearExpiry(t *testing.T) {
+	tLogger := withTestLogger(t)
+
+	certPEM := selfSignedCertPEM(t, time.Now().Add(2*24*time.Hour))
+	warnIfCertExpiringSoon(certPEM)
+
+	msg := testlogger.LogMessage{}
+	require.NoError(t, tLogger.GetNext(&msg))
+	assert.Equal(t, "WARN", strings.TrimSpace(msg.LevelStr))
+	assert.Contains(t, msg.Message, "expiring soon")
+}
+
+func TestWarnIfCertExpiringSoon_InvalidCert(t *testing.T) {
+	tLogger := withTestLogger(t)
+
+	warnIfCertExpiringSoon("not a pem block")
+
+	msg := testlogger.LogMessage{}
+	require.NoError(t, tLogger.GetNext(&msg))
+	assert.Equal(t, "ERROR", strings.TrimSpace(msg.LevelStr))
+}

--- a/docs/ecs-server.md
+++ b/docs/ecs-server.md
@@ -106,7 +106,10 @@ run `--delete`, then `--delete-ca`, then `--self-signed`, which does require
 repeating the trust steps everywhere.
 
 Once the leaf has fewer than 5 days of validity left, `aws-sso ecs server` logs a warning
-every time new IAM role credentials are loaded, as a reminder to rerun `--self-signed`.
+every time new IAM role credentials are loaded, as a reminder to rerun `--self-signed`. The
+`aws-sso ecs load`/`list`/`profile`/`unload` client commands log the same warning locally
+whenever they read a soon-to-expire leaf cert from the secure store, so you see the reminder
+even if you aren't watching the server's own log output.
 
 Once you have generated the CA/leaf certificate, future invocations of the aws-sso
 ECS Server will automatically disable HTTP and enable HTTPS. There is no flag to

--- a/internal/certutil/certutil.go
+++ b/internal/certutil/certutil.go
@@ -44,6 +44,10 @@ const CAValidity = 10 * 365 * 24 * time.Hour
 // requires re-trusting anything, so there's no reason to make it long-lived.
 const LeafValidity = 30 * 24 * time.Hour
 
+// CertExpiryWarning is how far ahead of a leaf cert's expiration ExpiringSoon
+// starts reporting true, so callers can warn users to rotate it.
+const CertExpiryWarning = 5 * 24 * time.Hour
+
 // CACommonName identifies the generated CA in OS trust-store UIs so users
 // can find (and remove) it later.
 const CACommonName = "aws-sso-cli ECS Server CA"
@@ -197,6 +201,16 @@ func Expiry(certPEM string) (time.Time, error) {
 		return time.Time{}, err
 	}
 	return cert.NotAfter, nil
+}
+
+// ExpiringSoon reports whether a PEM-encoded certificate has less than
+// CertExpiryWarning validity remaining, along with its NotAfter time.
+func ExpiringSoon(certPEM string) (bool, time.Time, error) {
+	notAfter, err := Expiry(certPEM)
+	if err != nil {
+		return false, time.Time{}, err
+	}
+	return time.Until(notAfter) < CertExpiryWarning, notAfter, nil
 }
 
 // singleHostIPRanges converts each IP into a single-host CIDR (/32 for IPv4,

--- a/internal/certutil/certutil_test.go
+++ b/internal/certutil/certutil_test.go
@@ -28,6 +28,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
+	"math/big"
 	"net"
 	"strings"
 	"testing"
@@ -328,6 +329,60 @@ func TestExpiry_InvalidCertificateBytes(t *testing.T) {
 	badCertPEM := string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("not a real cert")}))
 	_, err := Expiry(badCertPEM)
 	assert.ErrorContains(t, err, "unable to parse certificate")
+}
+
+func TestExpiringSoon_False(t *testing.T) {
+	t.Parallel()
+
+	ca, err := GenerateCA()
+	require.NoError(t, err)
+	leaf, err := GenerateLeaf(ca)
+	require.NoError(t, err)
+
+	soon, notAfter, err := ExpiringSoon(leaf.CertPEM)
+	require.NoError(t, err)
+	assert.False(t, soon)
+	assert.WithinDuration(t, time.Now().Add(LeafValidity), notAfter, time.Minute)
+}
+
+func TestExpiringSoon_True(t *testing.T) {
+	t.Parallel()
+
+	certPEM := selfSignedCertPEM(t, time.Now().Add(2*24*time.Hour))
+
+	soon, notAfter, err := ExpiringSoon(certPEM)
+	require.NoError(t, err)
+	assert.True(t, soon)
+	assert.WithinDuration(t, time.Now().Add(2*24*time.Hour), notAfter, time.Minute)
+}
+
+func TestExpiringSoon_InvalidPEM(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := ExpiringSoon("not a pem block")
+	assert.ErrorContains(t, err, "unable to decode PEM certificate")
+}
+
+// selfSignedCertPEM generates a self-signed leaf cert PEM with the given
+// NotAfter, for exercising ExpiringSoon without waiting on the fixed
+// LeafValidity used by GenerateLeaf.
+func selfSignedCertPEM(t *testing.T, notAfter time.Time) string {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     notAfter,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}))
 }
 
 func parsePEMCert(t *testing.T, certPEM string) *x509.Certificate {

--- a/internal/ecs/server/server.go
+++ b/internal/ecs/server/server.go
@@ -35,10 +35,6 @@ import (
 	"github.com/synfinatic/flexlog"
 )
 
-// CertExpiryWarning is how far ahead of a TLS cert's expiration the ECS
-// server starts warning on every credential load.
-const CertExpiryWarning = 5 * 24 * time.Hour
-
 var log flexlog.FlexLogger
 
 func init() {
@@ -136,19 +132,19 @@ func (e *EcsServer) PutSlottedCreds(creds *ecs.ECSClientRequest) error {
 }
 
 // warnIfCertExpiringSoon logs a warning if the server's TLS cert (if any)
-// expires within CertExpiryWarning.
+// expires within certutil.CertExpiryWarning.
 func (e *EcsServer) warnIfCertExpiringSoon() {
 	if e.certChain == "" {
 		return
 	}
 
-	notAfter, err := certutil.Expiry(e.certChain)
+	soon, notAfter, err := certutil.ExpiringSoon(e.certChain)
 	if err != nil {
 		log.Error("unable to check ECS server TLS cert expiry", "error", err.Error())
 		return
 	}
 
-	if remaining := time.Until(notAfter); remaining < CertExpiryWarning {
+	if soon {
 		log.Warn("ECS server TLS cert is expiring soon",
 			"expires", notAfter.Format(time.RFC3339),
 			"hint", "run `aws-sso setup ecs ssl --self-signed` to rotate it")


### PR DESCRIPTION
## Summary
- The ECS server already logs a warning when its TLS leaf cert has fewer than 5 days of validity
  left, but that only shows up in the server's own log output — a user driving it purely via the
  `aws-sso ecs` client commands never sees it.
- `ecs load`/`list`/`profile`/`unload` already read the leaf cert PEM from the secure store before
  talking to the server, so they now run the same expiry check locally and log the same warning,
  no new wire protocol needed.
- Extracted the threshold/comparison logic into `certutil.ExpiringSoon()`, shared by both the
  server and the new client-side check, while each keeps its own logging.

## Test plan
- [x] `make unittest` — new `certutil.ExpiringSoon` tests and new `cmd/aws-sso`
  `warnIfCertExpiringSoon` tests pass; existing `internal/ecs/server` tests unaffected
- [x] `make lint` — 0 issues
- [x] `go mod tidy` — no diff
- [x] `gofmt -s -l` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qSsDJSwk8TzRTDG5KYQmU